### PR TITLE
Develop Stream 2024-03-21 ROCm 6.0 fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,7 @@ build:cmake-cuda:
      -D GPU_RUNTIME=CUDA
      -D CMAKE_CXX_FLAGS="$CXX_FLAGS"
      -D CMAKE_CUDA_FLAGS="$CUDA_FLAGS"
-     -D CMAKE_MODULE_PATH=/opt/rocm/hip/cmake
+     -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip
      2>&1 | tee cmake_log.txt
    # check if all dependencies were found
    - |-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,9 @@ include:
       - /rules.yaml
 
 variables:
-  CUDA_FLAGS: "-Xcompiler -Wall,-Wextra,-Werror --Werror all-warnings"
+  # Removed -Werror --Werror all-warnings flags due to warnings appearing with
+  # the new release of ROCm (ROCm6.0) for CUDA backend
+  CUDA_FLAGS: "-Xcompiler -Wall,-Wextra"
   # We require '-Wno-unused-command-line-argument' due to the followiwng warning:
   #   argument unused during compilation: '--rtlib=compiler-rt'
   CXX_FLAGS: "-Wno-unused-command-line-argument -Wall -Wextra -Werror"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,10 +30,10 @@ include:
       - /rules.yaml
 
 variables:
-  # Removed -Werror --Werror all-warnings flags due to warnings appearing with
-  # the new release of ROCm (ROCm6.0) for CUDA backend
-  CUDA_FLAGS: "-Xcompiler -Wall,-Wextra"
-  # We require '-Wno-unused-command-line-argument' due to the followiwng warning:
+  # Temporary suppress warnings due to nvidia_hip_runtime_api bug
+  CUDA_WARNING_SUPPRESS_FLAGS: ",-Wno-missing-field-initializers,-Wno-deprecated-declarations,-Wno-sign-compare,-Wno-return-local-addr -diag-suppress=1056"
+  CUDA_FLAGS: "-Xcompiler -Wall,-Wextra,-Werror${CUDA_WARNING_SUPPRESS_FLAGS} --Werror all-warnings"
+  # We require '-Wno-unused-command-line-argument' due to the following warning:
   #   argument unused during compilation: '--rtlib=compiler-rt'
   CXX_FLAGS: "-Wno-unused-command-line-argument -Wall -Wextra -Werror"
   HIP_FLAGS: "-Wno-unused-command-line-argument -Wall -Wextra -Werror"

--- a/Common/rocsparse_utils.hpp
+++ b/Common/rocsparse_utils.hpp
@@ -47,6 +47,10 @@ inline const char* rocsparse_status_to_string(rocsparse_status status)
         case rocsparse_status_not_initialized: return "rocsparse_status_not_initialized";
         case rocsparse_status_type_mismatch: return "rocsparse_status_type_mismatch";
         case rocsparse_status_thrown_exception: return "rocsparse_status_thrown_exception";
+// rocSPARSE 3.0 adds new status
+#if ROCSPARSE_VERSION_MAJOR >= 3
+        case rocsparse_status_continue: return "rocsparse_status_continue";
+#endif
         case rocsparse_status_requires_sorted_storage:
             return "rocsparse_status_requires_sorted_storage";
     }

--- a/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
@@ -90,14 +90,16 @@ RUN wget https://github.com/ROCm/hipSOLVER/archive/refs/tags/rocm-6.0.0.tar.gz \
     && rm -rf ./hipSOLVER-rocm-6.0.0
 
 # Install hipRAND
-RUN wget https://github.com/ROCm/hipRAND/archive/refs/tags/rocm-6.0.0.tar.gz \
-    && tar -xf ./rocm-6.0.0.tar.gz \
-    && rm ./rocm-6.0.0.tar.gz \
-    && cmake -S ./hipRAND-rocm-6.0.0 -B ./hipRAND-rocm-6.0.0/build \
+# Build from commit that removes deprecated macro use
+RUN git clone https://github.com/ROCm/hipRAND.git hipRAND-rocm-6.0.0 \
+    && cd hipRAND-rocm-6.0.0 \
+    && git reset --hard  4925f0da96fad5b9f532ddc79f1f52fc279d329f \
+    && cmake -S . -B ./build \
         -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
         -D BUILD_WITH_LIB=CUDA \
-    && cmake --build ./hipRAND-rocm-6.0.0/build --target install \
+    && cmake --build ./build --target install \
+    && cd .. \
     && rm -rf ./hipRAND-rocm-6.0.0
 
 # Install hipFFT

