### PR TITLE
Fix Tutorials config and build

### DIFF
--- a/Tutorials/reduction/CMakeLists.txt
+++ b/Tutorials/reduction/CMakeLists.txt
@@ -31,9 +31,14 @@ if("${GPU_RUNTIME}" STREQUAL "CUDA")
     cmake_minimum_required(VERSION 3.25.2)
 else()
     cmake_minimum_required(VERSION 3.21)
+    if(WIN32)
+        message(STATUS "The reduction tutorial is not supported on Windows. Not building.")
+        return()
+    endif()
 endif()
 
 project(Reduction LANGUAGES CXX)
+
 
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})

--- a/Tutorials/reduction/CMakeLists.txt
+++ b/Tutorials/reduction/CMakeLists.txt
@@ -32,13 +32,15 @@ if("${GPU_RUNTIME}" STREQUAL "CUDA")
 else()
     cmake_minimum_required(VERSION 3.21)
     if(WIN32)
-        message(STATUS "The reduction tutorial is not supported on Windows. Not building.")
+        message(
+            STATUS
+            "The reduction tutorial is not supported on Windows. Not building."
+        )
         return()
     endif()
 endif()
 
 project(Reduction LANGUAGES CXX)
-
 
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})

--- a/Tutorials/reduction/benchmark/CMakeLists.txt
+++ b/Tutorials/reduction/benchmark/CMakeLists.txt
@@ -70,18 +70,24 @@ list(APPEND include_dirs "${PROJECT_SOURCE_DIR}")
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
     # For examples targeting NVIDIA, include the HIP header directory.
     list(APPEND include_dirs "${ROCM_ROOT}/include")
-    
+
     # Some CUDA versions have issues when compiling for C++20 on Windows, check if we are using those
     if(WIN32)
         find_package(CUDA)
         if(CUDA_FOUND)
             set(FAULTY_CUDA_VERSION "12.5")
             if(CUDA_VERSION VERSION_LESS_EQUAL ${FAULTY_CUDA_VERSION})
-                message(WARNING "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction benchmarks.")
+                message(
+                    WARNING
+                    "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction benchmarks."
+                )
                 return()
             endif()
         else()
-            message(STATUS "CUDA Toolkit not found. Not building reduction benchmarks.")
+            message(
+                STATUS
+                "CUDA Toolkit not found. Not building reduction benchmarks."
+            )
             return()
         endif()
     endif()
@@ -158,7 +164,7 @@ foreach(VER RANGE 0 10)
             ${Sources}
             PROPERTIES LANGUAGE ${GPU_RUNTIME}
         )
-        SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ROCM_ROOT}/cmake)
+        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ROCM_ROOT}/cmake)
         find_package(HIP MODULE REQUIRED)
         target_include_directories(
             ${TargetName}

--- a/Tutorials/reduction/benchmark/CMakeLists.txt
+++ b/Tutorials/reduction/benchmark/CMakeLists.txt
@@ -141,6 +141,7 @@ foreach(VER RANGE 0 10)
             ${Sources}
             PROPERTIES LANGUAGE ${GPU_RUNTIME}
         )
