### PR TITLE
Fix CMake Failure Within Libraries/

### DIFF
--- a/HIP-Basic/texture_management/README.md
+++ b/HIP-Basic/texture_management/README.md
@@ -64,3 +64,7 @@ This example demonstrates how a kernel may use texture memory through the textur
 - `hipStreamDefault`
 - `hipTextureDesc`
 - `hipTextureObject_t`
+
+## Limitations
+
+This example is not supported on CDNA3 architecture (MI300) and above.

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES NONE)
+project(Libraries LANGUAGES CXX)
 
 # CMake configuration files for CUDA versions of HIP libraries are not yet
 # included under the HIP SDK for Windows.

--- a/Libraries/hipBLAS/CMakeLists.txt
+++ b/Libraries/hipBLAS/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(hipBLAS_examples LANGUAGES NONE)
+project(hipBLAS_examples LANGUAGES CXX)
 
 if(WIN32)
     set(ROCM_ROOT

--- a/Libraries/hipSOLVER/CMakeLists.txt
+++ b/Libraries/hipSOLVER/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(hipSOLVER_examples LANGUAGES NONE)
+project(hipSOLVER_examples LANGUAGES CXX)
 
 if(WIN32)
     set(ROCM_ROOT

--- a/Libraries/rocBLAS/CMakeLists.txt
+++ b/Libraries/rocBLAS/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocBLAS_examples LANGUAGES NONE)
+project(rocBLAS_examples LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocBLAS examples do not support the CUDA runtime")

--- a/Libraries/rocBLAS/level_1/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_1/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocBLAS_level_1_examples LANGUAGES NONE)
+project(rocBLAS_level_1_examples LANGUAGES CXX)
 
 add_subdirectory(axpy)
 add_subdirectory(dot)

--- a/Libraries/rocBLAS/level_2/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_2/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocBLAS_level_2_examples LANGUAGES NONE)
+project(rocBLAS_level_2_examples LANGUAGES CXX)
 
 add_subdirectory(gemv)
 add_subdirectory(her)

--- a/Libraries/rocBLAS/level_3/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocBLAS_level_3_examples LANGUAGES NONE)
+project(rocBLAS_level_3_examples LANGUAGES CXX)
 
 add_subdirectory(gemm)
 add_subdirectory(gemm_strided_batched)

--- a/Libraries/rocSOLVER/CMakeLists.txt
+++ b/Libraries/rocSOLVER/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocSOLVER_examples LANGUAGES NONE)
+project(rocSOLVER_examples LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocSOLVER examples do not support the CUDA runtime")

--- a/Libraries/rocSPARSE/CMakeLists.txt
+++ b/Libraries/rocSPARSE/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocSPARSE_examples LANGUAGES NONE)
+project(rocSPARSE_examples LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocSPARSE examples do not support the CUDA runtime")

--- a/Libraries/rocSPARSE/level_2/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocSPARSE_level_2_examples LANGUAGES NONE)
+project(rocSPARSE_level_2_examples LANGUAGES CXX)
 
 add_subdirectory(bsrmv)
 add_subdirectory(bsrsv)

--- a/Libraries/rocSPARSE/level_3/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocSPARSE_level_3_examples LANGUAGES NONE)
+project(rocSPARSE_level_3_examples LANGUAGES CXX)
 
 add_subdirectory(bsrmm)
 add_subdirectory(bsrsm)

--- a/Libraries/rocSPARSE/preconditioner/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(rocSPARSE_preconditioner_examples LANGUAGES NONE)
+project(rocSPARSE_preconditioner_examples LANGUAGES CXX)
 
 add_subdirectory(bsric0)
 add_subdirectory(bsrilu0)


### PR DESCRIPTION
Project languages is not set before "find_package" is called. This leads to a configuration failure when running `cmake` within the `Libraries/` folder.