### PR TITLE
[vcxproj][6.1][vs2017] Move projects from 5.7 to 6.1

### DIFF
--- a/Applications/bitonic_sort/bitonic_sort_vs2017.vcxproj
+++ b/Applications/bitonic_sort/bitonic_sort_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{265F7154-A362-45FA-B300-DB74E14BA010}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/convolution/convolution_vs2017.vcxproj
+++ b/Applications/convolution/convolution_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{4232B140-4C47-4961-8A8A-F67D14DC9349}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/floyd_warshall/floyd_warshall_vs2017.vcxproj
+++ b/Applications/floyd_warshall/floyd_warshall_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{3bbda23b-43c0-4b91-8ba8-1cfe8b981184}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/histogram/histogram_vs2017.vcxproj
+++ b/Applications/histogram/histogram_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{D3531843-4D0D-445D-BD8D-2352038D8221}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Applications/prefix_sum/prefix_sum_vs2017.vcxproj
+++ b/Applications/prefix_sum/prefix_sum_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{015df085-feb3-4c7a-acee-7cffb3c9aff0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/assembly_to_executable/assembly_to_executable_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{f72a2ce8-6391-4929-8688-dd5d1e338773}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -87,13 +87,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/bandwidth/bandwidth_vs2017.vcxproj
+++ b/HIP-Basic/bandwidth/bandwidth_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8c3bbaaf-04f6-46f5-96a2-81c047167343}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/bit_extract/bit_extract_vs2017.vcxproj
+++ b/HIP-Basic/bit_extract/bit_extract_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{e9dc3573-5fa9-4c03-8830-909f71ed34d9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
+++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{30739f04-9ef3-4f41-8de4-500bdbfecff9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/device_globals/device_globals_vs2017.vcxproj
+++ b/HIP-Basic/device_globals/device_globals_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{f6b4fc89-465a-455a-b1e9-ff4c8689e3f0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/device_query/device_query_vs2017.vcxproj
+++ b/HIP-Basic/device_query/device_query_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{a9e1c716-820c-4b29-b36e-4f0ab057f09f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/dynamic_shared/dynamic_shared_vs2017.vcxproj
+++ b/HIP-Basic/dynamic_shared/dynamic_shared_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{2e7bb11b-fe0f-419c-aa07-448a1472b593}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/events/events_vs2017.vcxproj
+++ b/HIP-Basic/events/events_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{aa9e497a-fede-45a4-a6ce-a8e3ddddeb82}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/gpu_arch/gpu_arch_vs2017.vcxproj
+++ b/HIP-Basic/gpu_arch/gpu_arch_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{99e1a6eb-e9e3-48af-a71b-5fe792550f5d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/hello_world/hello_world_vs2017.vcxproj
+++ b/HIP-Basic/hello_world/hello_world_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{bd725c86-e381-4bdd-b3fc-06a42221bebb}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/inline_assembly/inline_assembly_vs2017.vcxproj
+++ b/HIP-Basic/inline_assembly/inline_assembly_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{66b01cd4-735e-4e83-9def-e7ee88546e8f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2017.vcxproj
+++ b/HIP-Basic/llvm_ir_to_executable/llvm_ir_to_executable_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8588f3a8-6540-483f-92f4-191db4953f95}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2017.vcxproj
+++ b/HIP-Basic/matrix_multiplication/matrix_multiplication_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{e300ed61-e779-4009-80a7-d566dac4ed52}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/module_api/module_api_vs2017.vcxproj
+++ b/HIP-Basic/module_api/module_api_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{af173513-f266-4d26-af06-5960104114a6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
+++ b/HIP-Basic/moving_average/moving_average_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5ad84319-5c2e-4012-869f-fd579114b248}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2017.vcxproj
+++ b/HIP-Basic/multi_gpu_data_transfer/multi_gpu_data_transfer_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{46798a26-0c49-4e91-85b8-2a9783973c0c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/occupancy/occupancy_vs2017.vcxproj
+++ b/HIP-Basic/occupancy/occupancy_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{982a35a8-670e-417a-aea2-612706ed5e7a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/opengl_interop/opengl_interop_vs2017.vcxproj
+++ b/HIP-Basic/opengl_interop/opengl_interop_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{3a7b4351-9f76-4863-aeb3-2ca6d2fc3bef}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -36,13 +36,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/runtime_compilation/runtime_compilation_vs2017.vcxproj
+++ b/HIP-Basic/runtime_compilation/runtime_compilation_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{cdf0652f-3ebe-4e69-ab80-e065747bbdbc}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/saxpy/saxpy_vs2017.vcxproj
+++ b/HIP-Basic/saxpy/saxpy_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{1945ef9b-6e3c-4b44-a5d4-c88074402aaf}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/shared_memory/shared_memory_vs2017.vcxproj
+++ b/HIP-Basic/shared_memory/shared_memory_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{b71a0e84-07ad-4053-b211-214e64eb210d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/static_host_library/library/libhip_static_host_vs2017.vcxproj
+++ b/HIP-Basic/static_host_library/library/libhip_static_host_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{588559e5-a232-45d3-9181-7bd61bcc6a3f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/static_host_library/static_host_library_vs2017.vcxproj
+++ b/HIP-Basic/static_host_library/static_host_library_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{b9fb86c4-d4f9-437c-9430-983ba5d0d152}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -30,13 +30,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/streams/streams_vs2017.vcxproj
+++ b/HIP-Basic/streams/streams_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{71f0f220-961d-4e58-847e-4afac2e43143}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/texture_management/texture_management_vs2017.vcxproj
+++ b/HIP-Basic/texture_management/texture_management_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{61585ee3-7d6b-48ea-bb00-50878cd11604}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/vulkan_interop/vulkan_interop_vs2017.vcxproj
+++ b/HIP-Basic/vulkan_interop/vulkan_interop_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{2136fa2b-ecae-4998-bed9-14e529d42ca3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -57,13 +57,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/HIP-Basic/warp_shuffle/warp_shuffle_vs2017.vcxproj
+++ b/HIP-Basic/warp_shuffle/warp_shuffle_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{a5763302-f669-4ccb-9429-a1f1ed8d93ec}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
+++ b/Libraries/hipBLAS/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{e76bdeba-8119-46fb-87bb-69667aa1dae6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipBLAS/her/her_vs2017.vcxproj
+++ b/Libraries/hipBLAS/her/her_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{cacadce2-358a-4433-9211-04621019ff89}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipBLAS/scal/scal_vs2017.vcxproj
+++ b/Libraries/hipBLAS/scal/scal_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9a7fa569-e93a-4066-ac8b-096dd2955df7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2017.vcxproj
+++ b/Libraries/hipCUB/device_radix_sort/device_radix_sort_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{c8edeff9-36b0-4942-b6dd-2548911d0677}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipCUB/device_sum/device_sum_vs2017.vcxproj
+++ b/Libraries/hipCUB/device_sum/device_sum_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{48af1513-2732-45c2-a1ac-28a551a9de79}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/gels/gels_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/gels/gels_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8C00B558-05CB-476A-B9FE-16A141392F78}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/geqrf/geqrf_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/geqrf/geqrf_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{ADA05FC0-06CF-4427-89A9-7A8446E66FB7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -49,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/gesvd/gesvd_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/gesvd/gesvd_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{112D9E7B-A590-4BC4-B9AA-3B167F853098}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -49,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/getrf/getrf_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/getrf/getrf_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{D1C40C14-2881-43C7-8DAD-72BAAB169323}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/potrf/potrf_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/potrf/potrf_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{ACF45DFD-5DEA-4BF2-81BD-0C66E971D97F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevd/syevd_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevd/syevd_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{B8458274-7CCF-4D96-9C07-88CBD1ACDB99}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevdx/syevdx_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevdx/syevdx_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{90387A34-8095-4343-8AA5-F0F350EAC462}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -48,13 +48,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevj/syevj_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevj/syevj_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{7139c801-489d-464a-82dc-3abdb706c7a2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -45,13 +45,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/syevj_batched/syevj_batched_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/syevj_batched/syevj_batched_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{0A2F8D99-E6A8-4DDF-9FC0-E6936120A899}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -49,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/sygvd/sygvd_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/sygvd/sygvd_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{88F5329E-8AEB-4CA0-BA95-59BA4DE42477}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -48,13 +48,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/hipSOLVER/sygvj/sygvj_vs2017.vcxproj
+++ b/Libraries/hipSOLVER/sygvj/sygvj_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC943}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -44,13 +44,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/axpy/axpy_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/axpy/axpy_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{a9f4bc5e-94c6-47be-819a-d10313aaab57}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/dot/dot_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/dot/dot_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9477b5df-e2c3-42d2-b1ec-dc158f75db43}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/nrm2/nrm2_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{2a7579ab-7148-406b-ac28-e6c3fedd5b75}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/scal/scal_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/scal/scal_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{316dcce2-84ec-46e0-9bb0-2622fcf88206}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_1/swap/swap_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_1/swap/swap_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{141c9b9b-1319-4f7a-be3f-6b3c410fe562}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_2/gemv/gemv_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_2/gemv/gemv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{d12eddee-bdc1-4c0d-8fd8-69410fdc988d}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_2/her/her_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_2/her/her_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{330276ce-a36b-4aef-909b-ba44032a4e06}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_3/gemm/gemm_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm/gemm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{cc8acbf9-40da-40e5-875a-10263c2c7809}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/gemm_strided_batched_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5652efc0-087e-480a-bf2e-9b24b7afdf6a}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -39,13 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocPRIM/block_sum/block_sum_vs2017.vcxproj
+++ b/Libraries/rocPRIM/block_sum/block_sum_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{89593b1e-dfd0-4ad1-bfd7-20e035cf68ac}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocPRIM/device_sum/device_sum_vs2017.vcxproj
+++ b/Libraries/rocPRIM/device_sum/device_sum_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{f98c4e4a-9ac7-4d5b-9bfc-470b95b143b2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2017.vcxproj
+++ b/Libraries/rocRAND/simple_distributions_cpp/simple_distributions_cpp_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{0609d861-fceb-4a19-9786-ac4c57a6b955}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/getf2/getf2_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/getf2/getf2_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{D1C40C14-2881-43C7-8DAD-72BAAB169333}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/getri/getri_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/getri/getri_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9952d458-a7a6-4d97-944a-ebbc3505b1ea}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/syev/syev_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/syev/syev_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8f15aaa6-12f8-44a9-afa1-752f263b094f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/syev_batched/syev_batched_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/syev_batched/syev_batched_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{0c4830af-b13c-4880-b556-c5aac1a5897f}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSOLVER/syev_strided_batched/syev_strided_batched_vs2017.vcxproj
+++ b/Libraries/rocSOLVER/syev_strided_batched/syev_strided_batched_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{D15701D6-BBA1-4909-8CD1-15D1C19E484F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/bsrmv/bsrmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrmv/bsrmv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{0214f832-8fd4-45dc-8425-de8ad13ccbef}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -33,13 +33,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/bsrsv/bsrsv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrsv/bsrsv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5F1B4CA0-3C30-4491-88B2-1DC5048BBCA5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/bsrxmv/bsrxmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/bsrxmv/bsrxmv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{CFA1826D-C202-4F97-92C9-DB019675DCCB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/coomv/coomv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/coomv/coomv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{74544EB3-6654-4BDD-8DD5-C28003AB63E5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/csrmv/csrmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/csrmv/csrmv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9ED94F3A-9A68-47B2-9F5C-6EB1348D0A9C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/csrsv/csrsv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/csrsv/csrsv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{6E123DA9-5770-403B-AD31-D0C79265C16C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/ellmv/ellmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/ellmv/ellmv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{A0A1AE5A-C34B-49FF-B040-49B7A091BBF0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/gebsrmv/gebsrmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/gebsrmv/gebsrmv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{2369AEF5-B590-4716-A093-A58DC4D230DE}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -33,13 +33,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/gemvi/gemvi_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/gemvi/gemvi_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{61c345d6-c263-4f51-8b2e-e628d3f2d2e8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -38,13 +38,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/spsv/spsv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/spsv/spsv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{0FBB30C1-C516-44CF-8CD6-9720F078DACC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/bsrmm/bsrmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/bsrmm/bsrmm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{87144c93-603e-4d63-a66f-e6dd41605b33}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/bsrsm/bsrsm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/bsrsm/bsrsm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{33F547D4-7627-49EA-8270-369C775CD9E4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/csrmm/csrmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/csrmm/csrmm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{AF09BC1E-C6B8-4029-8A99-AE9D19CCC54C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/csrsm/csrsm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/csrsm/csrsm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{4CA37D63-1707-4F65-9F91-C49224962498}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/gebsrmm/gebsrmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/gebsrmm/gebsrmm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{DD383DAD-A385-4A85-B6F2-97C5EB735346}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/gemmi/gemmi_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/gemmi/gemmi_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{434D4180-1650-44AC-AB43-963706CE8922}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/bsric0/bsric0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/bsric0/bsric0_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{3AC4CAC9-61C3-469E-A509-E16C01863B6E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/bsrilu0/bsrilu0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/bsrilu0/bsrilu0_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{27E23356-8DDF-44DB-AEA2-3730B154A0A7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/csric0/csric0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csric0/csric0_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{538AE193-B826-445F-AC37-6B834654DF8C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/csrilu0/csrilu0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csrilu0/csrilu0_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5FAE3496-9B40-4BAC-92B3-4AF9508DEC23}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/csritilu0_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/csritilu0_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{97E922FD-4778-426A-8078-5029FC8BA5B4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/device_ptr/device_ptr_vs2017.vcxproj
+++ b/Libraries/rocThrust/device_ptr/device_ptr_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5dd923eb-e763-4b23-af94-0527326a61ce}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/norm/norm_vs2017.vcxproj
+++ b/Libraries/rocThrust/norm/norm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{a07ecfa4-c1be-4b7f-a202-08695f0227e4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/reduce_sum/reduce_sum_vs2017.vcxproj
+++ b/Libraries/rocThrust/reduce_sum/reduce_sum_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{b586e07c-8cd6-4ee1-9dc1-8995ebb44f0e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/remove_points/remove_points_vs2017.vcxproj
+++ b/Libraries/rocThrust/remove_points/remove_points_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{79395786-c1b9-408f-ade5-df9b2793da33}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/saxpy/saxpy_vs2017.vcxproj
+++ b/Libraries/rocThrust/saxpy/saxpy_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{176119ca-c9c7-49df-be61-4361f908239e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocThrust/vectors/vectors_vs2017.vcxproj
+++ b/Libraries/rocThrust/vectors/vectors_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{8e591049-d3c4-408e-a847-88bb85852962}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -28,13 +28,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
+ [IMP] HIP-VS 6.1 should be installed for compiling `rocm-examples` for both `AMD` and `NVIDIA`
