### PR TITLE
[docker][git] Minor `Dockerfile` and `.gitignore` enhancements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 [Dd]ebug
 [Rr]elease
 *.vcxproj.user
-build
+[Bb]uild

--- a/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
@@ -73,8 +73,11 @@ RUN wget https://github.com/ROCmSoftwarePlatform/hipBLAS/archive/refs/tags/rocm-
     && cmake --build ./hipBLAS-rocm-5.3.0/build --target install \
     && rm -rf ./hipBLAS-rocm-5.3.0
 
+# Use render group as an argument from user
+ARG GID=109
+
 # Add the render group and a user with sudo permissions for the container
-RUN groupadd --system --gid 109 render \
+RUN groupadd --system --gid ${ARG} render \
     && useradd -Um -G sudo,video,render developer \
     && echo developer ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/developer \
     && chmod 0440 /etc/sudoers.d/developer

--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -43,8 +43,11 @@ ENV PATH="/cmake/bin:/opt/rocm/bin:${PATH}"
 RUN echo "/opt/rocm/lib" >> /etc/ld.so.conf.d/rocm.conf \
     && ldconfig
 
+# Use render group as an argument from user
+ARG GID=109
+
 # Add the render group and a user with sudo permissions for the container
-RUN groupadd --system --gid 109 render \
+RUN groupadd --system --gid ${GID} render \
     && useradd -Um -G sudo,video,render developer \
     && echo developer ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/developer \
     && chmod 0440 /etc/sudoers.d/developer


### PR DESCRIPTION
I thank you for reviewing this PR.

The purpose of the PR is to enable an optional (group ID) `GID` argument to be passed so that it matches the
one on the host. Often, the `render` group id, when matched with the host, allows us to build and
run the examples without requiring root permissions. With that, I am able to run this on most distributions
and I can pass `--build-arg GID=$(getent group render  | cut -d: -f3)` while building with Docker.

The other fix adds the `Build` directory to `.gitignore`, in-line with the naming convention.

Commit Message:

```
Build Fixes for various distributions.

* Change groupid to an optional argument a user can pass when building.
* Add Build to .gitignore
```