### PR TITLE
Pass in $ROCM_EXAMPLES_ROOT and $TEST_PACKAGE_INSTALL_PREFIX in install_packages.sh

### DIFF
--- a/Scripts/Packaging/build_packages.sh
+++ b/Scripts/Packaging/build_packages.sh
@@ -52,6 +52,7 @@ SOURCE_DIRS=(
     "HIP-Basic"
     "Libraries"
     "LLVM_ASAN"
+    "Tutorials"
 )
 
 


### PR DESCRIPTION
The `build_packages.sh` script previously assumed that the source is located in `BUILD_DIR/..`, instead I pass in `$ROCM_EXAMPLES_ROOT` to locate the source and `$TEST_PACKAGE_INSTALL_PREFIX` for custom installation for the test packages.