### PR TITLE
Give Developer user full root privileges

### DIFF
--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -67,7 +67,7 @@ ARG GID=109
 
 # Add the render group and a user with sudo permissions for the container
 RUN groupadd --system --gid ${GID} render \
-    && useradd -Um -G sudo,video,render developer \
+    && useradd -u 0 -o -Um -G sudo,video,render developer \
     && echo developer ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/developer \
     && chmod 0440 /etc/sudoers.d/developer
 

--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -67,9 +67,7 @@ ARG GID=109
 
 # Add the render group and a user with sudo permissions for the container
 RUN groupadd --system --gid ${GID} render \
-    && useradd -u 0 -o -Um -G sudo,video,render developer \
-    && echo developer ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/developer \
-    && chmod 0440 /etc/sudoers.d/developer
+    && useradd -u 0 -o -Um -G video,render developer
 
 RUN mkdir /workspaces && chown developer:developer /workspaces
 WORKDIR /workspaces


### PR DESCRIPTION
Fix for https://github.com/ROCm/rocm-examples/issues/171. 

Even after the installation of rocm-smi, GPUs are not visible due to lack of permissions in docker container. Permissions can be checked by running `rocminfo` which fails and `sudo rocminfo` which executes correctly. 

This PR sets `developer` to a root user which is the status quo on other ROCm docker images such as rocm/pytorch, rocm/tensorflow and the base 24.04 ROCm image. Confirmed rocm-examples are successfully built and ran after this change.