--- a/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
@@ -1,5 +1,5 @@
 # CUDA based docker image
-FROM nvidia/cuda:11.8.0-devel-ubuntu20.04
+FROM nvidia/cuda:12.0.0-devel-ubuntu20.04
 
 # Base packages that are required for the installation
 RUN export DEBIAN_FRONTEND=noninteractive; \
@@ -52,6 +52,7 @@ RUN wget https://github.com/ROCm/rocRAND/archive/refs/tags/rocm-6.0.0.tar.gz \
         -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D BUILD_HIPRAND=OFF \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
+        -D NVGPU_TARGETS="50" \
     && cmake --build ./rocRAND-rocm-6.0.0/build --target install \
     && rm -rf ./rocRAND-rocm-6.0.0
 
@@ -98,6 +99,7 @@ RUN git clone https://github.com/ROCm/hipRAND.git hipRAND-rocm-6.0.0 \
         -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
         -D BUILD_WITH_LIB=CUDA \
+        -D NVGPU_TARGETS="50" \
     && cmake --build ./build --target install \
     && cd .. \
     && rm -rf ./hipRAND-rocm-6.0.0

--- a/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
@@ -1,5 +1,5 @@
 # CUDA based docker image
-FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu20.04
 
 # Base packages that are required for the installation
 RUN export DEBIAN_FRONTEND=noninteractive; \
@@ -27,7 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
 # Install HIP using the installer script
 RUN export DEBIAN_FRONTEND=noninteractive; \
     wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
-    && echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/5.7/ ubuntu main' > /etc/apt/sources.list.d/rocm.list \
+    && echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/6.0/ ubuntu main' > /etc/apt/sources.list.d/rocm.list \
     && apt-get update -qq \
     && apt-get install -y hip-base hipify-clang rocm-core hipcc hip-dev
 
@@ -45,58 +45,71 @@ RUN echo "/opt/rocm/lib" >> /etc/ld.so.conf.d/rocm.conf \
     && ldconfig
 
 # Install rocRAND
-RUN wget https://github.com/ROCmSoftwarePlatform/rocRAND/archive/refs/tags/rocm-5.7.0.tar.gz \
-    && tar -xf ./rocm-5.7.0.tar.gz \
-    && rm ./rocm-5.7.0.tar.gz \
-    && cmake -S ./rocRAND-rocm-5.7.0 -B ./rocRAND-rocm-5.7.0/build \
-        -D CMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
+RUN wget https://github.com/ROCm/rocRAND/archive/refs/tags/rocm-6.0.0.tar.gz \
+    && tar -xf ./rocm-6.0.0.tar.gz \
+    && rm ./rocm-6.0.0.tar.gz \
+    && cmake -S ./rocRAND-rocm-6.0.0 -B ./rocRAND-rocm-6.0.0/build \
+        -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D BUILD_HIPRAND=OFF \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
-    && cmake --build ./rocRAND-rocm-5.7.0/build --target install \
-    && rm -rf ./rocRAND-rocm-5.7.0
+    && cmake --build ./rocRAND-rocm-6.0.0/build --target install \
+    && rm -rf ./rocRAND-rocm-6.0.0
 
 # Install hipCUB
-RUN wget https://github.com/ROCmSoftwarePlatform/hipCUB/archive/refs/tags/rocm-5.7.0.tar.gz \
-    && tar -xf ./rocm-5.7.0.tar.gz \
-    && rm ./rocm-5.7.0.tar.gz \
-    && cmake -S ./hipCUB-rocm-5.7.0 -B ./hipCUB-rocm-5.7.0/build \
-        -D CMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
+RUN wget https://github.com/ROCm/hipCUB/archive/refs/tags/rocm-6.0.0.tar.gz \
+    && tar -xf ./rocm-6.0.0.tar.gz \
+    && rm ./rocm-6.0.0.tar.gz \
+    && cmake -S ./hipCUB-rocm-6.0.0 -B ./hipCUB-rocm-6.0.0/build \
+        -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
-    && cmake --build ./hipCUB-rocm-5.7.0/build --target install \
-    && rm -rf ./hipCUB-rocm-5.7.0
+    && cmake --build ./hipCUB-rocm-6.0.0/build --target install \
+    && rm -rf ./hipCUB-rocm-6.0.0
 
 # Install hipBLAS
