### PR TITLE
Develop Stream - Fix ROCm 6.2.2 build error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ variables:
   HIP_FLAGS: "-Wno-unused-command-line-argument -Wall -Wextra -Werror"
   # Keep in sync with ROCM_VERSION in Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
   # and Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
-  DOCKER_ROCM_VERSION: 6.2.0
+  DOCKER_ROCM_VERSION: 6.3.0
   DOCKER_HIP_LIBRARIES_ROCM_TAG: rocm-ubuntu-${DOCKER_ROCM_VERSION}
   DOCKER_HIP_LIBRARIES_CUDA_TAG: cuda-ubuntu-${DOCKER_ROCM_VERSION}
   DOCKER_HIP_LIBRARIES_ROCM: $DOCKER_TAG_PREFIX:$DOCKER_HIP_LIBRARIES_ROCM_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -286,23 +286,6 @@ test:cuda:
     - windows
     - shell
     - rx6900
-  variables:
-    SOLUTION_PREFIX: ROCm-Examples-VS
-    # hip_vulkant_interop: graphical
-    # hip_texture_management: does not work
-    # rocsparse_*: broken with new SDK
-    SkippedExamples: >
-      hip_vulkan_interop_*.exe,
-      hip_texture_management_*.exe,
-      rocsparse_bsric0_*.exe,
-      rocsparse_bsrilu0_*.exe,
-      rocsparse_bsrsm_*.exe,
-      rocsparse_bsrsv_*.exe,
-      rocsparse_csric0_*.exe,
-      rocsparse_csrilu0_*.exe,
-      rocsparse_csrsv_*.exe,
-      rocsparse_spsv_*.exe,
-      rocsparse_spsm_*.exe
 
 .test:windows-nvcc:
   tags:
@@ -326,6 +309,7 @@ test:cuda:
   variables:
     Timeout: 60
     Filter: "*_vs$VS_VERSION.exe"
+
   script:
     - |
       & ${env:HIP_PATH}/bin/clang++ --version
@@ -374,9 +358,24 @@ test:windows-rocm-vs:
   variables:
     SOLUTION_PREFIX: ROCm-Examples-VS
     # hip_vulkan_interop: graphical
+    # broken with new SDK (6.2):
+    # - applications_prefix_sum
+    # - hip_dynamic_shared
+    # - hipsolver_*
+    # - rocsolver_*
     SkippedExamples: >
-      hip_vulkan_interop_*.exe,
+      applications_prefix_sum_*.exe,
+      hip_dynamic_shared_*.exe,
       hip_opengl_interop_*.exe,
+      hip_vulkan_interop_*.exe,
+      hipsolver_gels_*.exe,
+      hipsolver_getrf_*.exe,
+      hipsolver_potrf_*.exe,
+      hipsolver_sygvd_*.exe,
+      hipsolver_sygvj_*.exe,
+      rocsolver_getf2_*.exe,
+      rocsolver_getri_*.exe
+
 test:windows-nvcc-vs:
   extends:
     - .test:windows-nvcc
@@ -408,6 +407,8 @@ test:windows-nvcc-vs:
   variables:
     VS_VERSION: 2022
     BUILD_TYPE: Release
+    SkippedExamples: applications_prefix_sum_*|hip_dynamic_shared_*|hip_opengl_interop_*|hip_vulkan_interop_*|hipsolver_gels_*|hipsolver_getrf_*|hipsolver_potrf_*|hipsolver_sygvd_*|hipsolver_sygvj_*|rocsolver_getf2_*|rocsolver_getri_*
+
   before_script:
     - | # Find VS installation
       $VS_PATH = (
@@ -428,7 +429,7 @@ test:windows-nvcc-vs:
     # So for now, just add the library path here.
     - $env:PATH = "${env:HIP_PATH}\bin;" + $env:PATH
     - cd "$CI_PROJECT_DIR/build"
-    - ctest --output-on-failure --timeout 15 --parallel 8
+    - ctest --output-on-failure --timeout 15 --parallel 8 -E "$SkippedExamples"
     - cmake --install "$CI_PROJECT_DIR/build" --prefix "$CI_PROJECT_DIR/install"
   needs: []
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21.3 FATAL_ERROR)
-project(ROCm-SDK-Examples LANGUAGES CXX VERSION 6.2.0)
+project(ROCm-SDK-Examples LANGUAGES CXX VERSION 6.3.0)
 enable_testing()
 
 add_subdirectory(Applications)

--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:22.04
 
 # The ROCm versions that this image is based of.
 # Always write this down as major.minor.patch
-ENV ROCM_VERSION=6.2.0
+ENV ROCM_VERSION=6.3.0
 ENV ROCM_VERSION_APT=${ROCM_VERSION%.0}
 
 # Base packages that are required for the installation

--- a/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
@@ -9,12 +9,17 @@
 # Input: Bundled Object file .hipfb file
 # Output: Host Bundled Object File .o
 
