### PR TITLE
Develop Stream: modify CMake output directory of binaries

### DIFF
--- a/Applications/CMakeLists.txt
+++ b/Applications/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,9 @@
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(Applications LANGUAGES CXX)
+
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
 add_subdirectory(bitonic_sort)
 add_subdirectory(convolution)

--- a/Applications/bitonic_sort/CMakeLists.txt
+++ b/Applications/bitonic_sort/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/Applications/convolution/CMakeLists.txt
+++ b/Applications/convolution/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/Applications/floyd_warshall/CMakeLists.txt
+++ b/Applications/floyd_warshall/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/Applications/histogram/CMakeLists.txt
+++ b/Applications/histogram/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/Applications/monte_carlo_pi/CMakeLists.txt
+++ b/Applications/monte_carlo_pi/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
 endif()
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE hip::hipcub hip::hiprand)
 # Workaround for hipRAND, requires manual linking with backend.

--- a/Applications/prefix_sum/CMakeLists.txt
+++ b/Applications/prefix_sum/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -38,6 +38,9 @@ else()
     )
 endif()
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 # Only supported on HIP (not CUDA)
 if(NOT "${GPU_RUNTIME}" STREQUAL "CUDA")
     # Make sure the dependencies can be found before building.

--- a/HIP-Basic/assembly_to_executable/CMakeLists.txt
+++ b/HIP-Basic/assembly_to_executable/CMakeLists.txt
@@ -189,7 +189,7 @@ add_custom_command(
 add_executable(${example_name} main.hip ${DEVICE_OBJECT})
 
 # Make example runnable using ctest.
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 target_include_directories(${example_name} PRIVATE ${include_dirs})

--- a/HIP-Basic/bandwidth/CMakeLists.txt
+++ b/HIP-Basic/bandwidth/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")
     list(APPEND include_dirs "${ROCM_ROOT}/include")

--- a/HIP-Basic/bit_extract/CMakeLists.txt
+++ b/HIP-Basic/bit_extract/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/cooperative_groups/CMakeLists.txt
+++ b/HIP-Basic/cooperative_groups/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/device_globals/CMakeLists.txt
+++ b/HIP-Basic/device_globals/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/device_query/CMakeLists.txt
+++ b/HIP-Basic/device_query/CMakeLists.txt
@@ -66,7 +66,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/HIP-Basic/dynamic_shared/CMakeLists.txt
+++ b/HIP-Basic/dynamic_shared/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/events/CMakeLists.txt
+++ b/HIP-Basic/events/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/gpu_arch/CMakeLists.txt
+++ b/HIP-Basic/gpu_arch/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/hello_world/CMakeLists.txt
+++ b/HIP-Basic/hello_world/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/HIP-Basic/hello_world_cuda/CMakeLists.txt
+++ b/HIP-Basic/hello_world_cuda/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 add_executable(${example_name} main.hip)
 
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Make the HIP runtime headers accessible
 target_include_directories(

--- a/HIP-Basic/hipify/CMakeLists.txt
+++ b/HIP-Basic/hipify/CMakeLists.txt
@@ -79,7 +79,7 @@ add_custom_command(
 
 add_executable(${example_name} ${CMAKE_CURRENT_BINARY_DIR}/main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 if(GPU_RUNTIME STREQUAL "CUDA")
     set(include_dirs "${ROCM_ROOT}/include")

--- a/HIP-Basic/inline_assembly/CMakeLists.txt
+++ b/HIP-Basic/inline_assembly/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
+++ b/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
@@ -212,7 +212,7 @@ add_custom_command(
 add_executable(${example_name} main.hip ${DEVICE_OBJECT})
 
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 target_include_directories(${example_name} PRIVATE ${include_dirs})

--- a/HIP-Basic/matrix_multiplication/CMakeLists.txt
+++ b/HIP-Basic/matrix_multiplication/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")
     list(APPEND include_dirs "${ROCM_ROOT}/include")

--- a/HIP-Basic/module_api/CMakeLists.txt
+++ b/HIP-Basic/module_api/CMakeLists.txt
@@ -84,7 +84,7 @@ add_custom_command(
 
 add_dependencies(${example_name} ${example_name}_module)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 target_include_directories(${example_name} PRIVATE ${include_dirs})

--- a/HIP-Basic/moving_average/CMakeLists.txt
+++ b/HIP-Basic/moving_average/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/multi_gpu_data_transfer/CMakeLists.txt
+++ b/HIP-Basic/multi_gpu_data_transfer/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/HIP-Basic/occupancy/CMakeLists.txt
+++ b/HIP-Basic/occupancy/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")
     list(APPEND include_dirs "${ROCM_ROOT}/include")

--- a/HIP-Basic/runtime_compilation/CMakeLists.txt
+++ b/HIP-Basic/runtime_compilation/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(link_libs "")
 set(include_dirs "../../Common")

--- a/HIP-Basic/saxpy/CMakeLists.txt
+++ b/HIP-Basic/saxpy/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/HIP-Basic/shared_memory/CMakeLists.txt
+++ b/HIP-Basic/shared_memory/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 

--- a/HIP-Basic/static_host_library/CMakeLists.txt
+++ b/HIP-Basic/static_host_library/CMakeLists.txt
@@ -93,7 +93,7 @@ target_link_libraries(${example_name_cxx} PRIVATE ${library_name})
 set_target_properties(${example_name_cxx} PROPERTIES LINKER_LANGUAGE CXX)
 
 # Make examples runnable using ctest
-add_test(${example_name} ${example_name})
-add_test(${example_name_cxx} ${example_name_cxx})
+add_test(NAME ${example_name} COMMAND ${example_name})
+add_test(NAME ${example_name_cxx} COMMAND ${example_name_cxx})
 
 install(TARGETS ${example_name} ${example_name_cxx})

--- a/HIP-Basic/streams/CMakeLists.txt
+++ b/HIP-Basic/streams/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 set(include_dirs "../../Common")
 if(GPU_RUNTIME STREQUAL "CUDA")
     list(APPEND include_dirs "${ROCM_ROOT}/include")

--- a/HIP-Basic/texture_management/CMakeLists.txt
+++ b/HIP-Basic/texture_management/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Temporary workaround: a known bug prevents the example from executing succesfully
 # if multiple GPUs are visible 

--- a/HIP-Basic/warp_shuffle/CMakeLists.txt
+++ b/HIP-Basic/warp_shuffle/CMakeLists.txt
@@ -59,7 +59,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest.
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common")
 # For examples targeting NVIDIA, include the HIP header directory.

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(Libraries LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 # CMake configuration files for CUDA versions of HIP libraries are not yet
 # included under the HIP SDK for Windows.
 if(NOT (CMAKE_SYSTEM_NAME MATCHES Windows AND "${GPU_RUNTIME}" STREQUAL "CUDA"))

--- a/Libraries/hipBLAS/CMakeLists.txt
+++ b/Libraries/hipBLAS/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(hipBLAS_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(WIN32)
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"

--- a/Libraries/hipBLAS/gemm_strided_batched/CMakeLists.txt
+++ b/Libraries/hipBLAS/gemm_strided_batched/CMakeLists.txt
@@ -61,7 +61,7 @@ find_package(hipblas REQUIRED)
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas)

--- a/Libraries/hipBLAS/her/CMakeLists.txt
+++ b/Libraries/hipBLAS/her/CMakeLists.txt
@@ -61,7 +61,7 @@ find_package(hipblas REQUIRED)
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas)

--- a/Libraries/hipBLAS/scal/CMakeLists.txt
+++ b/Libraries/hipBLAS/scal/CMakeLists.txt
@@ -61,7 +61,7 @@ find_package(hipblas REQUIRED)
 
 add_executable(${example_name} main.hip)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas)

--- a/Libraries/hipCUB/CMakeLists.txt
+++ b/Libraries/hipCUB/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(hipCUB_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(WIN32)
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"

--- a/Libraries/hipCUB/device_radix_sort/CMakeLists.txt
+++ b/Libraries/hipCUB/device_radix_sort/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 find_package(hipcub REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE hip::hipcub)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/hipCUB/device_sum/CMakeLists.txt
+++ b/Libraries/hipCUB/device_sum/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 find_package(hipcub REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE hip::hipcub)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/hipSOLVER/CMakeLists.txt
+++ b/Libraries/hipSOLVER/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(hipSOLVER_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(WIN32)
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"

--- a/Libraries/hipSOLVER/gels/CMakeLists.txt
+++ b/Libraries/hipSOLVER/gels/CMakeLists.txt
@@ -59,7 +59,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipsolver)

--- a/Libraries/hipSOLVER/geqrf/CMakeLists.txt
+++ b/Libraries/hipSOLVER/geqrf/CMakeLists.txt
@@ -60,7 +60,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas roc::hipsolver)

--- a/Libraries/hipSOLVER/gesvd/CMakeLists.txt
+++ b/Libraries/hipSOLVER/gesvd/CMakeLists.txt
@@ -60,7 +60,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas roc::hipsolver)

--- a/Libraries/hipSOLVER/getrf/CMakeLists.txt
+++ b/Libraries/hipSOLVER/getrf/CMakeLists.txt
@@ -59,7 +59,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipsolver)

--- a/Libraries/hipSOLVER/potrf/CMakeLists.txt
+++ b/Libraries/hipSOLVER/potrf/CMakeLists.txt
@@ -59,7 +59,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipsolver)

--- a/Libraries/hipSOLVER/syevd/CMakeLists.txt
+++ b/Libraries/hipSOLVER/syevd/CMakeLists.txt
@@ -59,7 +59,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipsolver)

--- a/Libraries/hipSOLVER/syevdx/CMakeLists.txt
+++ b/Libraries/hipSOLVER/syevdx/CMakeLists.txt
@@ -60,7 +60,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas roc::hipsolver)

