### PR TITLE
[vcxproj][fix] Use `LatestTargetPlatformVersion` as `WindowsTargetPlatformVersion` instead of `10.0` in all vcxproj files

### DIFF
--- a/Applications/floyd_warshall/floyd_warshall_vs2017.vcxproj
+++ b/Applications/floyd_warshall/floyd_warshall_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{3bbda23b-43c0-4b91-8ba8-1cfe8b981184}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>floyd_warshall_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Applications/floyd_warshall/floyd_warshall_vs2019.vcxproj
+++ b/Applications/floyd_warshall/floyd_warshall_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{FB6B7014-2BC9-475C-B3CC-FEE6B4C5B103}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>floyd_warshall_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Applications/floyd_warshall/floyd_warshall_vs2022.vcxproj
+++ b/Applications/floyd_warshall/floyd_warshall_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{015df085-feb3-4c7a-acee-7cffb3c9aff0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>floyd_warshall_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{f72a2ce8-6391-4929-8688-dd5d1e338773}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>assembly_to_executable_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip">

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2019.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{60b4ade0-8286-46ae-b884-5da51b541ded}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>assembly_to_executable_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip">

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2022.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{96af6231-97e6-4fef-8132-11897d33e973}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>assembly_to_executable_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip">

--- a/HIP-Basic/bandwidth/bandwidth_vs2017.vcxproj
+++ b/HIP-Basic/bandwidth/bandwidth_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8c3bbaaf-04f6-46f5-96a2-81c047167343}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bandwidth_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/bandwidth/bandwidth_vs2019.vcxproj
+++ b/HIP-Basic/bandwidth/bandwidth_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{16b11b54-cd72-43b6-b226-38c668b41a79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bandwidth_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/bandwidth/bandwidth_vs2022.vcxproj
+++ b/HIP-Basic/bandwidth/bandwidth_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8b999fec-741b-4ff7-9835-11077ee3726e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bandwidth_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/bit_extract/bit_extract_vs2017.vcxproj
+++ b/HIP-Basic/bit_extract/bit_extract_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{e9dc3573-5fa9-4c03-8830-909f71ed34d9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bit_extract_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/bit_extract/bit_extract_vs2019.vcxproj
+++ b/HIP-Basic/bit_extract/bit_extract_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{63823DD0-787C-42AE-B6E7-C03CF4CF5CE2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bit_extract_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/bit_extract/bit_extract_vs2022.vcxproj
+++ b/HIP-Basic/bit_extract/bit_extract_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{7c53480c-5014-4bd7-8b3e-c45a183fa5df}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bit_extract_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
+++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{30739f04-9ef3-4f41-8de4-500bdbfecff9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cooperative_groups_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
+++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{7a25ce69-bace-4410-beb0-12a69890f212}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cooperative_groups_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj
+++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{6c44066e-6e5b-4dcb-8af9-4e8d0630a849}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>cooperative_groups_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/device_globals/device_globals_vs2017.vcxproj
+++ b/HIP-Basic/device_globals/device_globals_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{f6b4fc89-465a-455a-b1e9-ff4c8689e3f0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_globals_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/device_globals/device_globals_vs2019.vcxproj
+++ b/HIP-Basic/device_globals/device_globals_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{f7dd9451-b0ca-4c76-ab92-0e01cbebdbbe}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_globals_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/device_globals/device_globals_vs2022.vcxproj
+++ b/HIP-Basic/device_globals/device_globals_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{3c13d642-960a-4f99-84a9-5559bce3b347}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_globals_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/device_query/device_query_vs2017.vcxproj
+++ b/HIP-Basic/device_query/device_query_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a9e1c716-820c-4b29-b36e-4f0ab057f09f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_query_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/HIP-Basic/device_query/device_query_vs2019.vcxproj
+++ b/HIP-Basic/device_query/device_query_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{C2C6E811-57E3-44C5-9AB9-195D60A1638C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_query_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/HIP-Basic/device_query/device_query_vs2022.vcxproj
+++ b/HIP-Basic/device_query/device_query_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{428c7c0b-c055-4126-a6d2-1e51344e5d40}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_query_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/HIP-Basic/dynamic_shared/dynamic_shared_vs2017.vcxproj
+++ b/HIP-Basic/dynamic_shared/dynamic_shared_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{2e7bb11b-fe0f-419c-aa07-448a1472b593}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dynamic_shared_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/dynamic_shared/dynamic_shared_vs2019.vcxproj
+++ b/HIP-Basic/dynamic_shared/dynamic_shared_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{7b7d1745-7635-40da-b6af-b8f728a31124}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dynamic_shared_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/dynamic_shared/dynamic_shared_vs2022.vcxproj
+++ b/HIP-Basic/dynamic_shared/dynamic_shared_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a1d6c8e8-9e43-4703-a368-39fec450548c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dynamic_shared_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/events/events_vs2017.vcxproj
+++ b/HIP-Basic/events/events_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{aa9e497a-fede-45a4-a6ce-a8e3ddddeb82}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>events_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/events/events_vs2019.vcxproj
+++ b/HIP-Basic/events/events_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5B822836-110B-44D8-8E02-2A9B2CB83D14}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>events_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/events/events_vs2022.vcxproj
+++ b/HIP-Basic/events/events_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{df601563-b579-4571-88c9-3ec7312d567f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>events_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/gpu_arch/gpu_arch_vs2017.vcxproj
+++ b/HIP-Basic/gpu_arch/gpu_arch_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{99e1a6eb-e9e3-48af-a71b-5fe792550f5d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gpu_arch_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/gpu_arch/gpu_arch_vs2019.vcxproj
+++ b/HIP-Basic/gpu_arch/gpu_arch_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4e6b2034-d7ed-4cb4-98b2-7b2d2b71e0a8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gpu_arch_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/gpu_arch/gpu_arch_vs2022.vcxproj
+++ b/HIP-Basic/gpu_arch/gpu_arch_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{d5ceb4c2-4867-4a5c-ad3a-e025ef3c7c0e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gpu_arch_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/hello_world/hello_world_vs2017.vcxproj
+++ b/HIP-Basic/hello_world/hello_world_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{bd725c86-e381-4bdd-b3fc-06a42221bebb}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>hello_world_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/hello_world/hello_world_vs2019.vcxproj
+++ b/HIP-Basic/hello_world/hello_world_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5e0e9ab0-b708-481f-9226-dd92c3798341}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>hello_world_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/hello_world/hello_world_vs2022.vcxproj
+++ b/HIP-Basic/hello_world/hello_world_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{aa92ef7e-2323-4497-accd-b76fb196c545}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>hello_world_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/inline_assembly/inline_assembly_vs2017.vcxproj
+++ b/HIP-Basic/inline_assembly/inline_assembly_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{66b01cd4-735e-4e83-9def-e7ee88546e8f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>inline_assembly_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/inline_assembly/inline_assembly_vs2019.vcxproj
+++ b/HIP-Basic/inline_assembly/inline_assembly_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4e6b2034-d7ed-4cb4-98b2-7b2d2b71e0a7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>inline_assembly_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/inline_assembly/inline_assembly_vs2022.vcxproj
+++ b/HIP-Basic/inline_assembly/inline_assembly_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8f2ece57-1e5f-4175-8a7a-8b5f12663d68}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>inline_assembly_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8588f3a8-6540-483f-92f4-191db4953f95}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>llvm_ir_to_executable_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip">

--- a/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2019.vcxproj
+++ b/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{dbb8dfe9-cb1b-473c-937c-2a8120e0d819}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>llvm_ir_to_executable_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip">

--- a/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2022.vcxproj
+++ b/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a8e51ed9-38fd-462b-a992-fce1044bdcc2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>llvm_ir_to_executable_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip">

--- a/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2017.vcxproj
+++ b/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{e300ed61-e779-4009-80a7-d566dac4ed52}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>matrix_multiplication_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2019.vcxproj
+++ b/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{ACC2A1E7-5865-4FAE-9016-E6EF73F8FA9E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>matrix_multiplication_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2022.vcxproj
+++ b/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{9214477c-b90f-4ddd-a138-455b83a5bab2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>matrix_multiplication_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/module_api/module_api_vs2017.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{af173513-f266-4d26-af06-5960104114a6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>module_api_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/module_api/module_api_vs2019.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{306eb993-653a-45f6-863a-5f43bc86da79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>module_api_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/module_api/module_api_vs2022.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{03516e9d-31d1-40c1-9846-54c412d91c2c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>module_api_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5ad84319-5c2e-4012-869f-fd579114b248}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>moving_average_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />

--- a/HIP-Basic/moving_average/moving_average_vs2019.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{628390E3-DB62-4D52-9594-DE6BC15F9943}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>moving_average_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />

--- a/HIP-Basic/moving_average/moving_average_vs2022.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{0851ba21-ffdb-4e7a-b798-4dbaadb94b8e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>moving_average_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />

--- a/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2017.vcxproj
+++ b/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{46798a26-0c49-4e91-85b8-2a9783973c0c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>multi_gpu_data_transfer_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2019.vcxproj
+++ b/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{6A0FFF7E-9C0A-4BF5-BBA5-745CB4253EFB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>multi_gpu_data_transfer_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2022.vcxproj
+++ b/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{6fb2bcb7-bfa5-4342-a04d-b4ebfe570d46}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>multi_gpu_data_transfer_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/occupancy/occupancy_vs2017.vcxproj
+++ b/HIP-Basic/occupancy/occupancy_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{982a35a8-670e-417a-aea2-612706ed5e7a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>occupancy_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/occupancy/occupancy_vs2019.vcxproj
+++ b/HIP-Basic/occupancy/occupancy_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{e5b2fc79-3928-47f6-b57b-33aaa3c5d9c5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>occupancy_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/occupancy/occupancy_vs2022.vcxproj
+++ b/HIP-Basic/occupancy/occupancy_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{e6d8c701-08b7-482b-af43-1ca6765ca5fb}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>occupancy_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2017.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{3a7b4351-9f76-4863-aeb3-2ca6d2fc3bef}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>opengl_interop_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\External\glad\glad.cpp" />

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2019.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{96f8be41-5c64-4bf2-8a8e-474beaacaa5a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>opengl_interop_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\External\glad\glad.cpp" />

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2022.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4111d437-c931-44e1-a45d-407fafd3c444}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>opengl_interop_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\External\glad\glad.cpp" />

--- a/HIP-Basic/runtime_compilation/runtime_compilation_vs2017.vcxproj
+++ b/HIP-Basic/runtime_compilation/runtime_compilation_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{cdf0652f-3ebe-4e69-ab80-e065747bbdbc}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>runtime_compilation_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/runtime_compilation/runtime_compilation_vs2019.vcxproj
+++ b/HIP-Basic/runtime_compilation/runtime_compilation_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{E03790B7-B203-4504-BEF5-F4F061183642}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>runtime_compilation_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/runtime_compilation/runtime_compilation_vs2022.vcxproj
+++ b/HIP-Basic/runtime_compilation/runtime_compilation_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{f233f9b0-da39-49b7-a776-0fac215e6d0c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>runtime_compilation_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/saxpy/saxpy_vs2017.vcxproj
+++ b/HIP-Basic/saxpy/saxpy_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{1945ef9b-6e3c-4b44-a5d4-c88074402aaf}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>saxpy_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/saxpy/saxpy_vs2019.vcxproj
+++ b/HIP-Basic/saxpy/saxpy_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{D6334F08-D560-439A-A704-ADA0349D72B7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>saxpy_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/saxpy/saxpy_vs2022.vcxproj
+++ b/HIP-Basic/saxpy/saxpy_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4579d781-7ca9-470c-a76c-5903369c40e8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>saxpy_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/shared_memory/shared_memory_vs2017.vcxproj
+++ b/HIP-Basic/shared_memory/shared_memory_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{b71a0e84-07ad-4053-b211-214e64eb210d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>shared_memory_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/shared_memory/shared_memory_vs2019.vcxproj
+++ b/HIP-Basic/shared_memory/shared_memory_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{C370ACB7-AE52-4AD8-8C3D-4C32567FFE7D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>shared_memory_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/shared_memory/shared_memory_vs2022.vcxproj
+++ b/HIP-Basic/shared_memory/shared_memory_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{740b1c46-e54e-415f-900e-eb154402427c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>shared_memory_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/static_host_library/library/libhip_static_host_vs2017.vcxproj
+++ b/HIP-Basic/static_host_library/library/libhip_static_host_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{588559e5-a232-45d3-9181-7bd61bcc6a3f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libhip_static_host_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="library.hip" />

--- a/HIP-Basic/static_host_library/library/libhip_static_host_vs2019.vcxproj
+++ b/HIP-Basic/static_host_library/library/libhip_static_host_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{6d3f8f78-225e-490e-abd3-762857ebf597}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libhip_static_host_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="library.hip" />

--- a/HIP-Basic/static_host_library/library/libhip_static_host_vs2022.vcxproj
+++ b/HIP-Basic/static_host_library/library/libhip_static_host_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5fc8c701-b961-4719-a465-fc0fc84d2eee}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libhip_static_host_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="library.hip" />

--- a/HIP-Basic/static_host_library/static_host_library_msvc/static_host_library_msvc_vs2019.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_msvc/static_host_library_msvc_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{547b99c2-cbe3-4e1f-a1d6-26e261d67a3e}</ProjectGuid>
     <RootNamespace>static_host_library_msvc_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/HIP-Basic/static_host_library/static_host_library_msvc/static_host_library_msvc_vs2022.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_msvc/static_host_library_msvc_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{78759a7f-2b5c-4fe3-ae66-71df7a90a500}</ProjectGuid>
     <RootNamespace>static_host_library_msvc_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/HIP-Basic/static_host_library/static_host_library_vs2017.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{b9fb86c4-d4f9-437c-9430-983ba5d0d152}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>static_host_library_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/HIP-Basic/static_host_library/static_host_library_vs2019.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5f8a7fee-3a79-4588-9244-8575748026f7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>static_host_library_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/HIP-Basic/static_host_library/static_host_library_vs2022.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{27a6f412-bae5-49ff-b557-c86ee98352c9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>static_host_library_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/HIP-Basic/streams/streams_vs2017.vcxproj
+++ b/HIP-Basic/streams/streams_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{71f0f220-961d-4e58-847e-4afac2e43143}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>streams_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/streams/streams_vs2019.vcxproj
+++ b/HIP-Basic/streams/streams_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4e6b2034-d7ed-4cb4-98b2-7b2d2b71e0a9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>streams_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/streams/streams_vs2022.vcxproj
+++ b/HIP-Basic/streams/streams_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{3271c75f-a07a-454a-9ef7-f72f79845d77}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>streams_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/texture_management/texture_management_vs2017.vcxproj
+++ b/HIP-Basic/texture_management/texture_management_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{61585ee3-7d6b-48ea-bb00-50878cd11604}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>texture_management_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/texture_management/texture_management_vs2019.vcxproj
+++ b/HIP-Basic/texture_management/texture_management_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{40E56BFB-1A0C-4618-BB49-A9AA635127C1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>texture_management_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/texture_management/texture_management_vs2022.vcxproj
+++ b/HIP-Basic/texture_management/texture_management_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{be0294b1-c162-4877-b7a5-4ca9bb73146b}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>texture_management_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/vulkan_interop/vulkan_interop_vs2017.vcxproj
+++ b/HIP-Basic/vulkan_interop/vulkan_interop_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{2136fa2b-ecae-4998-bed9-14e529d42ca3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vulkan_interop_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />

--- a/HIP-Basic/vulkan_interop/vulkan_interop_vs2019.vcxproj
+++ b/HIP-Basic/vulkan_interop/vulkan_interop_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{688433e2-b189-431d-a5f8-9ac82102b58c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vulkan_interop_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />

--- a/HIP-Basic/vulkan_interop/vulkan_interop_vs2022.vcxproj
+++ b/HIP-Basic/vulkan_interop/vulkan_interop_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{73fcede4-fd46-43dc-8ae3-784318accb39}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vulkan_interop_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />

--- a/HIP-Basic/warp_shuffle/warp_shuffle_vs2017.vcxproj
+++ b/HIP-Basic/warp_shuffle/warp_shuffle_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a5763302-f669-4ccb-9429-a1f1ed8d93ec}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>warp_shuffle_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/warp_shuffle/warp_shuffle_vs2019.vcxproj
+++ b/HIP-Basic/warp_shuffle/warp_shuffle_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5852BE0E-BDA5-4BD9-8A16-30E8E40F4045}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>warp_shuffle_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/HIP-Basic/warp_shuffle/warp_shuffle_vs2022.vcxproj
+++ b/HIP-Basic/warp_shuffle/warp_shuffle_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{6fb434e3-82c7-46fd-b18a-31c280b535a2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>warp_shuffle_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
+++ b/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{e76bdeba-8119-46fb-87bb-69667aa1dae6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_strided_batched_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
+++ b/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{961a0eaa-2c41-42ad-a96b-d865203f3a94}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_strided_batched_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2022.vcxproj
+++ b/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{68e1c6f4-9bdb-440e-abbd-54700571932b}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_strided_batched_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/her/her_vs2017.vcxproj
+++ b/Libraries/hipBLAS/her/her_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{cacadce2-358a-4433-9211-04621019ff89}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>her_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/her/her_vs2019.vcxproj
+++ b/Libraries/hipBLAS/her/her_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{984032B2-170B-4DF2-AF16-96713C42C47D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>her_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/her/her_vs2022.vcxproj
+++ b/Libraries/hipBLAS/her/her_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{c7c11143-9097-4ede-8f3a-af5beb724283}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>her_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/scal/scal_vs2017.vcxproj
+++ b/Libraries/hipBLAS/scal/scal_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{9a7fa569-e93a-4066-ac8b-096dd2955df7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scal_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/scal/scal_vs2019.vcxproj
+++ b/Libraries/hipBLAS/scal/scal_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{658c0200-6fc1-4460-b7a5-bb1876830607}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scal_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipBLAS/scal/scal_vs2022.vcxproj
+++ b/Libraries/hipBLAS/scal/scal_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{68e84ad8-8fdc-44ae-a10a-b576803913d4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scal_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2017.vcxproj
+++ b/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{c8edeff9-36b0-4942-b6dd-2548911d0677}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_radix_sort_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2019.vcxproj
+++ b/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{be670e16-8a40-46e0-9cf2-93352ed685b0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_radix_sort_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2022.vcxproj
+++ b/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{94f30c07-0514-4ab9-b269-196dc0c0f0e0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_radix_sort_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipCUB/device_sum/device_sum_vs2017.vcxproj
+++ b/Libraries/hipCUB/device_sum/device_sum_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{48af1513-2732-45c2-a1ac-28a551a9de79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_sum_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipCUB/device_sum/device_sum_vs2019.vcxproj
+++ b/Libraries/hipCUB/device_sum/device_sum_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{ef1e1a7e-2803-4606-bd9a-da8fa981aba4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_sum_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/hipCUB/device_sum/device_sum_vs2022.vcxproj
+++ b/Libraries/hipCUB/device_sum/device_sum_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{2f0f836d-cab8-470e-ae1a-d04bffdb4474}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_sum_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocBLAS/level_1/axpy/axpy_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/axpy/axpy_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a9f4bc5e-94c6-47be-819a-d10313aaab57}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>axpy_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/axpy/axpy_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/axpy/axpy_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{DDC6904E-B174-4F08-908E-0535C3BD5A9A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>axpy_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/axpy/axpy_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_1/axpy/axpy_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{29da7c17-c373-4197-963b-78d870c79dfe}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>axpy_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/dot/dot_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/dot/dot_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{9477b5df-e2c3-42d2-b1ec-dc158f75db43}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dot_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/dot/dot_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/dot/dot_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{D306FFB0-DD32-4B12-9E48-8AAC5DDF48E4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dot_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/dot/dot_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_1/dot/dot_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{c8534317-bd87-4690-8cdb-eccb72cb8318}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>dot_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{2a7579ab-7148-406b-ac28-e6c3fedd5b75}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>nrm2_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{16A9CB28-E8ED-4040-BD0B-7290685EE782}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>nrm2_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{266dc180-311b-4311-845a-ebb43719e231}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>nrm2_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/scal/scal_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/scal/scal_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{316dcce2-84ec-46e0-9bb0-2622fcf88206}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scal_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/scal/scal_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/scal/scal_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{201e0855-44cb-4b99-bebd-a8b3e9f67aea}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scal_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/scal/scal_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_1/scal/scal_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{0f219659-c445-4f47-81bf-b3c767f0636a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>scal_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/swap/swap_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/swap/swap_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{141c9b9b-1319-4f7a-be3f-6b3c410fe562}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>swap_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/swap/swap_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/swap/swap_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{00eff6d1-ea39-4fd7-a84d-2d93feabd6cf}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>swap_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_1/swap/swap_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_1/swap/swap_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{567d0873-192c-4c37-8962-3b4eeb023088}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>swap_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{d12eddee-bdc1-4c0d-8fd8-69410fdc988d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemv_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{E4A7C45C-BF68-455A-A37B-3558F427DC53}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemv_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{f7a01532-e65a-4a8a-a798-badfa5fdb156}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemv_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_2/her/her_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{330276ce-a36b-4aef-909b-ba44032a4e06}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>her_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_2/her/her_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{1bf2770a-a16c-428e-9bd0-09070d2bee30}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>her_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_2/her/her_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5e132540-08ac-4849-8581-5426fe28df9b}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>her_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{cc8acbf9-40da-40e5-875a-10263c2c7809}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4E28F2B0-CE5D-40F4-9AF5-5BC18A27C59B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{759bc899-20d2-4706-802e-d54ea99796f0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5652efc0-087e-480a-bf2e-9b24b7afdf6a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_strided_batched_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{1E9ED0DD-CCD1-4658-B958-34E85E5348FE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_strided_batched_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{9a7364e9-5ea8-4fa1-8d1a-5ed5952809c3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>gemm_strided_batched_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocPRIM/block_sum/block_sum_vs2017.vcxproj
+++ b/Libraries/rocPRIM/block_sum/block_sum_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{89593b1e-dfd0-4ad1-bfd7-20e035cf68ac}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>block_sum_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocPRIM/block_sum/block_sum_vs2019.vcxproj
+++ b/Libraries/rocPRIM/block_sum/block_sum_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{65B21869-2BE2-4DA5-BEC5-28D1F910731C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>block_sum_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocPRIM/block_sum/block_sum_vs2022.vcxproj
+++ b/Libraries/rocPRIM/block_sum/block_sum_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5e910bcc-9b1d-4c26-9689-d46d14bb08ce}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>block_sum_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocPRIM/device_sum/device_sum_vs2017.vcxproj
+++ b/Libraries/rocPRIM/device_sum/device_sum_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{f98c4e4a-9ac7-4d5b-9bfc-470b95b143b2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_sum_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocPRIM/device_sum/device_sum_vs2019.vcxproj
+++ b/Libraries/rocPRIM/device_sum/device_sum_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{E71DB5FB-A1C4-4BB4-8B46-0037C32C885E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_sum_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocPRIM/device_sum/device_sum_vs2022.vcxproj
+++ b/Libraries/rocPRIM/device_sum/device_sum_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a5a197db-acf8-438b-b4f7-ceddfb786ead}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_sum_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2017.vcxproj
+++ b/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{0609d861-fceb-4a19-9786-ac4c57a6b955}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>simple_distributions_cpp_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2019.vcxproj
+++ b/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{13bb009a-0679-49c0-a763-3f0a388ea78f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>simple_distributions_cpp_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2022.vcxproj
+++ b/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{36b865db-b189-47a7-ad1f-75fca0280606}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>simple_distributions_cpp_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Libraries/rocThrust/device_ptr/device_ptr_vs2017.vcxproj
+++ b/Libraries/rocThrust/device_ptr/device_ptr_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{5dd923eb-e763-4b23-af94-0527326a61ce}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_ptr_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/device_ptr/device_ptr_vs2019.vcxproj
+++ b/Libraries/rocThrust/device_ptr/device_ptr_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{fd1402c4-336f-4aef-a5f6-1dd7903a965c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_ptr_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/device_ptr/device_ptr_vs2022.vcxproj
+++ b/Libraries/rocThrust/device_ptr/device_ptr_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{20cf76e8-258c-42fb-b050-2387d60441e9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>device_ptr_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/norm/norm_vs2017.vcxproj
+++ b/Libraries/rocThrust/norm/norm_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{a07ecfa4-c1be-4b7f-a202-08695f0227e4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>norm_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/norm/norm_vs2019.vcxproj
+++ b/Libraries/rocThrust/norm/norm_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8683c739-f470-44a6-a187-9a5929ae9df9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>norm_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/norm/norm_vs2022.vcxproj
+++ b/Libraries/rocThrust/norm/norm_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{933121f0-5c1d-44da-9db7-260dc8dd0c44}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>norm_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/reduce_sum/reduce_sum_vs2017.vcxproj
+++ b/Libraries/rocThrust/reduce_sum/reduce_sum_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{b586e07c-8cd6-4ee1-9dc1-8995ebb44f0e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>reduce_sum_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/reduce_sum/reduce_sum_vs2019.vcxproj
+++ b/Libraries/rocThrust/reduce_sum/reduce_sum_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{c0405ffb-7aa2-49c2-9ab5-af336a54b41c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>reduce_sum_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/reduce_sum/reduce_sum_vs2022.vcxproj
+++ b/Libraries/rocThrust/reduce_sum/reduce_sum_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{c1caca43-1565-4e23-9e3f-3f64cb19d4ce}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>reduce_sum_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/remove_points/remove_points_vs2017.vcxproj
+++ b/Libraries/rocThrust/remove_points/remove_points_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{79395786-c1b9-408f-ade5-df9b2793da33}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>remove_points_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/remove_points/remove_points_vs2019.vcxproj
+++ b/Libraries/rocThrust/remove_points/remove_points_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{631c61aa-52ba-4818-bd39-fa9cf47076c7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>remove_points_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/remove_points/remove_points_vs2022.vcxproj
+++ b/Libraries/rocThrust/remove_points/remove_points_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{3754051f-0225-4667-9982-570e319a19f6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>remove_points_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/saxpy/saxpy_vs2017.vcxproj
+++ b/Libraries/rocThrust/saxpy/saxpy_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{176119ca-c9c7-49df-be61-4361f908239e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>saxpy_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/saxpy/saxpy_vs2019.vcxproj
+++ b/Libraries/rocThrust/saxpy/saxpy_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{e1d552cf-3fe3-427a-95e1-8cffb60bbf8e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>saxpy_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/saxpy/saxpy_vs2022.vcxproj
+++ b/Libraries/rocThrust/saxpy/saxpy_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{4634d5ea-9f81-4b15-8d6a-61a531555da8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>saxpy_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/vectors/vectors_vs2017.vcxproj
+++ b/Libraries/rocThrust/vectors/vectors_vs2017.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8e591049-d3c4-408e-a847-88bb85852962}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vectors_vs2017</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/vectors/vectors_vs2019.vcxproj
+++ b/Libraries/rocThrust/vectors/vectors_vs2019.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8dea1f0f-8bf3-422c-9bcd-99f69f43d013}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vectors_vs2019</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />

--- a/Libraries/rocThrust/vectors/vectors_vs2022.vcxproj
+++ b/Libraries/rocThrust/vectors/vectors_vs2022.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{d01d63fc-ca52-4aca-be79-f96ba5b8bef8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vectors_vs2022</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="main.hip" />


### PR DESCRIPTION
**[Reasons]**
+ `$(LatestTargetPlatformVersion)` is already a default value for both Platform Toolsets `HIP_clang` and `HIP_nvcc`
+ Better to have the latest Windows SDK version for the already created projects when Windows SDK is updated
+ Backward compatibility: Visual Studio 2017 users, for instance, may have Windows SDK < 10.0