+        SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ROCM_ROOT}/cmake)
         find_package(HIP MODULE REQUIRED)
         target_include_directories(
             ${TargetName}

--- a/Tutorials/reduction/benchmark/CMakeLists.txt
+++ b/Tutorials/reduction/benchmark/CMakeLists.txt
@@ -67,9 +67,24 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 set(include_dirs "../../Common")
 list(APPEND include_dirs "${PROJECT_SOURCE_DIR}")
 
-# For examples targeting NVIDIA, include the HIP header directory.
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
+    # For examples targeting NVIDIA, include the HIP header directory.
     list(APPEND include_dirs "${ROCM_ROOT}/include")
+    
+    # Some CUDA versions have issues when compiling for C++20 on Windows, check if we are using those
+    if(WIN32)
+        find_package(CUDA)
+        if(CUDA_FOUND)
+            set(FAULTY_CUDA_VERSION "12.5")
+            if(CUDA_VERSION VERSION_LESS_EQUAL ${FAULTY_CUDA_VERSION})
+                message(WARNING "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction benchmarks.")
+                return()
+            endif()
+        else()
+            message(STATUS "CUDA Toolkit not found. Not building reduction benchmarks.")
+            return()
+        endif()
+    endif()
 endif()
 
 # libstdc++ Parallel STL on Ubuntu 20.04 requires explicit linking to TBB

--- a/Tutorials/reduction/benchmark/CMakeLists.txt
+++ b/Tutorials/reduction/benchmark/CMakeLists.txt
@@ -24,6 +24,8 @@ project(reduction_benchmarks LANGUAGES CXX)
 
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
     cmake_minimum_required(VERSION 3.25.2)
+    # Allow __device__ or __host__ annotated lambdas
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda")
 else()
     cmake_minimum_required(VERSION 3.21)
     # Add -fPIE flag to compiler.

--- a/Tutorials/reduction/example/CMakeLists.txt
+++ b/Tutorials/reduction/example/CMakeLists.txt
@@ -24,6 +24,8 @@ project(reduction_examples LANGUAGES CXX)
 
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
     cmake_minimum_required(VERSION 3.25.2)
+    # Allow __device__ or __host__ annotated lambdas
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda")
 else()
     cmake_minimum_required(VERSION 3.21)
     # Add -fPIE flag to compiler.

--- a/Tutorials/reduction/example/CMakeLists.txt
+++ b/Tutorials/reduction/example/CMakeLists.txt
@@ -67,9 +67,24 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 set(include_dirs "../../Common")
 list(APPEND include_dirs "${PROJECT_SOURCE_DIR}")
 
-# For examples targeting NVIDIA, include the HIP header directory.
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
+    # For examples targeting NVIDIA, include the HIP header directory.
     list(APPEND include_dirs "${ROCM_ROOT}/include")
+
+    # Some CUDA versions have issues when compiling for C++20 on Windows, check if we are using those
+    if(WIN32)
+        find_package(CUDA)
+        if(CUDA_FOUND)
+            set(FAULTY_CUDA_VERSION "12.5")
+            if(CUDA_VERSION VERSION_LESS_EQUAL ${FAULTY_CUDA_VERSION})
+                message(WARNING "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction examples.")
+                return()
+            endif()
+        else()
+            message(STATUS "CUDA Toolkit not found. Not building reduction examples.")
+            return()
+        endif()
+    endif()
 endif()
 
 # libstdc++ Parallel STL on Ubuntu 20.04 requires explicit linking to TBB

--- a/Tutorials/reduction/example/CMakeLists.txt
+++ b/Tutorials/reduction/example/CMakeLists.txt
@@ -77,11 +77,17 @@ if("${GPU_RUNTIME}" STREQUAL "CUDA")
         if(CUDA_FOUND)
             set(FAULTY_CUDA_VERSION "12.5")
             if(CUDA_VERSION VERSION_LESS_EQUAL ${FAULTY_CUDA_VERSION})
-                message(WARNING "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction examples.")
+                message(
+                    WARNING
+                    "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction examples."
+                )
                 return()
             endif()
         else()
-            message(STATUS "CUDA Toolkit not found. Not building reduction examples.")
+            message(
+                STATUS
+                "CUDA Toolkit not found. Not building reduction examples."
+            )
             return()
         endif()
     endif()

--- a/Tutorials/reduction/include/Reduction/v10.hpp
+++ b/Tutorials/reduction/include/Reduction/v10.hpp
@@ -49,6 +49,52 @@
 
 namespace reduction
 {
+template<typename T, typename F, uint32_t BlockSize, uint32_t WarpSize>
+__global__ static __launch_bounds__(BlockSize) void kernel(
+    T* front, T* back, F op, T zero_elem, uint32_t front_size)
+{
+    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    __shared__ T              shared[WarpCount];
+
+    auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
+    auto read_shared_safe = [&](const uint32_t i) { return i < WarpCount ? shared[i] : zero_elem; };
+
+    const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * blockDim.x + tid,
+                   gsi = gridDim.x * blockDim.x, wid = tid / WarpSize, lid = tid % WarpSize;
+
+    // Read input from front buffer to local
+    T              res               = read_global_safe(gid);
+    const uint32_t num_global_passes = front_size > gsi ? front_size / gsi : 0;
+    for(uint32_t i = 0; i < num_global_passes; ++i)
+        res = op(res, read_global_safe((i + 1) * gsi + gid));
+
+    // Perform warp reductions and communicate results via shared
+    tmp::static_for<WarpCount,
+                    tmp::not_equal<0>,
+                    tmp::select<tmp::not_equal<1>, tmp::divide_ceil<WarpSize>, tmp::constant<0>>>(
+        [&]<uint32_t ActiveWarps>()
+        {
+            if(wid < ActiveWarps)
+            {
+                // Warp reduction
+                tmp::static_for<WarpSize / 2, tmp::not_equal<0>, tmp::divide<2>>(
+                    [&]<int Delta>() { res = op(res, __shfl_down(res, Delta)); });
+
+                // Write warp result from local to shared
+                if(lid == 0)
+                    shared[wid] = res;
+            }
+            __syncthreads();
+
+            // Read warp result from shared to local
+            res = read_shared_safe(tid);
+        });
+
+    // Write result from local to back buffer
+    if(tid == 0)
+        back[bid] = res;
+}
+
 template<typename T, typename F>
 class v10
 {
@@ -97,21 +143,21 @@ public:
                 block_size,
                 [&]<int BlockSize>() noexcept
                 {
-                    tmp::static_switch<std::array{32, 64}>(warp_size,
-                                                           [&]<int WarpSize>() noexcept
-                                                           {
-                                                               hipLaunchKernelGGL(
-                                                                   kernel<BlockSize, WarpSize>,
-                                                                   dim3(block_count),
-                                                                   dim3(BlockSize),
-                                                                   0,
-                                                                   0,
-                                                                   front,
-                                                                   back,
-                                                                   kernel_op,
-                                                                   zero_elem,
-                                                                   step_size);
-                                                           });
+                    tmp::static_switch<std::array{32, 64}>(
+                        warp_size,
+                        [&]<int WarpSize>() noexcept
+                        {
+                            HIP_KERNEL_NAME(
+                                kernel<T,
+                                       F,
+                                       BlockSize,
+                                       WarpSize>)<<<dim3(block_count), dim3(BlockSize), 0, 0>>>(
+                                front,
+                                back,
+                                kernel_op,
+                                zero_elem,
+                                step_size);
+                        });
                 });
         };
 
@@ -157,55 +203,6 @@ private:
     std::size_t new_size(const std::size_t factor, const std::size_t actual)
     {
         return actual / factor + (actual % factor == 0 ? 0 : 1);
-    }
-
-    template<uint32_t BlockSize, uint32_t WarpSize>
-    __global__ static __launch_bounds__(BlockSize) void kernel(
-        T* front, T* back, F op, T zero_elem, uint32_t front_size)
-    {
-        static constexpr uint32_t WarpCount = BlockSize / WarpSize;
-        __shared__ T              shared[WarpCount];
-
-        auto read_global_safe
-            = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
-        auto read_shared_safe
-            = [&](const uint32_t i) { return i < WarpCount ? shared[i] : zero_elem; };
-
-        const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * blockDim.x + tid,
-                       gsi = gridDim.x * blockDim.x, wid = tid / WarpSize, lid = tid % WarpSize;
-
-        // Read input from front buffer to local
-        T              res               = read_global_safe(gid);
-        const uint32_t num_global_passes = front_size > gsi ? front_size / gsi : 0;
-        for(uint32_t i = 0; i < num_global_passes; ++i)
-            res = op(res, read_global_safe((i + 1) * gsi + gid));
-
-        // Perform warp reductions and communicate results via shared
-        tmp::static_for<
-            WarpCount,
-            tmp::not_equal<0>,
-            tmp::select<tmp::not_equal<1>, tmp::divide_ceil<WarpSize>, tmp::constant<0>>>(
-            [&]<uint32_t ActiveWarps>()
-            {
-                if(wid < ActiveWarps)
-                {
-                    // Warp reduction
-                    tmp::static_for<WarpSize / 2, tmp::not_equal<0>, tmp::divide<2>>(
-                        [&]<int Delta>() { res = op(res, __shfl_down(res, Delta)); });
-
-                    // Write warp result from local to shared
-                    if(lid == 0)
-                        shared[wid] = res;
-                }
-                __syncthreads();
-
-                // Read warp result from shared to local
-                res = read_shared_safe(tid);
-            });
-
-        // Write result from local to back buffer
-        if(tid == 0)
-            back[bid] = res;
     }
 };
 } // namespace reduction