-RUN wget https://github.com/ROCmSoftwarePlatform/hipBLAS/archive/refs/tags/rocm-5.7.0.tar.gz \
-    && tar -xf ./rocm-5.7.0.tar.gz \
-    && rm ./rocm-5.7.0.tar.gz \
-    && cmake -S ./hipBLAS-rocm-5.7.0 -B ./hipBLAS-rocm-5.7.0/build \
-        -D CMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
+# hipBLAS cmake for rocm-6.0.0 is broken added CXXFLAGS=-D__HIP_PLATFORM_NVIDIA__ as fix
+RUN wget https://github.com/ROCm/hipBLAS/archive/refs/tags/rocm-6.0.0.tar.gz \
+    && tar -xf ./rocm-6.0.0.tar.gz \
+    && rm ./rocm-6.0.0.tar.gz \
+    && CXXFLAGS=-D__HIP_PLATFORM_NVIDIA__ cmake -S ./hipBLAS-rocm-6.0.0 -B ./hipBLAS-rocm-6.0.0/build \
+        -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
         -D USE_CUDA=ON \
-    && cmake --build ./hipBLAS-rocm-5.7.0/build --target install \
-    && rm -rf ./hipBLAS-rocm-5.7.0
+    && cmake --build ./hipBLAS-rocm-6.0.0/build --target install \
+    && rm -rf ./hipBLAS-rocm-6.0.0
 
 # Install hipSOLVER
-RUN wget https://github.com/ROCmSoftwarePlatform/hipSOLVER/archive/refs/tags/rocm-5.7.0.tar.gz \
-    && tar -xf ./rocm-5.7.0.tar.gz \
-    && rm ./rocm-5.7.0.tar.gz \
-    && cmake -S ./hipSOLVER-rocm-5.7.0 -B ./hipSOLVER-rocm-5.7.0/build \
-        -D CMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
+# hipSOLVER cmake for rocm-6.0.0 is broken added CXXFLAGS=-D__HIP_PLATFORM_NVIDIA__ as fix
+RUN wget https://github.com/ROCm/hipSOLVER/archive/refs/tags/rocm-6.0.0.tar.gz \
+    && tar -xf ./rocm-6.0.0.tar.gz \
+    && rm ./rocm-6.0.0.tar.gz \
+    && CXXFLAGS=-D__HIP_PLATFORM_NVIDIA__ cmake -S ./hipSOLVER-rocm-6.0.0 -B ./hipSOLVER-rocm-6.0.0/build \
+        -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
         -D USE_CUDA=ON \
-    && cmake --build ./hipSOLVER-rocm-5.7.0/build --target install \
-    && rm -rf ./hipSOLVER-rocm-5.7.0
+    && cmake --build ./hipSOLVER-rocm-6.0.0/build --target install \
+    && rm -rf ./hipSOLVER-rocm-6.0.0
 
 # Install hipRAND
-RUN wget https://github.com/ROCmSoftwarePlatform/hipRAND/archive/refs/tags/rocm-5.7.0.tar.gz \
-    && tar -xf ./rocm-5.7.0.tar.gz \
-    && rm ./rocm-5.7.0.tar.gz \
-    && cmake -S ./hipRAND-rocm-5.7.0 -B ./hipRAND-rocm-5.7.0/build \
-        -D CMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
+RUN wget https://github.com/ROCm/hipRAND/archive/refs/tags/rocm-6.0.0.tar.gz \
+    && tar -xf ./rocm-6.0.0.tar.gz \
+    && rm ./rocm-6.0.0.tar.gz \
+    && cmake -S ./hipRAND-rocm-6.0.0 -B ./hipRAND-rocm-6.0.0/build \
+        -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
         -D CMAKE_INSTALL_PREFIX=/opt/rocm \
         -D BUILD_WITH_LIB=CUDA \
-    && cmake --build ./hipRAND-rocm-5.7.0/build --target install \
-    && rm -rf ./hipRAND-rocm-5.7.0
+    && cmake --build ./hipRAND-rocm-6.0.0/build --target install \
+    && rm -rf ./hipRAND-rocm-6.0.0
+
+# Install hipFFT
+RUN wget https://github.com/ROCm/hipFFT/archive/refs/tags/rocm-6.0.0.tar.gz \
+    && tar -xf ./rocm-6.0.0.tar.gz \
+    && rm ./rocm-6.0.0.tar.gz \
+    && cmake -S ./hipFFT-rocm-6.0.0 -B ./hipFFT-rocm-6.0.0/build \
+        -D CMAKE_MODULE_PATH=/opt/rocm/lib/cmake/hip \
+        -D CMAKE_INSTALL_PREFIX=/opt/rocm \
+        -D BUILD_WITH_LIB=CUDA \
+    && cmake --build ./hipFFT-rocm-6.0.0/build --target install \
+    && rm -rf ./hipFFT-rocm-6.0.0
 
 # Use render group as an argument from user
 ARG GID=109

