### PR TITLE
[nvcc][fix] Fix compilation problems with HIP_nvcc toolchain

### DIFF
--- a/HIP-Basic/matrix_multiplication/main.hip
+++ b/HIP-Basic/matrix_multiplication/main.hip
@@ -184,7 +184,7 @@ int main(int argc, const char* argv[])
     HIP_CHECK(hipMemcpy(d_A, A.data(), a_bytes, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(d_B, B.data(), b_bytes, hipMemcpyHostToDevice));
 
-    constexpr dim3 block_dim(block_size, block_size);
+    const dim3 block_dim(block_size, block_size);
     const dim3     grid_dim(c_cols / block_size, c_rows / block_size);
 
     // Launch matrix multiplication kernel.

--- a/HIP-Basic/moving_average/main.hip
+++ b/HIP-Basic/moving_average/main.hip
@@ -101,7 +101,7 @@ int main()
     std::transform(h_input.begin(),
                    h_input.end(),
                    h_input.begin(),
-                   [](unsigned int i) { return i % window_size; });
+                   [&](unsigned int i) { return i % window_size; });
 
     // Allocate device input data and copy host data to it.
     unsigned int*    d_input{};

--- a/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
@@ -65,6 +65,12 @@
   <PropertyGroup Label="HIP_clang" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP_clang'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/moving_average/moving_average_vs2019.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2019.vcxproj
@@ -65,6 +65,12 @@
   <PropertyGroup Label="HIP_clang" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP_clang'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/moving_average/moving_average_vs2022.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2022.vcxproj
@@ -65,6 +65,12 @@
   <PropertyGroup Label="HIP_clang" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP_clang'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/multi_gpu_data_transfer/main.hip
+++ b/HIP-Basic/multi_gpu_data_transfer/main.hip
@@ -177,8 +177,8 @@ int main()
     constexpr unsigned int grid_size = (width + block_size - 1) / block_size;
 
     // Block and grid sizes in 2D.
-    constexpr dim3 block_dim(block_size, block_size);
-    constexpr dim3 grid_dim(grid_size, grid_size);
+    const dim3 block_dim(block_size, block_size);
+    const dim3 grid_dim(grid_size, grid_size);
 
     // Allocate host input matrix and initialize with increasing sequence 1, 2, 3, ....
     std::vector<float> matrix(size);

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2022.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2022.vcxproj
@@ -88,12 +88,12 @@
       <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(IntDir);$(GLFW_DIR)\include\;$(MSBuildProjectDirectory)\..\..\Common;$(MSBuildProjectDirectory)\..\..\External;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalLibraryDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GLFW_DIR)\lib-vc2022</AdditionalLibraryDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>glfw3dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(GLFW_DIR)\lib-vc2022</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP_clang'">

--- a/HIP-Basic/shared_memory/main.hip
+++ b/HIP-Basic/shared_memory/main.hip
@@ -90,8 +90,8 @@ int main()
     constexpr unsigned int grid_size = (width + block_size - 1) / block_size;
 
     // Block and grid sizes in 2D.
-    constexpr dim3 block_dim(block_size, block_size);
-    constexpr dim3 grid_dim(grid_size, grid_size);
+    const dim3 block_dim(block_size, block_size);
+    const dim3 grid_dim(grid_size, grid_size);
 
     // Allocate host input matrix and initialize with increasing sequence 10, 20, 30, ....
     std::vector<float> matrix(size);

--- a/HIP-Basic/streams/streams_vs2017.vcxproj
+++ b/HIP-Basic/streams/streams_vs2017.vcxproj
@@ -65,6 +65,12 @@
   <PropertyGroup Label="HIP_clang" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP_clang'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/streams/streams_vs2019.vcxproj
+++ b/HIP-Basic/streams/streams_vs2019.vcxproj
@@ -65,6 +65,12 @@
   <PropertyGroup Label="HIP_clang" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP_clang'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/streams/streams_vs2022.vcxproj
+++ b/HIP-Basic/streams/streams_vs2022.vcxproj
@@ -65,6 +65,12 @@
   <PropertyGroup Label="HIP_clang" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
+  <PropertyGroup Label="HIP" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NvccAdditionalOptions>-std=c++17</NvccAdditionalOptions>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP_clang'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/warp_shuffle/main.hip
+++ b/HIP-Basic/warp_shuffle/main.hip
@@ -86,8 +86,8 @@ int main()
            && "Matrix has more elements than architecture's warp size value.");
 
     // Block (2D) and grid sizes. Note that in this example we have only 1 block (and 1 warp).
-    constexpr dim3 block_dim(width, width);
-    constexpr dim3 grid_dim(1);
+    const dim3 block_dim(width, width);
+    const dim3 grid_dim(1);
 
     // Allocate host input matrix and initialize with increasing sequence 10, 20, 30, ....
     std::vector<float> matrix(size);


### PR DESCRIPTION
**Fix several compilation problems with HIP_nvcc toolchain (CUDA Toolkit 11.8):**


- HIP-Basic/matrix_multiplication
> main.hip
- HIP-Basic/moving_average
> main.hip
> moving_average_vs2017.vcxproj
> moving_average_vs2019.vcxproj
> moving_average_vs2022.vcxproj
- HIP-Basic/multi_gpu_data_transfer
> main.hip
- HIP-Basic/opengl_interop
> opengl_interop_vs2022.vcxproj
- HIP-Basic/shared_memory
> main.hip
- HIP-Basic/streams
> streams_vs2017.vcxproj
> streams_vs2019.vcxproj
> streams_vs2022.vcxproj
- HIP-Basic/warp_shuffle
> main.hip