### PR TITLE
Print compute capability on NVIDIA platform

### DIFF
--- a/HIP-Basic/device_query/main.cpp
+++ b/HIP-Basic/device_query/main.cpp
@@ -83,6 +83,8 @@ void print_device_properties(int device_id)
     // On the AMD platform only, print the architecture name.
 #ifdef __HIP_PLATFORM_AMD__
     std::cout << std::setw(col_w) << "gcnArchName: " << props.gcnArchName << '\n';
+#elif defined(__HIP_PLATFORM_NVIDIA__)
+    std::cout << std::setw(col_w) << "major.minor: " << props.major << "." << props.minor << '\n';
 #endif
     std::cout << '\n';
 


### PR DESCRIPTION
In the soon-to-come tutorial I would like to omit having to compile NVIDIA's deviceQuery from [cuda-samples](https://github.com/NVIDIA/cuda-samples/tree/master/Samples/1_Utilities/deviceQuery) mostly because it looks bad how obtaining this information requires "3rd-party" intervention.

In the long term, users of the NVIDIA back-end should get the same breadth of tools trivially pre-installed that users of the AMD platform get. If `rocminfo/hipInfo.exe` are available, they should get the matching, pre-compiled binaries for the NVIDIA platform.