### PR TITLE
[vcxproj][6.1][vs2019] Move projects from 5.7 to 6.1

### DIFF
--- a/Applications/bitonic_sort/bitonic_sort_vs2019.vcxproj
+++ b/Applications/bitonic_sort/bitonic_sort_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{265F7154-A362-45FA-B300-DB74E14BA010}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/convolution/convolution_vs2019.vcxproj
+++ b/Applications/convolution/convolution_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{A557F6A4-C0FD-4D65-B1BD-A201FABAEF7F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/floyd_warshall/floyd_warshall_vs2019.vcxproj
+++ b/Applications/floyd_warshall/floyd_warshall_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{FB6B7014-2BC9-475C-B3CC-FEE6B4C5B103}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/histogram/histogram_vs2019.vcxproj
+++ b/Applications/histogram/histogram_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D3531843-4D0D-445D-BD8D-2352038D8221}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/prefix_sum/prefix_sum_vs2019.vcxproj
+++ b/Applications/prefix_sum/prefix_sum_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{015df085-feb3-4c7a-acee-7cffb3c9aff0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2019.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{60b4ade0-8286-46ae-b884-5da51b541ded}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -87,13 +87,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/bandwidth/bandwidth_vs2019.vcxproj
+++ b/HIP-Basic/bandwidth/bandwidth_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{16b11b54-cd72-43b6-b226-38c668b41a79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/bit_extract/bit_extract_vs2019.vcxproj
+++ b/HIP-Basic/bit_extract/bit_extract_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{63823DD0-787C-42AE-B6E7-C03CF4CF5CE2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
+++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{7a25ce69-bace-4410-beb0-12a69890f212}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/device_globals/device_globals_vs2019.vcxproj
+++ b/HIP-Basic/device_globals/device_globals_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{f7dd9451-b0ca-4c76-ab92-0e01cbebdbbe}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/device_query/device_query_vs2019.vcxproj
+++ b/HIP-Basic/device_query/device_query_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{C2C6E811-57E3-44C5-9AB9-195D60A1638C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/dynamic_shared/dynamic_shared_vs2019.vcxproj
+++ b/HIP-Basic/dynamic_shared/dynamic_shared_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{7b7d1745-7635-40da-b6af-b8f728a31124}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/events/events_vs2019.vcxproj
+++ b/HIP-Basic/events/events_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{5B822836-110B-44D8-8E02-2A9B2CB83D14}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/gpu_arch/gpu_arch_vs2019.vcxproj
+++ b/HIP-Basic/gpu_arch/gpu_arch_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{4e6b2034-d7ed-4cb4-98b2-7b2d2b71e0a8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/hello_world/hello_world_vs2019.vcxproj
+++ b/HIP-Basic/hello_world/hello_world_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{5e0e9ab0-b708-481f-9226-dd92c3798341}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/inline_assembly/inline_assembly_vs2019.vcxproj
+++ b/HIP-Basic/inline_assembly/inline_assembly_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{4e6b2034-d7ed-4cb4-98b2-7b2d2b71e0a7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2019.vcxproj
+++ b/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{dbb8dfe9-cb1b-473c-937c-2a8120e0d819}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2019.vcxproj
+++ b/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{ACC2A1E7-5865-4FAE-9016-E6EF73F8FA9E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/module_api/module_api_vs2019.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{306eb993-653a-45f6-863a-5f43bc86da79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/moving_average/moving_average_vs2019.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{628390E3-DB62-4D52-9594-DE6BC15F9943}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2019.vcxproj
+++ b/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{6A0FFF7E-9C0A-4BF5-BBA5-745CB4253EFB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/occupancy/occupancy_vs2019.vcxproj
+++ b/HIP-Basic/occupancy/occupancy_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{e5b2fc79-3928-47f6-b57b-33aaa3c5d9c5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2019.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{96f8be41-5c64-4bf2-8a8e-474beaacaa5a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -36,13 +36,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/runtime_compilation/runtime_compilation_vs2019.vcxproj
+++ b/HIP-Basic/runtime_compilation/runtime_compilation_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{E03790B7-B203-4504-BEF5-F4F061183642}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/saxpy/saxpy_vs2019.vcxproj
+++ b/HIP-Basic/saxpy/saxpy_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D6334F08-D560-439A-A704-ADA0349D72B7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/shared_memory/shared_memory_vs2019.vcxproj
+++ b/HIP-Basic/shared_memory/shared_memory_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{C370ACB7-AE52-4AD8-8C3D-4C32567FFE7D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/static_host_library/library/libhip_static_host_vs2019.vcxproj
+++ b/HIP-Basic/static_host_library/library/libhip_static_host_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{6d3f8f78-225e-490e-abd3-762857ebf597}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/static_host_library/static_host_library_vs2019.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{5f8a7fee-3a79-4588-9244-8575748026f7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -30,13 +30,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/streams/streams_vs2019.vcxproj
+++ b/HIP-Basic/streams/streams_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{4e6b2034-d7ed-4cb4-98b2-7b2d2b71e0a9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/texture_management/texture_management_vs2019.vcxproj
+++ b/HIP-Basic/texture_management/texture_management_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{40E56BFB-1A0C-4618-BB49-A9AA635127C1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/vulkan_interop/vulkan_interop_vs2019.vcxproj
+++ b/HIP-Basic/vulkan_interop/vulkan_interop_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{688433e2-b189-431d-a5f8-9ac82102b58c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -59,13 +59,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/warp_shuffle/warp_shuffle_vs2019.vcxproj
+++ b/HIP-Basic/warp_shuffle/warp_shuffle_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{5852BE0E-BDA5-4BD9-8A16-30E8E40F4045}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
+++ b/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{961a0eaa-2c41-42ad-a96b-d865203f3a94}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipBLAS/her/her_vs2019.vcxproj
+++ b/Libraries/hipBLAS/her/her_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{984032B2-170B-4DF2-AF16-96713C42C47D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipBLAS/scal/scal_vs2019.vcxproj
+++ b/Libraries/hipBLAS/scal/scal_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{658c0200-6fc1-4460-b7a5-bb1876830607}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2019.vcxproj
+++ b/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{be670e16-8a40-46e0-9cf2-93352ed685b0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipCUB/device_sum/device_sum_vs2019.vcxproj
+++ b/Libraries/hipCUB/device_sum/device_sum_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{ef1e1a7e-2803-4606-bd9a-da8fa981aba4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/gels/gels_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/gels/gels_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{9144246D-5E29-4477-8C8E-F3BB291A2714}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/geqrf/geqrf_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/geqrf/geqrf_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{64A75FF5-B298-4256-A35B-A164972A91F9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -49,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/gesvd/gesvd_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/gesvd/gesvd_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D1C40C14-2881-43C7-8DAD-72BAAB169757}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -49,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/getrf/getrf_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/getrf/getrf_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D1C40C14-2881-43C7-8DAD-72BAAB169324}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/potrf/potrf_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/potrf/potrf_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{7CD5972B-BC1C-405E-9B90-EBE5733A41D8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevd/syevd_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/syevd/syevd_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{578F7B33-698D-4B8A-B8E6-7CBF82F42556}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevdx/syevdx_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/syevdx/syevdx_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{729914AA-2062-4B79-930E-630C6C3A60C7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -48,13 +48,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevj/syevj_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/syevj/syevj_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{7139c801-489d-464a-82dc-3abdb706c7a2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevj_batched/syevj_batched_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/syevj_batched/syevj_batched_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{EDD787C9-D057-4831-BB40-21A617C28B22}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -49,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/sygvd/sygvd_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/sygvd/sygvd_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{1209C293-D1F0-4BFC-B6D0-65A96B801135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -48,13 +48,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/sygvj/sygvj_vs2019.vcxproj
+++ b/Libraries/hipSOLVER/sygvj/sygvj_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC943}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -44,13 +44,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/axpy/axpy_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/axpy/axpy_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{DDC6904E-B174-4F08-908E-0535C3BD5A9A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/dot/dot_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/dot/dot_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D306FFB0-DD32-4B12-9E48-8AAC5DDF48E4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{16A9CB28-E8ED-4040-BD0B-7290685EE782}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/scal/scal_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/scal/scal_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{201e0855-44cb-4b99-bebd-a8b3e9f67aea}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/swap/swap_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_1/swap/swap_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{00eff6d1-ea39-4fd7-a84d-2d93feabd6cf}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{E4A7C45C-BF68-455A-A37B-3558F427DC53}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_2/her/her_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{1bf2770a-a16c-428e-9bd0-09070d2bee30}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{4E28F2B0-CE5D-40F4-9AF5-5BC18A27C59B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{1E9ED0DD-CCD1-4658-B958-34E85E5348FE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocPRIM/block_sum/block_sum_vs2019.vcxproj
+++ b/Libraries/rocPRIM/block_sum/block_sum_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{65B21869-2BE2-4DA5-BEC5-28D1F910731C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocPRIM/device_sum/device_sum_vs2019.vcxproj
+++ b/Libraries/rocPRIM/device_sum/device_sum_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{E71DB5FB-A1C4-4BB4-8B46-0037C32C885E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2019.vcxproj
+++ b/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{13bb009a-0679-49c0-a763-3f0a388ea78f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/getf2/getf2_vs2019.vcxproj
+++ b/Libraries/rocSOLVER/getf2/getf2_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{D1C40C14-2881-43C7-8DAD-72BAAB169334}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/getri/getri_vs2019.vcxproj
+++ b/Libraries/rocSOLVER/getri/getri_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{b7be499d-05e7-4f35-96c5-2326fed355d4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/syev/syev_vs2019.vcxproj
+++ b/Libraries/rocSOLVER/syev/syev_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{ea84a9df-d7ee-4e10-8de5-0e411c2ac0a3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/syev_batched/syev_batched_vs2019.vcxproj
+++ b/Libraries/rocSOLVER/syev_batched/syev_batched_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{C11381F8-089B-462C-8544-932666818546}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/syev_strided_batched/syev_strided_batched_vs2019.vcxproj
+++ b/Libraries/rocSOLVER/syev_strided_batched/syev_strided_batched_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{E320537D-C504-452D-8415-CEC25E3E5819}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/bsrmv/bsrmv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrmv/bsrmv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{d43e6e05-de45-4f1e-9553-275b0659525a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -33,13 +33,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/bsrsv/bsrsv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrsv/bsrsv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{C01AF4B2-052A-4AEA-9639-AC176490F033}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/bsrxmv/bsrxmv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrxmv/bsrxmv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{299E6CA6-4588-4373-99AD-FEDDD4A13342}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/coomv/coomv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/coomv/coomv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{2298D9B0-EA59-433E-925E-4DABBFC40B91}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/csrmv/csrmv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/csrmv/csrmv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{82AB0E9C-461D-49F1-A0A3-257C3CD052AC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/csrsv/csrsv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/csrsv/csrsv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{2532A54D-F703-45C1-B7A0-77E1BC07563C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/ellmv/ellmv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/ellmv/ellmv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{050227E6-EB8D-48E2-A381-D8BE4AAD1AEA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/gebsrmv/gebsrmv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/gebsrmv/gebsrmv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{85A63B7E-1449-4E5F-8785-E4CB0217207C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -33,13 +33,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/gemvi/gemvi_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/gemvi/gemvi_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{a17b1c9f-5160-4e64-8de1-403a3947a609}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -38,13 +38,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/spsv/spsv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/spsv/spsv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{ED626C21-CCBA-4144-80CE-446E792D0E9E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/bsrmm/bsrmm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/bsrmm/bsrmm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{ca6ee809-6611-41a9-805f-c532d1d7bd9c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/bsrsm/bsrsm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/bsrsm/bsrsm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{1C2BA747-6507-4E44-8DA2-A771BD762425}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/csrmm/csrmm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/csrmm/csrmm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{DB23B036-9FC2-4EA0-9CE1-75C9C53B6317}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/csrsm/csrsm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/csrsm/csrsm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{9F58AD34-6173-4DD8-B224-839416D24C52}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/gebsrmm/gebsrmm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/gebsrmm/gebsrmm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{51A90349-4B38-4C52-A414-E2AC4405F09E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/gemmi/gemmi_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/gemmi/gemmi_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{DD383DAD-A385-4A85-B6F2-97C5EB735346}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/bsric0/bsric0_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/bsric0/bsric0_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{E912342B-9B39-44AC-9EC8-61D3F4197700}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/bsrilu0/bsrilu0_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/bsrilu0/bsrilu0_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{2A1C2114-C270-483F-AF59-849996E1E77D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/csric0/csric0_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csric0/csric0_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{A5BC486D-8BF9-4739-A00A-EA3337D593AA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/csrilu0/csrilu0_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csrilu0/csrilu0_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{F994D68B-648C-45D2-8371-B90E6B0301D9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/csritilu0_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/csritilu0_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{51A0D314-F808-4245-A9EF-15401F9CB003}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/device_ptr/device_ptr_vs2019.vcxproj
+++ b/Libraries/rocThrust/device_ptr/device_ptr_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{fd1402c4-336f-4aef-a5f6-1dd7903a965c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/norm/norm_vs2019.vcxproj
+++ b/Libraries/rocThrust/norm/norm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{8683c739-f470-44a6-a187-9a5929ae9df9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/reduce_sum/reduce_sum_vs2019.vcxproj
+++ b/Libraries/rocThrust/reduce_sum/reduce_sum_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{c0405ffb-7aa2-49c2-9ab5-af336a54b41c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/remove_points/remove_points_vs2019.vcxproj
+++ b/Libraries/rocThrust/remove_points/remove_points_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{631c61aa-52ba-4818-bd39-fa9cf47076c7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/saxpy/saxpy_vs2019.vcxproj
+++ b/Libraries/rocThrust/saxpy/saxpy_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{e1d552cf-3fe3-427a-95e1-8cffb60bbf8e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/vectors/vectors_vs2019.vcxproj
+++ b/Libraries/rocThrust/vectors/vectors_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{8dea1f0f-8bf3-422c-9bcd-99f69f43d013}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
+ [IMP] HIP-VS 6.1 should be installed for compiling `rocm-examples` for both `AMD` and `NVIDIA`