--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -24,10 +24,10 @@ ENV LANG en_US.utf8
 
 # Install ROCM HIP and libraries using the installer script
 RUN export DEBIAN_FRONTEND=noninteractive; \
-    wget https://repo.radeon.com/amdgpu-install/5.7/ubuntu/focal/amdgpu-install_5.7.50700-1_all.deb \
+    wget https://repo.radeon.com/amdgpu-install/6.0/ubuntu/focal/amdgpu-install_6.0.60000-1_all.deb \
     && apt-get update -qq \
-    && apt-get install -y ./amdgpu-install_5.7.50700-1_all.deb \
-    && rm ./amdgpu-install_5.7.50700-1_all.deb \
+    && apt-get install -y ./amdgpu-install_6.0.60000-1_all.deb \
+    && rm ./amdgpu-install_6.0.60000-1_all.deb\
     && amdgpu-install -y --usecase=hiplibsdk --no-dkms \
     && apt-get install -y libnuma-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/HIP-Basic/opengl_interop/main.hip
+++ b/HIP-Basic/opengl_interop/main.hip
@@ -27,6 +27,7 @@
 #include "glad/glad.h"
 
 #include <GLFW/glfw3.h>
+#include <hip/hip_gl_interop.h>
 #include <hip/hip_runtime.h>
 
 #include <chrono>
