### PR TITLE
Create a build test CI for the HIP Examples

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -39,7 +39,7 @@ jobs:
                   apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
                   apt-get update -qq &&
                   apt-get install -y \
-                    rocm-dev rocm-llvm rocm-llvm-dev \
+                    rocm-dev rocm-llvm \
                     rocrand-dev hiprand-dev \
                     rocprim-dev hipcub-dev
                   rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -1,0 +1,55 @@
+name: Build Applications
+
+on:
+  push:
+    branches: [ develop, release/** ]
+    paths:
+      - 'Applications/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ develop, release/** ]
+    paths:
+      - 'Applications/**'
+      - '.github/workflows/**'
+
+env:
+    ROCM_VERSION: 6.2
+    AMDGPU_INSTALLER_VERSION: 6.2.60200-1
+
+jobs:
+    build:
+        name: "Build Applications Examples"
+        runs-on: ubuntu-latest
+        container:
+            image: ubuntu:22.04
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Install dependencies
+            run: |
+                  apt-get update -qq &&
+                  apt-get install -y build-essential g++ glslang-tools \
+                    python3 python3-pip libglfw3-dev libvulkan-dev locales wget
+                  python3 -m pip install --upgrade pip
+                  python3 -m pip install cmake
+          - name: Install ROCm Dev
+            run: |
+                  export DEBIAN_FRONTEND=noninteractive
+                  wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
+                  apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
+                  apt-get update -qq &&
+                  apt-get install -y \
+                    rocm-dev rocm-llvm rocm-llvm-dev \
+                    rocrand-dev hiprand-dev \
+                    rocprim-dev hipcub-dev
+                  rm -rf /var/lib/apt/lists/*
+                  echo "/opt/rocm/bin" >> $GITHUB_PATH
+                  echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
+                  echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+                  apt-get autoclean
+          - name: Configure and Build
+            shell: bash
+            run: |
+              cd Applications && mkdir build && cd build
+              cmake -DGPU_ARCHITECTURES=all -S ..
+              cmake --build . -j 4

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 22.04
+name: Build HIP-Basic
 
 on:
   push:

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -39,7 +39,7 @@ jobs:
                   apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
                   apt-get update -qq &&
                   apt-get install -y \
-                    rocm-dev rocm-llvm rocm-llvm-dev \
+                    rocm-dev rocm-llvm \
                     rocrand-dev hiprand-dev \
                     rocprim-dev hipcub-dev \
                     rocblas-dev hipblas-dev \

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -1,0 +1,60 @@
+name: Build Libraries
+
+on:
+  push:
+    branches: [ develop, release/** ]
+    paths:
+      - 'Libraries/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ develop, release/** ]
+    paths:
+      - 'Libraries/**'
+      - '.github/workflows/**'
+
+env:
+    ROCM_VERSION: 6.2
+    AMDGPU_INSTALLER_VERSION: 6.2.60200-1
+
+jobs:
+    build:
+        name: "Build Libraries Examples"
+        runs-on: ubuntu-latest
+        container:
+            image: ubuntu:22.04
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Install dependencies
+            run: |
+                  apt-get update -qq &&
+                  apt-get install -y build-essential g++ glslang-tools \
+                    python3 python3-pip libglfw3-dev libvulkan-dev locales wget
+                  python3 -m pip install --upgrade pip
+                  python3 -m pip install cmake
+          - name: Install ROCm Dev
+            run: |
+                  export DEBIAN_FRONTEND=noninteractive
+                  wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
+                  apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
+                  apt-get update -qq &&
+                  apt-get install -y \
+                    rocm-dev rocm-llvm rocm-llvm-dev \
+                    rocrand-dev hiprand-dev \
+                    rocprim-dev hipcub-dev \
+                    rocblas-dev hipblas-dev \
+                    rocsolver-dev hipsolver-dev \
+                    rocfft-dev hipfft-dev \
+                    rocsparse-dev \
+                    rocthrust-dev
+                  rm -rf /var/lib/apt/lists/*
+                  echo "/opt/rocm/bin" >> $GITHUB_PATH
+                  echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
+                  echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+                  apt-get autoclean
+          - name: Configure and Build
+            shell: bash
+            run: |
+              cd Libraries && mkdir build && cd build
+              cmake -DGPU_ARCHITECTURES=all -S ..
+              cmake --build . -j 4

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -1,0 +1,53 @@
+name: Ubuntu 22.04
+
+on:
+  push:
+    branches: [ develop, release/** ]
+    paths:
+      - 'HIP-Basic/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ develop, release/** ]
+    paths:
+      - 'HIP-Basic/**'
+      - '.github/workflows/**'
+
+env:
+    ROCM_VERSION: 6.2
+    AMDGPU_INSTALLER_VERSION: 6.2.60200-1
+
+jobs:
+    build:
+        name: "Build HIP Examples"
+        runs-on: ubuntu-latest
+        container:
+            image: ubuntu:22.04
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Install dependencies
+            run: |
+                  apt-get update -qq &&
+                  apt-get install -y build-essential g++ glslang-tools \
+                    python3 python3-pip libglfw3-dev libvulkan-dev locales wget
+                  python3 -m pip install --upgrade pip
+                  python3 -m pip install cmake
+
+          - name: Install ROCm Dev
+            run: |
+                  export DEBIAN_FRONTEND=noninteractive
+                  wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
+                  apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
+                  apt-get update -qq &&
+                  apt-get -y install rocm-dev rocm-llvm-dev
+                  echo "/opt/rocm/bin" >> $GITHUB_PATH
+                  echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
+                  echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+                  apt-get autoclean
+
+          - name: Configure and Build
+            shell: bash
+            run: |
+              cd HIP-Basic && mkdir build && cd build
+              cmake -DGPU_ARCHITECTURES=all -S ..
+              cmake --build . -j 4


### PR DESCRIPTION
The scope of this change is limited to the HIP-Basic folder. 
There was not enough disk space on the basic GitHub Runners to install the full ROCm stack and run the Library examples.