--- a/Tutorials/reduction/include/Reduction/v2.hpp
+++ b/Tutorials/reduction/include/Reduction/v2.hpp
@@ -48,6 +48,34 @@
 namespace reduction
 {
 template<typename T, typename F>
+__global__ static void kernel(T* front, T* back, F op, T zero_elem, uint32_t front_size)
+{
+    extern __shared__ T shared[];
+
+    auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
+
+    const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * blockDim.x + tid;
+
+    // Read input from front buffer to shared
+    shared[tid] = read_global_safe(gid);
+    __syncthreads();
+
+    // Shared reduction
+    for(uint32_t i = 1; i < blockDim.x; i *= 2)
+    {
+        uint32_t index = 2 * i * tid;
+
+        if(index < blockDim.x)
+            shared[index] = op(shared[index], shared[index + i]);
+        __syncthreads();
+    }
+
+    // Write result from shared to back buffer
+    if(tid == 0)
+        back[bid] = shared[0];
+}
+
+template<typename T, typename F>
 class v2
 {
 public:
@@ -89,16 +117,11 @@ public:
         std::size_t curr = input.size();
         while(curr > 1)
         {
-            hipLaunchKernelGGL(kernel,
-                               dim3(new_size(factor, curr)),
-                               dim3(block_size),
-                               factor * sizeof(T),
-                               hipStreamDefault,
-                               front,
-                               back,
-                               kernel_op,
-                               zero_elem,
-                               curr);
+            HIP_KERNEL_NAME(
+                kernel<T, F>)<<<dim3(new_size(factor, curr)),
+                                dim3(block_size),
+                                factor * sizeof(T),
+                                hipStreamDefault>>>(front, back, kernel_op, zero_elem, curr);
             hip::check(hipGetLastError(), "hipKernelLaunchGGL");
 
             curr = new_size(factor, curr);
@@ -135,34 +158,6 @@ private:
     std::size_t new_size(const std::size_t factor, const std::size_t actual)
     {
         return actual / factor + (actual % factor == 0 ? 0 : 1);
-    }
-
-    __global__ static void kernel(T* front, T* back, F op, T zero_elem, uint32_t front_size)
-    {
-        extern __shared__ T shared[];
-
-        auto read_global_safe
-            = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
-
-        const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * blockDim.x + tid;
-
-        // Read input from front buffer to shared
-        shared[tid] = read_global_safe(gid);
-        __syncthreads();
-
-        // Shared reduction
-        for(uint32_t i = 1; i < blockDim.x; i *= 2)
-        {
-            uint32_t index = 2 * i * tid;
-
-            if(index < blockDim.x)
-                shared[index] = op(shared[index], shared[index + i]);
-            __syncthreads();
-        }
-
-        // Write result from shared to back buffer
-        if(tid == 0)
-            back[bid] = shared[0];
     }
 };
 } // namespace reduction

--- a/Tutorials/reduction/include/Reduction/v3.hpp
+++ b/Tutorials/reduction/include/Reduction/v3.hpp
@@ -48,6 +48,31 @@
 namespace reduction
 {
 template<typename T, typename F>
+__global__ static void kernel(T* front, T* back, F op, T zero_elem, uint32_t front_size)
+{
+    extern __shared__ T shared[];
+
+    auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
+
+    const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * blockDim.x + tid;
+
+    // Read input from front buffer to shared
+    shared[tid] = read_global_safe(gid);
+    __syncthreads();
+
+    // Shared reduction
+    for(uint32_t i = blockDim.x / 2; i != 0; i /= 2)
+    {
+        if(tid < i)
+            shared[tid] = op(shared[tid], shared[tid + i]);
+        __syncthreads();
+    }
+
+    // Write result from shared to back buffer
+    if(tid == 0)
+        back[bid] = shared[0];
+}
+template<typename T, typename F>
 class v3
 {
 public:
@@ -89,16 +114,11 @@ public:
         std::size_t curr = input.size();
         while(curr > 1)
         {
-            hipLaunchKernelGGL(kernel,
-                               dim3(new_size(factor, curr)),
-                               dim3(block_size),
-                               block_size * sizeof(T),
-                               hipStreamDefault,
-                               front,
-                               back,
-                               kernel_op,
-                               zero_elem,
-                               curr);
+            HIP_KERNEL_NAME(
+                kernel<T, F>)<<<dim3(new_size(factor, curr)),
+                                dim3(block_size),
+                                block_size * sizeof(T),
+                                hipStreamDefault>>>(front, back, kernel_op, zero_elem, curr);
             hip::check(hipGetLastError(), "hipKernelLaunchGGL");
 
             curr = new_size(factor, curr);
@@ -135,32 +155,6 @@ private:
     std::size_t new_size(const std::size_t factor, const std::size_t actual)
     {
         return actual / factor + (actual % factor == 0 ? 0 : 1);
-    }
-
-    __global__ static void kernel(T* front, T* back, F op, T zero_elem, uint32_t front_size)
-    {
-        extern __shared__ T shared[];
-
-        auto read_global_safe
-            = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
-
-        const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * blockDim.x + tid;
-
-        // Read input from front buffer to shared
-        shared[tid] = read_global_safe(gid);
-        __syncthreads();
-
-        // Shared reduction
-        for(uint32_t i = blockDim.x / 2; i != 0; i /= 2)
-        {
-            if(tid < i)
-                shared[tid] = op(shared[tid], shared[tid + i]);
-            __syncthreads();
-        }
-
-        // Write result from shared to back buffer
-        if(tid == 0)
-            back[bid] = shared[0];
     }
 };
 } // namespace reduction

--- a/Tutorials/reduction/include/Reduction/v4.hpp
+++ b/Tutorials/reduction/include/Reduction/v4.hpp
@@ -48,6 +48,32 @@
 namespace reduction
 {
 template<typename T, typename F>
+__global__ static void kernel(T* front, T* back, F op, T zero_elem, uint32_t front_size)
+{
+    extern __shared__ T shared[];
+
+    auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
+
+    const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * (blockDim.x * 2) + tid;
+
+    // Read input from front buffer to shared
+    shared[tid] = op(read_global_safe(gid), read_global_safe(gid + blockDim.x));
+    __syncthreads();
+
+    // Shared reduction
+    for(uint32_t i = blockDim.x / 2; i != 0; i /= 2)
+    {
+        if(tid < i)
+            shared[tid] = op(shared[tid], shared[tid + i]);
+        __syncthreads();
+    }
+
+    // Write result from shared to back buffer
+    if(tid == 0)
+        back[bid] = shared[0];
+}
+
+template<typename T, typename F>
 class v4
 {
 public:
@@ -89,16 +115,11 @@ public:
         std::size_t curr = input.size();
         while(curr > 1)
         {
-            hipLaunchKernelGGL(kernel,
-                               dim3(new_size(factor, curr)),
-                               dim3(block_size),
-                               block_size * sizeof(T),
-                               hipStreamDefault,
-                               front,
-                               back,
-                               kernel_op,
-                               zero_elem,
-                               curr);
+            HIP_KERNEL_NAME(
+                kernel<T, F>)<<<dim3(new_size(factor, curr)),
+                                dim3(block_size),
+                                block_size * sizeof(T),
+                                hipStreamDefault>>>(front, back, kernel_op, zero_elem, curr);
             hip::check(hipGetLastError(), "hipKernelLaunchGGL");
 
             curr = new_size(factor, curr);
@@ -135,32 +156,6 @@ private:
     std::size_t new_size(const std::size_t factor, const std::size_t actual)
     {
         return actual / factor + (actual % factor == 0 ? 0 : 1);
-    }
-
-    __global__ static void kernel(T* front, T* back, F op, T zero_elem, uint32_t front_size)
-    {
-        extern __shared__ T shared[];
-
-        auto read_global_safe
-            = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
-
-        const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * (blockDim.x * 2) + tid;
-
-        // Read input from front buffer to shared
-        shared[tid] = op(read_global_safe(gid), read_global_safe(gid + blockDim.x));
-        __syncthreads();
-
-        // Shared reduction
-        for(uint32_t i = blockDim.x / 2; i != 0; i /= 2)
-        {
-            if(tid < i)
-                shared[tid] = op(shared[tid], shared[tid + i]);
-            __syncthreads();
-        }
-
-        // Write result from shared to back buffer
-        if(tid == 0)
-            back[bid] = shared[0];
     }
 };
 } // namespace reduction

--- a/Tutorials/reduction/include/Reduction/v6.hpp
+++ b/Tutorials/reduction/include/Reduction/v6.hpp
@@ -49,6 +49,41 @@
 
 namespace reduction
 {
+template<typename T, typename F, uint32_t BlockSize, uint32_t WarpSize>
+__global__ static __launch_bounds__(BlockSize) void kernel(
+    T* front, T* back, F op, T zero_elem, uint32_t front_size)
+{
+    __shared__ T shared[BlockSize];
+
+    auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
+
+    const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * (blockDim.x * 2) + tid;
+
+    // Read input from front buffer to shared
+    shared[tid] = op(read_global_safe(gid), read_global_safe(gid + blockDim.x));
+    __syncthreads();
+
+    // Shared reduction
+    tmp::static_for<BlockSize / 2, tmp::greater_than<WarpSize>, tmp::divide<2>>(
+        [&]<int I>()
+        {
+            if(tid < I)
+                shared[tid] = op(shared[tid], shared[tid + I]);
+            __syncthreads();
+        });
+    // Warp reduction
+    tmp::static_for<WarpSize, tmp::not_equal<0>, tmp::divide<2>>(
+        [&]<int I>()
+        {
+            if(tid < I)
+                shared[tid] = op(shared[tid], shared[tid + I]);
+        });
+
+    // Write result from shared to back buffer
+    if(tid == 0)
+        back[bid] = shared[0];
+}
+
 template<typename T, typename F>
 class v6
 {
@@ -100,16 +135,11 @@ public:
                         warp_size,
                         [&]<int WarpSize>() noexcept
                         {
-                            hipLaunchKernelGGL(kernel<BlockSize, WarpSize>,
-                                               dim3(new_size(factor, step_size)),
-                                               dim3(BlockSize),
-                                               0,
-                                               hipStreamDefault,
-                                               front,
-                                               back,
-                                               kernel_op,
-                                               zero_elem,
-                                               step_size);
+                            HIP_KERNEL_NAME(kernel<T, F, BlockSize, WarpSize>)<<<
+                                dim3(new_size(factor, step_size)),
+                                dim3(BlockSize),
+                                0,
+                                hipStreamDefault>>>(front, back, kernel_op, zero_elem, step_size);
                         });
                 });
         };
@@ -160,42 +190,6 @@ private:
     std::size_t new_size(const std::size_t factor, const std::size_t actual)
     {
         return actual / factor + (actual % factor == 0 ? 0 : 1);
-    }
-
-    template<uint32_t BlockSize, uint32_t WarpSize>
-    __global__ static __launch_bounds__(BlockSize) void kernel(
-        T* front, T* back, F op, T zero_elem, uint32_t front_size)
-    {
-        __shared__ T shared[BlockSize];
-
-        auto read_global_safe
-            = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
-
-        const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * (blockDim.x * 2) + tid;
-
-        // Read input from front buffer to shared
-        shared[tid] = op(read_global_safe(gid), read_global_safe(gid + blockDim.x));
-        __syncthreads();
-
-        // Shared reduction
-        tmp::static_for<BlockSize / 2, tmp::greater_than<WarpSize>, tmp::divide<2>>(
-            [&]<int I>()
-            {
-                if(tid < I)
-                    shared[tid] = op(shared[tid], shared[tid + I]);
-                __syncthreads();
-            });
-        // Warp reduction
-        tmp::static_for<WarpSize, tmp::not_equal<0>, tmp::divide<2>>(
-            [&]<int I>()
-            {
-                if(tid < I)
-                    shared[tid] = op(shared[tid], shared[tid + I]);
-            });
-
-        // Write result from shared to back buffer
-        if(tid == 0)
-            back[bid] = shared[0];
     }
 };
 } // namespace reduction