--- a/Libraries/hipSOLVER/syevj/CMakeLists.txt
+++ b/Libraries/hipSOLVER/syevj/CMakeLists.txt
@@ -59,7 +59,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipsolver)

--- a/Libraries/hipSOLVER/syevj_batched/CMakeLists.txt
+++ b/Libraries/hipSOLVER/syevj_batched/CMakeLists.txt
@@ -60,7 +60,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas roc::hipsolver)

--- a/Libraries/hipSOLVER/sygvd/CMakeLists.txt
+++ b/Libraries/hipSOLVER/sygvd/CMakeLists.txt
@@ -60,7 +60,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::hipblas roc::hipsolver)

--- a/Libraries/hipSOLVER/sygvj/CMakeLists.txt
+++ b/Libraries/hipSOLVER/sygvj/CMakeLists.txt
@@ -60,7 +60,7 @@ find_package(hipsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example libraries
 target_link_libraries(${example_name} PRIVATE roc::hipblas roc::hipsolver)

--- a/Libraries/rocBLAS/CMakeLists.txt
+++ b/Libraries/rocBLAS/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocBLAS_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocBLAS examples do not support the CUDA runtime")
     return()

--- a/Libraries/rocBLAS/level_1/axpy/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_1/axpy/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_1/dot/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_1/dot/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_1/nrm2/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_1/nrm2/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_1/scal/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_1/scal/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_1/swap/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_1/swap/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_2/gemv/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_2/gemv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_2/her/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_2/her/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_3/gemm/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_3/gemm/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/CMakeLists.txt
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocblas REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas)

