### PR TITLE
Add check for tool dependencies in HIP basic examples

### DIFF
--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,10 +23,54 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Basic LANGUAGES CXX)
 
+# ROCm installation path
+if(WIN32)
+    set(ROCM_ROOT "$ENV{HIP_PATH}" CACHE PATH "Root directory of the ROCm installation")
+else()
+    set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
+endif()
+
 # Only supported on HIP (not CUDA)
 if(NOT "${GPU_RUNTIME}" STREQUAL "CUDA")
-    add_subdirectory(assembly_to_executable)
+
+    # Make sure the dependencies can be found before building.
+    find_program(
+        LLVM_DIS_COMMAND llvm-dis
+        PATH_SUFFIXES bin
+        PATHS
+        ${ROCM_ROOT}/llvm
+        ${CMAKE_INSTALL_PREFIX}/llvm)
+    find_program(
+        OFFLOAD_BUNDLER_COMMAND clang-offload-bundler
+        PATH_SUFFIXES bin
+        PATHS
+        ${ROCM_ROOT}/llvm
+        ${CMAKE_INSTALL_PREFIX}/llvm)
+    find_program(
+        LLVM_MC_COMMAND llvm-mc
+        PATH_SUFFIXES bin
+        PATHS
+        ${ROCM_ROOT}/llvm
+        ${CMAKE_INSTALL_PREFIX}/llvm)
+
+    if(LLVM_DIS_COMMAND AND OFFLOAD_BUNDLER_COMMAND AND LLVM_MC_COMMAND)
     add_subdirectory(llvm_ir_to_executable)
+    else()  
+        message("'llvm-dis', 'llvm-mc', or 'clang-offload-bundler' not found, not building assembly example.")
+        if(NOT WIN32)
+            message("    These tools can be found in the 'rocm-llvm-dev' package.")
+        endif()
+    endif()
+
+    if(OFFLOAD_BUNDLER_COMMAND AND LLVM_MC_COMMAND)
+        add_subdirectory(assembly_to_executable)
+    else()
+        message("'llvm-mc' or 'clang-offload-bundler' not found, not building LLVM IR example.")
+        if(NOT WIN32)
+            message("    These tools can be found in the 'rocm-llvm-dev' package.")
+        endif()
+    endif()
+
     add_subdirectory(module_api)
 endif()
 

--- a/HIP-Basic/assembly_to_executable/CMakeLists.txt
+++ b/HIP-Basic/assembly_to_executable/CMakeLists.txt
@@ -92,9 +92,10 @@ endforeach()
 # Create an offload-bundle from the assembled object files. This needs the clang-offload-bundler tool.
 find_program(
     OFFLOAD_BUNDLER_COMMAND clang-offload-bundler
-    PATH_SUFFIXES
-        llvm/bin
-        bin
+    PATH_SUFFIXES bin
+    PATHS
+    ${ROCM_ROOT}/llvm
+    ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED)
 
 # Generate object bundle.
@@ -134,9 +135,10 @@ add_custom_command(
 # This needs an assembler.
 find_program(
     LLVM_MC_COMMAND llvm-mc
-    PATH_SUFFIXES
-        llvm/bin
-        bin
+    PATH_SUFFIXES bin
+    PATHS
+    ${ROCM_ROOT}/llvm
+    ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED)
 
 # Invoke llvm-mc to generate an object file containing the offload bundle.

--- a/HIP-Basic/assembly_to_executable/README.md
+++ b/HIP-Basic/assembly_to_executable/README.md
@@ -106,6 +106,15 @@ The above compilation steps are implemented in Visual Studio through Custom Buil
     Additional Dependencies: $(IntDir)main_device.obj;%(AdditionalDependencies)
     ```
 
+## Dependencies
+
+This example depends on the following tools:
+
+- `clang-offload-bundler`, which is included in the `rocm-llvm` package on Linux.
+- `llvm-mc`, which is included in the `rocm-llvm` package on Linux.
+
+`rocm-llvm` is installed with most ROCm installations.
+
 ## Used API surface
 ### HIP runtime
 - `hipFree`

--- a/HIP-Basic/llvm_ir_to_executable/README.md
+++ b/HIP-Basic/llvm_ir_to_executable/README.md
@@ -107,6 +107,16 @@ The above compilation steps are implemented in Visual Studio through Custom Buil
     Additional Dependencies: $(IntDir)main_device.obj;%(AdditionalDependencies)
     ```
 
+## Dependencies
+
+This example depends on the following tools:
+
+- `clang-offload-bundler`, which is included in the `rocm-llvm` package on Linux.
+- `llvm-mc`, which is included in the `rocm-llvm` package on Linux.
+- `llvm-dis`, which is included in the `rocm-llvm-dev` package on Linux. This package is usually not installed by default. It can be installed via the package manager (e.g. `apt install rocm-llvm-dev` on Ubuntu).
+
+`rocm-llvm` is installed with most ROCm installations.
+
 ## Used API surface
 ### HIP runtime
 - `hipFree`


### PR DESCRIPTION
> [!NOTE]
> This should be merged after https://github.com/ROCm/rocm-examples/pull/99, which adds various fixes for ROCm 6.x. Without #99, this PR does __not__ fix all issues related to building with ROCm 6.1.

This PR fixes build errors in ROCm 6.1 that would occur when the `rocm-llvm-dev` package is not installed. The root cause of this that in ROCm 6.1, certain tools were split of into their own package.

---

This change:
- adds checks in `HIP-Basic/CMakeLists.txt` for the existence of the tools required to build these examples,
- updates the prefix paths of in `HIP-Basic/assembly_to_executable/CMakeLists.txt` so it will look for the tools in the `rocm-x.y.z/llvm/bin` directory,
- updates the readme in the two affected examples, and
- closes https://github.com/ROCm/rocm-examples/issues/108.