### PR TITLE
[vcxproj][5.5][module_api][fix] Excluded HIP-specific `CustomBuild` from building by `HIP_nvcc`

### DIFF
--- a/HIP-Basic/module_api/module_api_vs2017.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2017.vcxproj
@@ -17,14 +17,14 @@
     <RootNamespace>module_api_vs2017</RootNamespace>
     <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PlatformToolset)'!='HIP_nvcc'">
     <ClCompile Include="main.hip" />
     <CustomBuild Include="module.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o $(OutDir)module.co %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o "$(OutDir)module.co" %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object module.co</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)module.co</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o $(OutDir)module.co %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o "$(OutDir)module.co" %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object module.co</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)module.co</Outputs>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)module.co</ObjectFileName>

--- a/HIP-Basic/module_api/module_api_vs2019.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2019.vcxproj
@@ -17,14 +17,14 @@
     <RootNamespace>module_api_vs2019</RootNamespace>
     <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PlatformToolset)'!='HIP_nvcc'">
     <ClCompile Include="main.hip" />
     <CustomBuild Include="module.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o $(OutDir)module.co %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o "$(OutDir)module.co" %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object module.co</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)module.co</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o $(OutDir)module.co %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o "$(OutDir)module.co" %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object module.co</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)module.co</Outputs>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)module.co</ObjectFileName>

--- a/HIP-Basic/module_api/module_api_vs2022.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2022.vcxproj
@@ -17,14 +17,14 @@
     <RootNamespace>module_api_vs2022</RootNamespace>
     <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PlatformToolset)'!='HIP_nvcc'">
     <ClCompile Include="main.hip" />
     <CustomBuild Include="module.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o $(OutDir)module.co %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o "$(OutDir)module.co" %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object module.co</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)module.co</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o $(OutDir)module.co %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -o "$(OutDir)module.co" %(Identity) --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object module.co</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)module.co</Outputs>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)module.co</ObjectFileName>


### PR DESCRIPTION
**[Reason]**
+ Despite the project being marked as `ProjectExcludedFromBuild` for `HIP_nvcc`, it doesn't affect `CustomBuild` steps - thus; as a result, the project is still being built for `HIP_nvcc` 

**[clang][fix]**
+ Double-quoted `-o` options to treat spaces correctly - it is needed for `5.7`