### PR TITLE
[vcxproj][5.7][vs2022][fix][#77] Move projects from 5.5 to 5.7 - Step 2 - Options - Exclude `GenerateDebugInformation` in `Release` configurations

### DIFF
--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2022.vcxproj
@@ -97,7 +97,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>rocblas.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/Libraries/rocBLAS/level_2/her/her_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2022.vcxproj
@@ -97,7 +97,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>rocblas.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2022.vcxproj
@@ -97,7 +97,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>rocblas.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2022.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2022.vcxproj
@@ -97,7 +97,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>rocblas.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
+ [fix] Exclude the rest erroneously missed in #77
+ Based on https://github.com/ROCm-Developer-Tools/HIP-VS/pull/1302
