### PR TITLE
[vcxproj][5.7][vs2017] Move projects from 5.5 to 5.7 - Step 2 - Options - Explicit `OffloadArch` removal

### DIFF
--- a/Applications/bitonic_sort/bitonic_sort_vs2017.vcxproj
+++ b/Applications/bitonic_sort/bitonic_sort_vs2017.vcxproj
@@ -61,12 +61,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>applications_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Applications/convolution/convolution_vs2017.vcxproj
+++ b/Applications/convolution/convolution_vs2017.vcxproj
@@ -61,12 +61,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>applications_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Applications/floyd_warshall/floyd_warshall_vs2017.vcxproj
+++ b/Applications/floyd_warshall/floyd_warshall_vs2017.vcxproj
@@ -61,12 +61,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>applications_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Applications/histogram/histogram_vs2017.vcxproj
+++ b/Applications/histogram/histogram_vs2017.vcxproj
@@ -61,12 +61,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>applications_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Applications/prefix_sum/prefix_sum_vs2017.vcxproj
+++ b/Applications/prefix_sum/prefix_sum_vs2017.vcxproj
@@ -61,12 +61,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>applications_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
@@ -124,12 +124,6 @@
     <TargetName>hip_$(ProjectName)</TargetName>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/bandwidth/bandwidth_vs2017.vcxproj
+++ b/HIP-Basic/bandwidth/bandwidth_vs2017.vcxproj
@@ -61,12 +61,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/bit_extract/bit_extract_vs2017.vcxproj
+++ b/HIP-Basic/bit_extract/bit_extract_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
+++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/device_globals/device_globals_vs2017.vcxproj
+++ b/HIP-Basic/device_globals/device_globals_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/device_query/device_query_vs2017.vcxproj
+++ b/HIP-Basic/device_query/device_query_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/dynamic_shared/dynamic_shared_vs2017.vcxproj
+++ b/HIP-Basic/dynamic_shared/dynamic_shared_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/events/events_vs2017.vcxproj
+++ b/HIP-Basic/events/events_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/gpu_arch/gpu_arch_vs2017.vcxproj
+++ b/HIP-Basic/gpu_arch/gpu_arch_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/hello_world/hello_world_vs2017.vcxproj
+++ b/HIP-Basic/hello_world/hello_world_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/inline_assembly/inline_assembly_vs2017.vcxproj
+++ b/HIP-Basic/inline_assembly/inline_assembly_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2017.vcxproj
@@ -79,12 +79,6 @@
     <TargetName>hip_$(ProjectName)</TargetName>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2017.vcxproj
+++ b/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/module_api/module_api_vs2017.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2017.vcxproj
@@ -76,12 +76,6 @@
     <TargetName>hip_$(ProjectName)</TargetName>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2017.vcxproj
+++ b/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/occupancy/occupancy_vs2017.vcxproj
+++ b/HIP-Basic/occupancy/occupancy_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2017.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2017.vcxproj
@@ -68,12 +68,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/runtime_compilation/runtime_compilation_vs2017.vcxproj
+++ b/HIP-Basic/runtime_compilation/runtime_compilation_vs2017.vcxproj
@@ -71,12 +71,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/saxpy/saxpy_vs2017.vcxproj
+++ b/HIP-Basic/saxpy/saxpy_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/shared_memory/shared_memory_vs2017.vcxproj
+++ b/HIP-Basic/shared_memory/shared_memory_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/static_host_library/library/libhip_static_host_vs2017.vcxproj
+++ b/HIP-Basic/static_host_library/library/libhip_static_host_vs2017.vcxproj
@@ -59,12 +59,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/static_host_library/static_host_library_vs2017.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_vs2017.vcxproj
@@ -62,12 +62,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/streams/streams_vs2017.vcxproj
+++ b/HIP-Basic/streams/streams_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/texture_management/texture_management_vs2017.vcxproj
+++ b/HIP-Basic/texture_management/texture_management_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/vulkan_interop/vulkan_interop_vs2017.vcxproj
+++ b/HIP-Basic/vulkan_interop/vulkan_interop_vs2017.vcxproj
@@ -94,12 +94,6 @@
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/HIP-Basic/warp_shuffle/warp_shuffle_vs2017.vcxproj
+++ b/HIP-Basic/warp_shuffle/warp_shuffle_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hip_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
+++ b/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipBLAS/her/her_vs2017.vcxproj
+++ b/Libraries/hipBLAS/her/her_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipBLAS/scal/scal_vs2017.vcxproj
+++ b/Libraries/hipBLAS/scal/scal_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2017.vcxproj
+++ b/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2017.vcxproj
@@ -61,11 +61,7 @@
     <TargetName>hipcub_$(ProjectName)</TargetName>
   </PropertyGroup>
   <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
     <ClangAdditionalOptions>-fno-stack-protector</ClangAdditionalOptions>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>

