### PR TITLE
Skip texture management example on MI300 and above

### DIFF
--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -127,7 +127,19 @@ if(NOT WIN32 AND NOT "${GPU_RUNTIME}" STREQUAL "HIP")
     add_subdirectory(static_host_library)
 endif()
 add_subdirectory(streams)
-add_subdirectory(texture_management)
+
+# This example is not supported on gfx940, gfx941, and gfx942
+# See: __HIP_NO_IMAGE_SUPPORT in hip/amd_detail/amd_device_functions.h
+list(REMOVE_DUPLICATES CMAKE_HIP_ARCHITECTURES)
+if(NOT (CMAKE_HIP_ARCHITECTURES MATCHES "gfx94*"))
+    add_subdirectory(texture_management)
+else()
+    message(
+        WARNING
+        "SKIP: Texture management example not supported on gfx940, gfx941, and gfx942"
+    )
+endif()
+
 add_subdirectory(warp_shuffle)
 
 find_package(glfw3)

--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -136,7 +136,7 @@ if(NOT (CMAKE_HIP_ARCHITECTURES MATCHES "gfx94*"))
 else()
     message(
         WARNING
-        "SKIP: Texture management example not supported on gfx940, gfx941, and gfx942"
+        "Texture functions not supported on gfx94*, not building texture management example"
     )
 endif()
 

--- a/HIP-Basic/assembly_to_executable/CMakeLists.txt
+++ b/HIP-Basic/assembly_to_executable/CMakeLists.txt
@@ -77,7 +77,10 @@ endif()
 
 # Remove duplicates.
 list(REMOVE_DUPLICATES GPU_ARCHITECTURES)
-message(STATUS "GPU_ARCHITECTURES: ${GPU_ARCHITECTURES}")
+message(
+    STATUS
+    "assembly_to_executable - GPU_ARCHITECTURES: ${GPU_ARCHITECTURES}"
+)
 
 set_source_files_properties(
     main.hip

--- a/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
+++ b/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
@@ -77,7 +77,10 @@ endif()
 
 # Remove duplicates
 list(REMOVE_DUPLICATES GPU_ARCHITECTURES)
-message(STATUS "GPU_ARCHITECTURES: ${GPU_ARCHITECTURES}")
+message(
+    STATUS
+    "llvm_ir_to_executable - GPU_ARCHITECTURES: ${GPU_ARCHITECTURES}"
+)
 
 set_source_files_properties(
     main.hip

--- a/HIP-Basic/texture_management/CMakeLists.txt
+++ b/HIP-Basic/texture_management/CMakeLists.txt
@@ -57,23 +57,36 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
-add_executable(${example_name} main.hip)
-# Make example runnable using ctest
-add_test(${example_name} ${example_name})
-
-# Temporary workaround: a known bug prevents the example from executing succesfully
-# if multiple GPUs are visible 
-set_tests_properties(
-    ${example_name}
-    PROPERTIES ENVIRONMENT "HIP_VISIBLE_DEVICES=0"
+# Check if GPU architecture is supported
+list(REMOVE_DUPLICATES CMAKE_HIP_ARCHITECTURES)
+message(
+    STATUS
+    "texture_management - CMAKE_HIP_ARCHITECTURES: ${CMAKE_HIP_ARCHITECTURES}"
 )
 
-set(include_dirs "../../Common")
-if(GPU_RUNTIME STREQUAL "CUDA")
-    list(APPEND include_dirs "${ROCM_ROOT}/include")
+if(NOT CMAKE_HIP_ARCHITECTURES MATCHES "gfx94*")
+    add_executable(${example_name} main.hip)
+
+    # Make example runnable using ctest
+    add_test(${example_name} ${example_name})
+
+    # Temporary workaround: a known bug prevents the example from executing succesfully
+    # if multiple GPUs are visible
+    set_tests_properties(
+        ${example_name}
+        PROPERTIES ENVIRONMENT "HIP_VISIBLE_DEVICES=0"
+    )
+
+    set(include_dirs "../../Common")
+    if(GPU_RUNTIME STREQUAL "CUDA")
+        list(APPEND include_dirs "${ROCM_ROOT}/include")
+    endif()
+
+    target_include_directories(${example_name} PRIVATE ${include_dirs})
+    set_source_files_properties(main.hip PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+    install(TARGETS ${example_name})
+else()
+    # As per hip/amd_detail/amd_device_function.h
+    message(WARNING "This example is not supported on gfx94*, skipping...")
 endif()
-
-target_include_directories(${example_name} PRIVATE ${include_dirs})
-set_source_files_properties(main.hip PROPERTIES LANGUAGE ${GPU_RUNTIME})
-
-install(TARGETS ${example_name})


### PR DESCRIPTION
To resolve build failure when building the entire example suite on an MI300.