--- a/Tutorials/reduction/include/Reduction/v8.hpp
+++ b/Tutorials/reduction/include/Reduction/v8.hpp
@@ -49,6 +49,49 @@
 
 namespace reduction
 {
+template<typename T, typename F, uint32_t BlockSize, uint32_t WarpSize>
+__global__ static __launch_bounds__(BlockSize) void kernel(
+    T* front, T* back, F op, T zero_elem, uint32_t front_size)
+{
+    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    __shared__ T              shared[WarpCount];
+
+    auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
+    auto read_shared_safe = [&](const uint32_t i) { return i < WarpCount ? shared[i] : zero_elem; };
+
+    const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * (blockDim.x * 2) + tid,
+                   wid = tid / WarpSize, lid = tid % WarpSize;
+
+    // Read input from front buffer to local
+    T res = op(read_global_safe(gid), read_global_safe(gid + blockDim.x));
+
+    // Perform warp reductions and communicate results via shared
+    tmp::static_for<WarpCount,
+                    tmp::not_equal<0>,
+                    tmp::select<tmp::not_equal<1>, tmp::divide_ceil<WarpSize>, tmp::constant<0>>>(
+        [&]<uint32_t ActiveWarps>()
+        {
+            if(wid < ActiveWarps)
+            {
+                // Warp reduction
+                tmp::static_for<WarpSize / 2, tmp::not_equal<0>, tmp::divide<2>>(
+                    [&]<int Delta>() { res = op(res, __shfl_down(res, Delta)); });
+
+                // Write warp result from local to shared
+                if(lid == 0)
+                    shared[wid] = res;
+            }
+            __syncthreads();
+
+            // Read warp result from shared to local
+            res = read_shared_safe(tid);
+        });
+
+    // Write result from local to back buffer
+    if(tid == 0)
+        back[bid] = res;
+}
+
 template<typename T, typename F>
 class v8
 {
@@ -100,16 +143,11 @@ public:
                         warp_size,
                         [&]<int WarpSize>() noexcept
                         {
-                            hipLaunchKernelGGL(kernel<BlockSize, WarpSize>,
-                                               dim3(new_size(factor, step_size)),
-                                               dim3(BlockSize),
-                                               0,
-                                               hipStreamDefault,
-                                               front,
-                                               back,
-                                               kernel_op,
-                                               zero_elem,
-                                               step_size);
+                            HIP_KERNEL_NAME(kernel<T, F, BlockSize, WarpSize>)<<<
+                                dim3(new_size(factor, step_size)),
+                                dim3(BlockSize),
+                                0,
+                                hipStreamDefault>>>(front, back, kernel_op, zero_elem, step_size);
                         });
                 });
         };