+    .section .hip_gpubin_handle,"dw"
+    .globl __hip_gpubin_handle_
+    .p2align 12
+__hip_gpubin_handle_:
+    .zero 8
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"
     # Make the symbol that addresses the binary public.
-    .globl __hip_fatbin
+    .globl __hip_fatbin_
     # Give the bundle the required alignment of 4096 (2 ^ 12).
     .p2align 12
-__hip_fatbin:
+__hip_fatbin_:
     # Include the offload bundle.
     .incbin "offload_bundle.hipfb"

--- a/HIP-Basic/llvm_ir_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/llvm_ir_to_executable/hip_obj_gen_win.mcin
@@ -9,12 +9,17 @@
 # Input: Bundled Object file .hipfb file
 # Output: Host Bundled Object File .o
 
+    .section .hip_gpubin_handle,"dw"
+    .globl __hip_gpubin_handle_
+    .p2align 12
+__hip_gpubin_handle_:
+    .zero 8
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"
     # Make the symbol that addresses the binary public.
-    .globl __hip_fatbin
+    .globl __hip_fatbin_
     # Give the bundle the required alignment of 4096 (2 ^ 12).
     .p2align 12
-__hip_fatbin:
+__hip_fatbin_:
     # Include the offload bundle.
     .incbin "offload_bundle.hipfb"

--- a/HIP-Basic/warp_shuffle/main.hip
+++ b/HIP-Basic/warp_shuffle/main.hip
@@ -45,11 +45,21 @@ __global__ void matrix_transpose_kernel(float* out, const float* in, const unsig
         // the thread with global id x * width + y will transpose.
         const float val = in[y * width + x];
 
-        // Transpose element reading it from the correspondent thread with a shuffle operation (__shfl).
-        // __shfl does not require all threads to be active, so it can be inside the if block.
+        // Transpose element reading it from the correspondent thread with a shuffle operation:
+        // * when targeting AMD devices, __shfl is used.
+        // * with targeting NVIDIA devices, __shfl is deprecated from CUDA 9 and __shfl_sync must
+        //   be used instead.
+        // __shfl/___shfl_sync do not require all threads to be active, so they can be inside the
+        // if block.
         // Note that, since the matrix in this example has less elements than the warp size value,
         // the ID within the warp of each thread matches its global ID.
+        // Also note that __shfl_sync needs the mask of active threads to be explicitly passed as
+        // argument. It can be retrieved with the warp intrinsic __activemask().
+#if defined(__HIP_PLATFORM_AMD__)
         out[x * width + y] = __shfl(val, y * width + x);
+#elif defined(__HIP_PLATFORM_NVIDIA__)
+        out[x * width + y] = __shfl_sync(__activemask(), val, y * width + x);
+#endif
     }
 }
 

--- a/Scripts/Packaging/build_packages.sh
+++ b/Scripts/Packaging/build_packages.sh
@@ -26,7 +26,7 @@ set -e
 # Default values
 GIT_TOP_LEVEL=$(git rev-parse --show-toplevel)
 PACKAGE_NAME="ROCm-SDK-Examples"
-PACKAGE_VERSION="6.2.0"
+PACKAGE_VERSION="6.3.0"
 DEB_PACKAGE_RELEASE="local.9999"
 RPM_PACKAGE_RELEASE="local.9999"
 PACKAGE_INSTALL_PREFIX="/opt/rocm/examples"


### PR DESCRIPTION
This PR updates the project to use ROCm 6.2.2 and tackles the internal ticket regarding `llvm_ir_to_executable` and `assembly_to_executable` examples not building on Windows.

The root cause of the issue was that a [commit in llvm-project](https://github.com/ROCm/llvm-project/commit/33a6ce18373ffd1457ebd54e930b6f02fe4c39c1#diff-3faa66fd85be57e36a4886dffe63ea9ed43581f0f02358e191e0d6429895e7bfR21) had made some modifications to the linking. I saw that there was a PR to fix this in Linux previously (https://github.com/ROCm/rocm-examples/pull/142) but it was later reverted (https://github.com/ROCm/rocm-examples/pull/161) because a fix for that linking-related commit had been added in [llvm-project](https://github.com/llvm/llvm-project/commit/c7435ccfabc5a4a91266e7dff71815a4c1094c37). However, said fix was not released as part of ROCm 6.2.2 (nor 6.2.4 as far as I'm aware), so this build error is still present in both Linux and Windows. Therefore, this PR brings back the fix for Linux from the PR mentioned previously and also adds the fix for Windows. These have been tested in our internal CI and no build errors have been observed.

FYI: this branch is based on `develop_stream_20241129`, so I set up the PR to target that branch instead of develop for a better review experience. Reviewers should keep in mind that PR https://github.com/ROCm/rocm-examples/pull/182 should be merged before this one, and then the target branch should be changed to develop.