### PR TITLE
Handle HIPSOLVER_STATUS_ZERO_PIVOT

### DIFF
--- a/Common/hipsolver_utils.hpp
+++ b/Common/hipsolver_utils.hpp
@@ -46,6 +46,9 @@ inline const char* hipsolverStatusToString(hipsolverStatus_t status)
         case HIPSOLVER_STATUS_HANDLE_IS_NULLPTR: return "HIPSOLVER_STATUS_HANDLE_IS_NULLPTR";
         case HIPSOLVER_STATUS_INVALID_ENUM: return "HIPSOLVER_STATUS_INVALID_ENUM";
         case HIPSOLVER_STATUS_UNKNOWN: return "HIPSOLVER_STATUS_UNKNOWN";
+#if hipsolverVersionMajor * 10 + hipsolverVersionMinor >= 18
+        case HIPSOLVER_STATUS_ZERO_PIVOT: return "HIPSOLVER_STATUS_ZERO_PIVOT";
+#endif
     }
     // We don't use default so that the compiler warns if any valid enums are missing from the
     // switch. If the value is not a valid hipsolverStatus_t, we return the following.

--- a/Common/hipsolver_utils.hpp
+++ b/Common/hipsolver_utils.hpp
@@ -46,7 +46,7 @@ inline const char* hipsolverStatusToString(hipsolverStatus_t status)
         case HIPSOLVER_STATUS_HANDLE_IS_NULLPTR: return "HIPSOLVER_STATUS_HANDLE_IS_NULLPTR";
         case HIPSOLVER_STATUS_INVALID_ENUM: return "HIPSOLVER_STATUS_INVALID_ENUM";
         case HIPSOLVER_STATUS_UNKNOWN: return "HIPSOLVER_STATUS_UNKNOWN";
-#if hipsolverVersionMajor * 10 + hipsolverVersionMinor >= 18
+#if (hipsolverVersionMajor == 1 && hipsolverVersionMinor >= 8) || hipsolverVersionMajor >= 2
         case HIPSOLVER_STATUS_ZERO_PIVOT: return "HIPSOLVER_STATUS_ZERO_PIVOT";
 #endif
     }


### PR DESCRIPTION
In ROCm 5.6 hipSOLVER introduced a new entry to `hipsolverStatus_t` which trips warning as error builds when not handled. The existence of the extra handling is done by detecting hipSOLVER version via preprocessor constants.