@@ -160,52 +198,6 @@ private:
     std::size_t new_size(const std::size_t factor, const std::size_t actual)
     {
         return actual / factor + (actual % factor == 0 ? 0 : 1);
-    }
-
-    template<uint32_t BlockSize, uint32_t WarpSize>
-    __global__ static __launch_bounds__(BlockSize) void kernel(
-        T* front, T* back, F op, T zero_elem, uint32_t front_size)
-    {
-        static constexpr uint32_t WarpCount = BlockSize / WarpSize;
-        __shared__ T              shared[WarpCount];
-
-        auto read_global_safe
-            = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };
-        auto read_shared_safe
-            = [&](const uint32_t i) { return i < WarpCount ? shared[i] : zero_elem; };
-
-        const uint32_t tid = threadIdx.x, bid = blockIdx.x, gid = bid * (blockDim.x * 2) + tid,
-                       wid = tid / WarpSize, lid = tid % WarpSize;
-
-        // Read input from front buffer to local
-        T res = op(read_global_safe(gid), read_global_safe(gid + blockDim.x));
-
-        // Perform warp reductions and communicate results via shared
-        tmp::static_for<
-            WarpCount,
-            tmp::not_equal<0>,
-            tmp::select<tmp::not_equal<1>, tmp::divide_ceil<WarpSize>, tmp::constant<0>>>(
-            [&]<uint32_t ActiveWarps>()
-            {
-                if(wid < ActiveWarps)
-                {
-                    // Warp reduction
-                    tmp::static_for<WarpSize / 2, tmp::not_equal<0>, tmp::divide<2>>(
-                        [&]<int Delta>() { res = op(res, __shfl_down(res, Delta)); });
-
-                    // Write warp result from local to shared
-                    if(lid == 0)
-                        shared[wid] = res;
-                }
-                __syncthreads();
-
-                // Read warp result from shared to local
-                res = read_shared_safe(tid);
-            });
-
-        // Write result from local to back buffer
-        if(tid == 0)
-            back[bid] = res;
     }
 };
 } // namespace reduction