--- a/Libraries/hipCUB/device_sum/device_sum_vs2017.vcxproj
+++ b/Libraries/hipCUB/device_sum/device_sum_vs2017.vcxproj
@@ -60,12 +60,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipcub_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/gels/gels_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/gels/gels_vs2017.vcxproj
@@ -80,12 +80,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/geqrf/geqrf_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/geqrf/geqrf_vs2017.vcxproj
@@ -84,12 +84,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/gesvd/gesvd_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/gesvd/gesvd_vs2017.vcxproj
@@ -84,12 +84,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/getrf/getrf_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/getrf/getrf_vs2017.vcxproj
@@ -80,12 +80,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/potrf/potrf_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/potrf/potrf_vs2017.vcxproj
@@ -80,12 +80,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/syevd/syevd_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevd/syevd_vs2017.vcxproj
@@ -80,12 +80,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/syevdx/syevdx_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevdx/syevdx_vs2017.vcxproj
@@ -83,12 +83,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/syevj/syevj_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevj/syevj_vs2017.vcxproj
@@ -80,12 +80,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/syevj_batched/syevj_batched_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevj_batched/syevj_batched_vs2017.vcxproj
@@ -84,12 +84,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/sygvd/sygvd_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/sygvd/sygvd_vs2017.vcxproj
@@ -83,12 +83,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/hipSOLVER/sygvj/sygvj_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/sygvj/sygvj_vs2017.vcxproj
@@ -79,12 +79,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>hipsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_1/axpy/axpy_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/axpy/axpy_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_1/dot/dot_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/dot/dot_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_1/scal/scal_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/scal/scal_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_1/swap/swap_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/swap/swap_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_2/her/her_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
@@ -74,12 +74,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocblas_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocPRIM/block_sum/block_sum_vs2017.vcxproj
+++ b/Libraries/rocPRIM/block_sum/block_sum_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocprim_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocPRIM/device_sum/device_sum_vs2017.vcxproj
+++ b/Libraries/rocPRIM/device_sum/device_sum_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocprim_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2017.vcxproj
+++ b/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocrand_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSOLVER/getf2/getf2_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/getf2/getf2_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSOLVER/getri/getri_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/getri/getri_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSOLVER/syev/syev_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/syev/syev_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSOLVER/syev_batched/syev_batched_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/syev_batched/syev_batched_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSOLVER/syev_strided_batched/syev_strided_batched_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/syev_strided_batched/syev_strided_batched_vs2017.vcxproj
@@ -77,12 +77,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsolver_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_2/bsrmv/bsrmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrmv/bsrmv_vs2017.vcxproj
@@ -68,12 +68,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_2/bsrsv/bsrsv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrsv/bsrsv_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_2/bsrxmv/bsrxmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrxmv/bsrxmv_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_2/csrmv/csrmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/csrmv/csrmv_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_2/csrsv/csrsv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/csrsv/csrsv_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_3/bsrmm/bsrmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/bsrmm/bsrmm_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_3/bsrsm/bsrsm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/bsrsm/bsrsm_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_3/csrmm/csrmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/csrmm/csrmm_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/level_3/csrsm/csrsm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/csrsm/csrsm_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/preconditioner/bsric0/bsric0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/bsric0/bsric0_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/preconditioner/bsrilu0/bsrilu0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/bsrilu0/bsrilu0_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/preconditioner/csric0/csric0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csric0/csric0_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/preconditioner/csrilu0/csrilu0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csrilu0/csrilu0_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/csritilu0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/csritilu0_vs2017.vcxproj
@@ -69,12 +69,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocsparse_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocThrust/device_ptr/device_ptr_vs2017.vcxproj
+++ b/Libraries/rocThrust/device_ptr/device_ptr_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocthrust_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocThrust/norm/norm_vs2017.vcxproj
+++ b/Libraries/rocThrust/norm/norm_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocthrust_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocThrust/reduce_sum/reduce_sum_vs2017.vcxproj
+++ b/Libraries/rocThrust/reduce_sum/reduce_sum_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocthrust_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocThrust/remove_points/remove_points_vs2017.vcxproj
+++ b/Libraries/rocThrust/remove_points/remove_points_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocthrust_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocThrust/saxpy/saxpy_vs2017.vcxproj
+++ b/Libraries/rocThrust/saxpy/saxpy_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocthrust_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>

--- a/Libraries/rocThrust/vectors/vectors_vs2017.vcxproj
+++ b/Libraries/rocThrust/vectors/vectors_vs2017.vcxproj
@@ -63,12 +63,6 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>rocthrust_$(ProjectName)</TargetName>
   </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
-  <PropertyGroup Label="HIP clang $(HIPVersion)" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OffloadArch>gfx1030;gfx1100;gfx1101;gfx1102</OffloadArch>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>


### PR DESCRIPTION
+ [Reason] `OffloadArch` is being set in the common `props` file `AMD.HIP.Clang.Common.props`, loaded for any `HIP` project
