### PR TITLE
[vcxproj][5.5][assembly_to_executable][fix] Excluded HIP-specific `CustomBuild` from building by `HIP_nvcc`

### DIFF
--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PlatformToolset)'=='HIP_clang'">
     <CustomBuild Include="hip_obj_gen_win.mcin">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy %(Identity) "$(IntDir)%(Identity)"</Command>
@@ -81,7 +81,6 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)clang++" -o "$(IntDir)%(FileName).o" "%(Identity)" -target amdgcn-amd-amdhsa -mcpu=gfx1102 </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)clang++" -o "$(IntDir)%(FileName).o" "%(Identity)" -target amdgcn-amd-amdhsa -mcpu=gfx1102 </Command>
     </CustomBuild>
-
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2019.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2019.vcxproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PlatformToolset)'=='HIP_clang'">
     <CustomBuild Include="hip_obj_gen_win.mcin">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy %(Identity) "$(IntDir)%(Identity)"</Command>
@@ -81,7 +81,6 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)clang++" -o "$(IntDir)%(FileName).o" "%(Identity)" -target amdgcn-amd-amdhsa -mcpu=gfx1102 </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)clang++" -o "$(IntDir)%(FileName).o" "%(Identity)" -target amdgcn-amd-amdhsa -mcpu=gfx1102 </Command>
     </CustomBuild>
-
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2022.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2022.vcxproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\Common\example_utils.hpp" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PlatformToolset)'=='HIP_clang'">
     <CustomBuild Include="hip_obj_gen_win.mcin">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy %(Identity) "$(IntDir)%(Identity)"</Command>
@@ -81,7 +81,6 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)clang++" -o "$(IntDir)%(FileName).o" "%(Identity)" -target amdgcn-amd-amdhsa -mcpu=gfx1102 </Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)clang++" -o "$(IntDir)%(FileName).o" "%(Identity)" -target amdgcn-amd-amdhsa -mcpu=gfx1102 </Command>
     </CustomBuild>
-
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
**[Reason]**

+ Despite the project being marked as `ProjectExcludedFromBuild` for `HIP_nvcc`, it doesn't affect `CustomBuild` steps - thus; as a result, the project is still being built for `HIP_nvcc`