--- a/Tutorials/reduction/test/CMakeLists.txt
+++ b/Tutorials/reduction/test/CMakeLists.txt
@@ -162,6 +162,7 @@ foreach(VER RANGE 1 10)
             ${Sources}
             PROPERTIES LANGUAGE ${GPU_RUNTIME}
         )
+        SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ROCM_ROOT}/cmake)
         find_package(HIP MODULE REQUIRED)
         target_include_directories(
             ${TargetName}

--- a/Tutorials/reduction/test/CMakeLists.txt
+++ b/Tutorials/reduction/test/CMakeLists.txt
@@ -24,6 +24,8 @@ project(reduction_tests LANGUAGES CXX)
 
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
     cmake_minimum_required(VERSION 3.25.2)
+    # Allow __device__ or __host__ annotated lambdas
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda")
 else()
     cmake_minimum_required(VERSION 3.21)
     # Add -fPIE flag to compiler.

--- a/Tutorials/reduction/test/CMakeLists.txt
+++ b/Tutorials/reduction/test/CMakeLists.txt
@@ -77,11 +77,17 @@ if("${GPU_RUNTIME}" STREQUAL "CUDA")
         if(CUDA_FOUND)
             set(FAULTY_CUDA_VERSION "12.5")
             if(CUDA_VERSION VERSION_LESS_EQUAL ${FAULTY_CUDA_VERSION})
-                message(WARNING "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction tests.")
+                message(
+                    WARNING
+                    "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction tests."
+                )
                 return()
             endif()
         else()
-            message(STATUS "CUDA Toolkit not found. Not building reduction tests.")
+            message(
+                STATUS
+                "CUDA Toolkit not found. Not building reduction tests."
+            )
             return()
         endif()
     endif()
@@ -179,7 +185,7 @@ foreach(VER RANGE 1 10)
             ${Sources}
             PROPERTIES LANGUAGE ${GPU_RUNTIME}
         )
