### PR TITLE
Add NO_DEFAULT_PATH for llvm-mc, llvm-dis, clang-offload-bundler

### DIFF
--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -49,18 +49,21 @@ if(NOT "${GPU_RUNTIME}" STREQUAL "CUDA")
         llvm-dis
         PATH_SUFFIXES bin
         PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
+        NO_DEFAULT_PATH
     )
     find_program(
         OFFLOAD_BUNDLER_COMMAND
         clang-offload-bundler
         PATH_SUFFIXES bin
         PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
+        NO_DEFAULT_PATH
     )
     find_program(
         LLVM_MC_COMMAND
         llvm-mc
         PATH_SUFFIXES bin
         PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
+        NO_DEFAULT_PATH
     )
 
     if(LLVM_DIS_COMMAND AND OFFLOAD_BUNDLER_COMMAND AND LLVM_MC_COMMAND)

--- a/HIP-Basic/assembly_to_executable/CMakeLists.txt
+++ b/HIP-Basic/assembly_to_executable/CMakeLists.txt
@@ -120,6 +120,7 @@ find_program(
     PATH_SUFFIXES bin
     PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED
+    NO_DEFAULT_PATH
 )
 
 # Generate object bundle.
@@ -170,6 +171,7 @@ find_program(
     PATH_SUFFIXES bin
     PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED
+    NO_DEFAULT_PATH
 )
 
 # Invoke llvm-mc to generate an object file containing the offload bundle.

--- a/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
+++ b/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
@@ -90,6 +90,7 @@ find_program(
     PATH_SUFFIXES bin
     PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED
+    NO_DEFAULT_PATH
 )
 
 # Generate the device LLVM IR using the HIP compiler.
@@ -145,6 +146,7 @@ find_program(
     PATH_SUFFIXES bin
     PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED
+    NO_DEFAULT_PATH
 )
 
 # Generate object bundle.
@@ -194,6 +196,7 @@ find_program(
     PATH_SUFFIXES bin
     PATHS ${ROCM_ROOT}/llvm ${CMAKE_INSTALL_PREFIX}/llvm
     REQUIRED
+    NO_DEFAULT_PATH
 )
 
 # Invoke llvm-mc to generate an object file containing the offload bundle.


### PR DESCRIPTION
Found in QA image, where LLVM is installed, but rocm-llvm-dev is not. `/usr/bin/llvm-dis` and `/opt/rocm/llvm/bin/llvm-mc` were being used to build the `llvm_ir_to_executable` example. This version mismatch results in a build failure.

Adding `NO_DEFAULT_PATH` to only search for these programs in the specified paths. ${ROCM_PATH}, for example.