### PR TITLE
Fixing Radeon 7600 not compiling inside docker

### DIFF
--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -24,10 +24,10 @@ ENV LANG en_US.utf8
 
 # Install ROCM HIP and libraries using the installer script
 RUN export DEBIAN_FRONTEND=noninteractive; \
-    wget https://repo.radeon.com/amdgpu-install/5.3/ubuntu/focal/amdgpu-install_5.3.50300-1_all.deb \
+    wget https://repo.radeon.com/amdgpu-install/5.6.1/ubuntu/focal/amdgpu-install_5.6.50601-1_all.deb \
     && apt-get update -qq \
-    && apt-get install -y ./amdgpu-install_5.3.50300-1_all.deb \
-    && rm ./amdgpu-install_5.3.50300-1_all.deb \
+    && apt-get install -y ./amdgpu-install_5.6.50601-1_all.deb \
+    && rm ./amdgpu-install_5.6.50601-1_all.deb \
     && amdgpu-install -y --usecase=hiplibsdk --no-dkms \
     && apt-get install -y libnuma-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
fix #45 

Seems that updating ROCm version inside Docker fixes the problem of not being able to compile the examples on my Radeon 7600.

Tested on ArchLinux 6.4.12-arch1-1 and docker:
```
Client:
 Version:    24.0.5
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  0.11.2
    Path:     /usr/lib/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  2.20.3
    Path:     /usr/lib/docker/cli-plugins/docker-compose
  extension: Manages Docker extensions (Docker Inc.)
    Version:  v0.2.20
    Path:     /usr/lib/docker/cli-plugins/docker-extension

Server:
 Containers: 11
  Running: 0
  Paused: 0
  Stopped: 11
 Images: 10
 Server Version: 24.0.5
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: true
  Native Overlay Diff: false
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: fe457eb99ac0e27b3ce638175ef8e68a7d2bc373.m
 runc version: 
 init version: de40ad0
 Security Options:
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 6.4.12-arch1-1
 Operating System: Arch Linux
 OSType: linux
 Architecture: x86_64
 CPUs: 12
 Total Memory: 15.53GiB
 Name: Lucas-PC
 ID: a5454384-9a93-4415-baa0-249de10f1d18
 Docker Root Dir: /home/lucas/HDSeguro/Docker
 Debug Mode: false
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false
```