### PR TITLE
Add "Tutorials" directory to SOURCE_DIRS in build_packages.sh

### DIFF
--- a/Scripts/Packaging/build_packages.sh
+++ b/Scripts/Packaging/build_packages.sh
@@ -52,6 +52,7 @@ SOURCE_DIRS=(
     "HIP-Basic"
     "Libraries"
     "LLVM_ASAN"
+    "Tutorials"
 )
 
 


### PR DESCRIPTION
This PR adds the "Tutorials" directory to the `SOURCE_DIRS` array in the `build_packages.sh` script. This ensures that the content in the "Tutorials" directory is included during the package build process. 

Attached is the content of the source package file including the new Tutorial source files:
[source-with-tutorial-deb-pkg-contents.txt](https://github.com/user-attachments/files/16766382/source-with-tutorial-deb-pkg-contents.txt)