--- a/Libraries/rocPRIM/CMakeLists.txt
+++ b/Libraries/rocPRIM/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocPRIM_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocPRIM examples do not support the CUDA runtime")
     return()

--- a/Libraries/rocPRIM/block_sum/CMakeLists.txt
+++ b/Libraries/rocPRIM/block_sum/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocprim REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocprim)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocPRIM/device_sum/CMakeLists.txt
+++ b/Libraries/rocPRIM/device_sum/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocprim REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocprim)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocRAND/CMakeLists.txt
+++ b/Libraries/rocRAND/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocRAND_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(WIN32)
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"

--- a/Libraries/rocRAND/simple_distributions_cpp/CMakeLists.txt
+++ b/Libraries/rocRAND/simple_distributions_cpp/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 find_package(rocrand REQUIRED)
 
 add_executable(${example_name} main.cpp)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 if(GPU_RUNTIME STREQUAL "CUDA")
     target_link_libraries(${example_name} PRIVATE roc::rocrand)

--- a/Libraries/rocSOLVER/CMakeLists.txt
+++ b/Libraries/rocSOLVER/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocSOLVER_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocSOLVER examples do not support the CUDA runtime")
     return()

--- a/Libraries/rocSOLVER/getf2/CMakeLists.txt
+++ b/Libraries/rocSOLVER/getf2/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsolver)

