### PR TITLE
[vcxproj][6.1][SWDEV-461192][#102][vs] Move of the newly added projects from 5.7 to 6.1

### DIFF
--- a/Libraries/rocSPARSE/level_2/spmv/spmv_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_2/spmv/spmv_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{7830AAFE-B001-40B5-BBF4-99EE8AAC519A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/spmv/spmv_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_2/spmv/spmv_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{0F437FDF-5F2B-4028-A816-FC1A2ACA51B1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_2/spmv/spmv_vs2022.vcxproj
+++ b/Libraries/rocSPARSE/level_2/spmv/spmv_vs2022.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{D32D396C-4B52-4AAC-AC5A-21CC99207E32}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/sddmm/sddmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/sddmm/sddmm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{FB80DE7F-A745-4FBC-891C-90A5686111C5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/sddmm/sddmm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/sddmm/sddmm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{7905320B-8CBA-48EC-B14A-E6346C1605B8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/sddmm/sddmm_vs2022.vcxproj
+++ b/Libraries/rocSPARSE/level_3/sddmm/sddmm_vs2022.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{8D0AB99C-7FA3-49B5-9554-C5332E8FFE46}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/spmm/spmm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/spmm/spmm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{DA4B2E3F-E114-49B2-91F6-02061F6AEF1A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/spmm/spmm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/spmm/spmm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{EC8FA476-A120-469B-BB48-DA4E0B3E50AD}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/spmm/spmm_vs2022.vcxproj
+++ b/Libraries/rocSPARSE/level_3/spmm/spmm_vs2022.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{A6919683-9E28-400A-8910-1BB207B29C4D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/spsm/spsm_vs2017.vcxproj
+++ b/Libraries/rocSPARSE/level_3/spsm/spsm_vs2017.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{7475A1E7-3CE7-46E3-8BB1-19C3E29F9294}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/spsm/spsm_vs2019.vcxproj
+++ b/Libraries/rocSPARSE/level_3/spsm/spsm_vs2019.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{99ADF085-118B-444D-95B9-1322FDC062C8}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Libraries/rocSPARSE/level_3/spsm/spsm_vs2022.vcxproj
+++ b/Libraries/rocSPARSE/level_3/spsm/spsm_vs2022.vcxproj
@@ -11,7 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <HIPVersion>5.7</HIPVersion>
+    <HIPVersion>6.1</HIPVersion>
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{970F957C-C0E0-481A-8D24-4F72934F583A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -34,13 +34,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>HIP clang 5.7</PlatformToolset>
+    <PlatformToolset>HIP clang 6.1</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
+ [IMP] HIP-VS 6.1 should be installed for compiling `rocm-examples` for both `AMD` and `NVIDIA`