-        SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ROCM_ROOT}/cmake)
+        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ROCM_ROOT}/cmake)
         find_package(HIP MODULE REQUIRED)
         target_include_directories(
             ${TargetName}

--- a/Tutorials/reduction/test/CMakeLists.txt
+++ b/Tutorials/reduction/test/CMakeLists.txt
@@ -67,9 +67,24 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 set(include_dirs "../../Common")
 list(APPEND include_dirs "${PROJECT_SOURCE_DIR}")
 
-# For examples targeting NVIDIA, include the HIP header directory.
 if("${GPU_RUNTIME}" STREQUAL "CUDA")
+    # For examples targeting NVIDIA, include the HIP header directory.
     list(APPEND include_dirs "${ROCM_ROOT}/include")
+
+    # Some CUDA versions have issues when compiling for C++20 on Windows, check if we are using those
+    if(WIN32)
+        find_package(CUDA)
+        if(CUDA_FOUND)
+            set(FAULTY_CUDA_VERSION "12.5")
+            if(CUDA_VERSION VERSION_LESS_EQUAL ${FAULTY_CUDA_VERSION})
+                message(WARNING "CUDA version ${CUDA_VERSION} has issues when compiling for C++20. Not building reduction tests.")
+                return()
+            endif()
+        else()
+            message(STATUS "CUDA Toolkit not found. Not building reduction tests.")
+            return()
+        endif()
+    endif()
 endif()
 
 # libstdc++ Parallel STL on Ubuntu 20.04 requires explicit linking to TBB


### PR DESCRIPTION
Got some build errors on our CI some time ago. Some of the them were fixed but in the end I needed to disable some build cases (most of Windows') because there wasn't any apparent fix for some of the issues:
- windows with ROCm because of some [linker issues with google benchmark](https://stackoverflow.com/questions/73494386/lnk2001-linker-error-while-linking-google-benchmark-lib)
- windows with CUDA for some toolkit versions (<=12.5) because of some nvcc issues with C++20 which seems to be solved in the [CUDA 12.5 Update 1](https://stackoverflow.com/questions/78586741/cudafe-died-with-status-0xc0000409-when-switching-to-c20-for-nvcc)