--- a/Libraries/rocSOLVER/getri/CMakeLists.txt
+++ b/Libraries/rocSOLVER/getri/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocblas roc::rocsolver)

--- a/Libraries/rocSOLVER/syev/CMakeLists.txt
+++ b/Libraries/rocSOLVER/syev/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsolver)

--- a/Libraries/rocSOLVER/syev_batched/CMakeLists.txt
+++ b/Libraries/rocSOLVER/syev_batched/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsolver)

--- a/Libraries/rocSOLVER/syev_strided_batched/CMakeLists.txt
+++ b/Libraries/rocSOLVER/syev_strided_batched/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsolver REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsolver)

--- a/Libraries/rocSPARSE/CMakeLists.txt
+++ b/Libraries/rocSPARSE/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocSPARSE_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocSPARSE examples do not support the CUDA runtime")
     return()

--- a/Libraries/rocSPARSE/level_2/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocSPARSE_level_2_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(bsrmv)
 add_subdirectory(bsrsv)
 add_subdirectory(bsrxmv)

--- a/Libraries/rocSPARSE/level_2/bsrmv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/bsrmv/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/bsrsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/bsrsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/bsrxmv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/bsrxmv/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/coomv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/coomv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/csritsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/csritsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/csrmv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/csrmv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/csrsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/csrsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/ellmv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/ellmv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/gebsrmv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/gebsrmv/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/gemvi/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/gemvi/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/spitsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/spitsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/spmv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/spmv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_2/spsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_2/spsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocSPARSE_level_3_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(bsrmm)
 add_subdirectory(bsrsm)
 add_subdirectory(csrmm)

--- a/Libraries/rocSPARSE/level_3/bsrmm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/bsrmm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/bsrsm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/bsrsm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/csrmm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/csrmm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/csrsm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/csrsm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/gebsrmm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/gebsrmm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/gemmi/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/gemmi/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/sddmm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/sddmm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/spmm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/spmm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/level_3/spsm/CMakeLists.txt
+++ b/Libraries/rocSPARSE/level_3/spsm/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocSPARSE_preconditioner_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(bsric0)
 add_subdirectory(bsrilu0)
 add_subdirectory(csric0)

--- a/Libraries/rocSPARSE/preconditioner/bsric0/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/bsric0/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/bsrilu0/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/bsrilu0/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/csric0/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/csric0/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/csrilu0/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/csrilu0/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/gpsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/gpsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocSPARSE/preconditioner/gtsv/CMakeLists.txt
+++ b/Libraries/rocSPARSE/preconditioner/gtsv/CMakeLists.txt
@@ -56,7 +56,7 @@ find_package(rocsparse REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
 target_link_libraries(${example_name} PRIVATE roc::rocsparse hip::host)

--- a/Libraries/rocThrust/CMakeLists.txt
+++ b/Libraries/rocThrust/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocThrust_examples LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocThrust examples do not support the CUDA runtime")
     return()

--- a/Libraries/rocThrust/device_ptr/CMakeLists.txt
+++ b/Libraries/rocThrust/device_ptr/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocthrust REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocthrust)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocThrust/norm/CMakeLists.txt
+++ b/Libraries/rocThrust/norm/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocthrust REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocthrust)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocThrust/reduce_sum/CMakeLists.txt
+++ b/Libraries/rocThrust/reduce_sum/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocthrust REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocthrust)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocThrust/remove_points/CMakeLists.txt
+++ b/Libraries/rocThrust/remove_points/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocthrust REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocthrust)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocThrust/saxpy/CMakeLists.txt
+++ b/Libraries/rocThrust/saxpy/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocthrust REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocthrust)
 target_include_directories(${example_name} PRIVATE "../../../Common")

--- a/Libraries/rocThrust/vectors/CMakeLists.txt
+++ b/Libraries/rocThrust/vectors/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 find_package(rocthrust REQUIRED)
 
 add_executable(${example_name} main.hip)
-add_test(${example_name} ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name})
 
 target_link_libraries(${example_name} PRIVATE roc::rocthrust)
 target_include_directories(${example_name} PRIVATE "../../../Common")


### PR DESCRIPTION
When compiling, the resulting executables along with CMake files are generated inside individual folders (one for each example) within the `build` folder, preserving the folder structure of the rocm-examples project.

This PR modifies this behaviour so that all the executables are nicely placed in a single `build/bin` directory.