### PR TITLE
Add DEB and RPM test packages for built test binaries

### DIFF
--- a/Scripts/Packaging/build_packages.sh
+++ b/Scripts/Packaging/build_packages.sh
@@ -72,7 +72,7 @@ build_project() {
     echo "** Building the project **"
     mkdir -p "$BUILD_DIR"
     pushd "$BUILD_DIR" || exit
-    cmake -DCMAKE_INSTALL_PREFIX="$PACKAGE_INSTALL_PREFIX" ..
+    cmake -DCMAKE_INSTALL_PREFIX="$PACKAGE_INSTALL_PREFIX" -DGPU_ARCHITECTURES=all ..
     make -j$(nproc)
     popd || exit
 }

--- a/Scripts/Packaging/build_packages.sh
+++ b/Scripts/Packaging/build_packages.sh
@@ -161,7 +161,7 @@ Package: ${PACKAGE_NAME}-test
 Version: $PACKAGE_VERSION
 Architecture: amd64
 Maintainer: $PACKAGE_CONTACT
-Description: CTest files for $PACKAGE_NAME
+Description: Test Package for ROCm-Examples
 Homepage: $PACKAGE_HOMEPAGE_URL
 Depends:
 Section: devel
@@ -258,7 +258,7 @@ create_rpm_test_package() {
 Name:           ${PACKAGE_NAME}-test
 Version:        $PACKAGE_VERSION
 Release:        $RPM_PACKAGE_RELEASE%{?dist}
-Summary:        CTest files for $PACKAGE_NAME
+Summary:       Test Package for ROCm-Examples
 License:        MIT
 URL:            $PACKAGE_HOMEPAGE_URL
 Source0:        %{name}-%{version}.tar.gz


### PR DESCRIPTION
Generate `Component-test.<deb/rpm> package` for `rocm-examples` that builds and tests the source as binaries. 