@@ -101,7 +102,8 @@ int pick_hip_device()
 {
     unsigned int gl_device_count;
     int          hip_device;
-    HIP_CHECK(hipGLGetDevices(&gl_device_count, &hip_device, 1, hipGLDeviceListAll));
+    HIP_CHECK(
+        hipGLGetDevices(&gl_device_count, &hip_device, 1, hipGLDeviceList::hipGLDeviceListAll));
 
     if(gl_device_count == 0)
     {

--- a/HIP-Basic/opengl_interop/nvidia_hip_fix.hpp
+++ b/HIP-Basic/opengl_interop/nvidia_hip_fix.hpp
@@ -4,10 +4,11 @@
 #include "glad/glad.h"
 
 #include <hip/hip_runtime.h>
+#include <hip/hip_version.h>
 
 // TODO: Remove this once HIP supports these symbols.
 // See https://github.com/ROCm-Developer-Tools/hipamd/issues/49.
-#if defined(__HIP_PLATFORM_NVCC__) && !defined(hipGLDeviceListAll)
+#if defined(__HIP_PLATFORM_NVIDIA__) && !defined(hipGLDeviceListAll) && HIP_VERSION_MAJOR < 6
 
     #include <cuda_gl_interop.h>
 

--- a/HIP-Basic/vulkan_interop/Makefile
+++ b/HIP-Basic/vulkan_interop/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,9 +26,12 @@ GPU_RUNTIME := HIP
 
 # HIP variables
 ROCM_INSTALL_DIR := /opt/rocm
+CUDA_INSTALL_DIR := /usr/local/cuda
+
 HIP_INCLUDE_DIR  := $(ROCM_INSTALL_DIR)/include
 
 HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+CUDACXX ?= $(CUDA_INSTALL_DIR)/bin/nvcc
 
 # Common variables and flags
 CXX_STD    := c++17
@@ -40,9 +43,12 @@ IGLSLFLAGS := -V100
 
 ifeq ($(GPU_RUNTIME), CUDA)
 	ICXXFLAGS += -x cu
-	ICPPFLAGS += -isystem $(HIP_INCLUDE_DIR)
+	ICPPFLAGS += -isystem $(HIP_INCLUDE_DIR) -D__HIP_PLATFORM_NVIDIA__
+	COMPILER := $(CUDACXX)
 else ifeq ($(GPU_RUNTIME), HIP)
-	CXXFLAGS ?= -Wall -Wextra
+	ICXXFLAGS ?= -Wall -Wextra
+	ICPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
 else
 	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be either CUDA or HIP)
 endif
@@ -54,7 +60,7 @@ ILDLIBS    += $(LDLIBS)
 IGLSLFLAGS += $(GLSLFLAGS)
 
 $(EXAMPLE): main.hip vulkan_utils.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp sinewave.frag.spv.h sinewave.vert.spv.h
-	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.hip vulkan_utils.hip $(ILDLIBS)
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.hip vulkan_utils.hip $(ILDLIBS)
 
 sinewave.vert.spv.h: sinewave.vert
 	glslangValidator $< -o $@ $(IGLSLFLAGS) --vn sinewave_vert

--- a/HIP-Basic/vulkan_interop/main.hip
+++ b/HIP-Basic/vulkan_interop/main.hip
@@ -141,7 +141,7 @@ struct uuid
         // Note: function is 0 anyway.
 
         return result;
-#elif defined(__HIP_PLATFORM_NVCC__)
+#elif defined(__HIP_PLATFORM_NVIDIA__)
         // Work around a compile error related to hipDeviceGetUuid when compiling for NVIDIA:
         // "undefined reference to `cuDeviceGetUuid'"
         // \see https://github.com/ROCm-Developer-Tools/hipamd/issues/51.

--- a/HIP-Basic/vulkan_interop/nvidia_hip_fix.hpp
+++ b/HIP-Basic/vulkan_interop/nvidia_hip_fix.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,13 @@
 #define _HIP_BASIC_VULKAN_INTEROP_NVIDIA_HIP_FIX_HPP
 
 #include <hip/hip_runtime.h>
+#include <hip/hip_version.h>
 
 // Currently these HIP symbols are missing when compiling for NVIDIA.
 // TODO: Remove this once HIP supports these symbols.
 // See https://github.com/ROCm-Developer-Tools/hipamd/issues/49.
-#if defined(__HIP_PLATFORM_NVCC__) && !defined(hipExternalMemoryHandleTypeOpaqueFd)
+#if defined(__HIP_PLATFORM_NVIDIA__) && !defined(hipExternalMemoryHandleTypeOpaqueFd) \
+    && HIP_VERSION_MAJOR < 6
     #define hipExternalMemoryHandleType cudaExternalMemoryHandleType
     #define hipExternalMemoryHandleTypeOpaqueFd cudaExternalMemoryHandleTypeOpaqueFd
     #define hipExternalSemaphoreHandleType cudaExternalSemaphoreHandleType

--- a/Libraries/rocSPARSE/level_2/bsrmv/README.md
+++ b/Libraries/rocSPARSE/level_2/bsrmv/README.md
@@ -150,7 +150,7 @@ bsr_col_ind = { 0, 0, 2, 0, 1 }
 ```
 
 ### rocSPARSE
-- `rocsparse_[dscz]bsrmv_ex(...)` performs the sparse matrix-dense vector multiplication $\hat{y}=\alpha \cdot A' x + \beta \cdot y$ using the BSR format. The correct function signature should be chosen based on the datatype of the input matrix:
+- `rocsparse_[dscz]bsrmv(...)` performs the sparse matrix-dense vector multiplication $\hat{y}=\alpha \cdot A' x + \beta \cdot y$ using the BSR format. The correct function signature should be chosen based on the datatype of the input matrix:
    - `s` single-precision real (`float`)
    - `d` double-precision real (`double`)
    - `c` single-precision complex (`rocsparse_float_complex`)


### PR DESCRIPTION
This PR contains all the fixes for ROCm 6.0 compatibility of the examples. ~It is based on the general fixes branches (the ones in #97 and #98 ), so the commits of those PRs appear in this one as well.~ The relevant commits are the last 11 (from [Update dockerfiles to rocm 6.0](https://github.com/amd/rocm-examples/pull/99/commits/1e941d8af66808c590d705e4b6ab25ad67dc821f) onwards) with roughly 11 files changed.

The modifications done can be summarized as follows:

- Updated dockerfiles to use ROCm6.0
- Added include now necessary as `hipGLGetDevices` is now in a different header (resolves https://github.com/ROCm/rocm-examples/issues/100, resolves https://github.com/ROCm/rocm-examples/issues/89)
- Fixed rocSPARSE function call so it's compatible with both 2.x and 3.x APIs
- Now using `__HIP_PLATFORM_NVIDIA__` instead of `__HIP_PLATFORM_NVCC__`
- Fixed cuda docker container to build hipRAND from source so a deprecated macro use is removed
- Upgraded cuda docker container cuda version
- Added guard in rocsparse_utils to include new 3.x API status only when using the new API