### PR TITLE
Change clang-offload-bundler to 4-tuple

### DIFF
--- a/HIP-Basic/assembly_to_executable/CMakeLists.txt
+++ b/HIP-Basic/assembly_to_executable/CMakeLists.txt
@@ -92,7 +92,7 @@ if(WIN32)
 else()
     set(OBJ_TYPE o)
     set(NULDEV /dev/null)
-    set(HOST_TARGET x86_64-unknown-linux)
+    set(HOST_TARGET x86_64-unknown-linux-gnu)
     set(HIP_OBJ_GEN_FILE hip_obj_gen.mcin)
 endif()
 

--- a/HIP-Basic/assembly_to_executable/Makefile
+++ b/HIP-Basic/assembly_to_executable/Makefile
@@ -68,7 +68,7 @@ main_device.o: hip_obj_gen.mcin offload_bundle.hipfb
 
 offload_bundle.hipfb: $(GPU_ARCHS:%=main_%.o)
 	$(CLANG_OFFLOAD_BUNDLER) -type=o -bundle-align=4096 \
-		-targets=host-x86_64-unknown-linux,$(GPU_ARCH_TRIPLES) \
+		-targets=host-x86_64-unknown-linux-gnu,$(GPU_ARCH_TRIPLES) \
 		-input=/dev/null \
 		$(^:%=-input=%) \
 		-output=$@

--- a/HIP-Basic/assembly_to_executable/README.md
+++ b/HIP-Basic/assembly_to_executable/README.md
@@ -52,11 +52,11 @@ A HIP binary consists of a regular host executable, which has an offload bundle 
     ...
     ```
 
-3. The device object files are combined into an offload bundle using `clang-offload-bundler`. This requires specifying the target as well as the offload kind for each device, in the form `<offload-kind>-<target>-<arch>`. For HIP device code, `<offload-kind>` is `hipv4`. Note that this command requires an (empty) entry for the host to also be present, with `<offload-kind>` `host`. The order of targets and inputs must match. `<target>` is an LLVM target triple, which is specified as `<isa>-<vendor>-<os>-<abi>`. `<abi>` is left empty for AMD targets.
+3. The device object files are combined into an offload bundle using `clang-offload-bundler`. This requires specifying the target as well as the offload kind for each device, in the form `<offload-kind>-<target>[-<target id>[:<target features>]]`. For HIP device code, `<offload-kind>` is `hipv4`. Note that this command requires an (empty) entry for the host to also be present, with `<offload-kind>` `host`. The order of targets and inputs must match. `<target>` is an LLVM target 4-tuple, which is specified as `<arch>-<vendor>-<os>-<env>`.
 
     ```shell
     $ROCM_INSTALL_DIR/llvm/bin/clang-offload-bundler -type=o -bundle-align=4096 \
-            -targets=host-x86_64-unknown-linux,hipv4-amdgcn-amd-amdhsa--gfx1030,hipv4-... \
+            -targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa--gfx1030,hipv4-... \
             -input=/dev/null \
             -input=main_gfx1030.o -input=... \
             -output=offload_bundle.hipfb

--- a/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
+++ b/HIP-Basic/llvm_ir_to_executable/CMakeLists.txt
@@ -119,7 +119,7 @@ if(WIN32)
 else()
     set(OBJ_TYPE o)
     set(NULDEV /dev/null)
-    set(HOST_TARGET x86_64-unknown-linux)
+    set(HOST_TARGET x86_64-unknown-linux-gnu)
     set(HIP_OBJ_GEN_FILE hip_obj_gen.mcin)
 endif()
 

--- a/HIP-Basic/llvm_ir_to_executable/Makefile
+++ b/HIP-Basic/llvm_ir_to_executable/Makefile
@@ -69,7 +69,7 @@ main_device.o: hip_obj_gen.mcin offload_bundle.hipfb
 
 offload_bundle.hipfb: $(GPU_ARCHS:%=main_%.o)
 	$(CLANG_OFFLOAD_BUNDLER) -type=o -bundle-align=4096 \
-		-targets=host-x86_64-unknown-linux,$(GPU_ARCH_TRIPLES) \
+		-targets=host-x86_64-unknown-linux-gnu,$(GPU_ARCH_TRIPLES) \
 		-input=/dev/null \
 		$(^:%=-input=%) \
 		-output=$@

--- a/HIP-Basic/llvm_ir_to_executable/README.md
+++ b/HIP-Basic/llvm_ir_to_executable/README.md
@@ -11,7 +11,7 @@ LLVM IR is the intermediary language used by the LLVM compiler, which hipcc is b
 - Build with Makefile: to compile for specific GPU architectures, optionally provide the HIP_ARCHITECTURES variable. Provide the architectures separated by comma.
 
     ```shell
-    make HIP_ARCHITECTURES="gfx803;gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102
+    make HIP_ARCHITECTURES="gfx803;gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102"
     ```
 
 - Build with CMake:

--- a/HIP-Basic/llvm_ir_to_executable/README.md
+++ b/HIP-Basic/llvm_ir_to_executable/README.md
@@ -54,11 +54,11 @@ A HIP binary consists of a regular host executable, which has an offload bundle 
     ...
     ```
 
-3. The device object files are combined into an offload bundle using `clang-offload-bundler`. This requires specifying the target as well as the offload kind for each device, in the form `<offload-kind>-<target>-<arch>`. For HIP device code, `<offload-kind>` is `hipv4`. Note that this command requires an (empty) entry for the host to also be present, with `<offload-kind>` `host`. The order of targets and inputs must match. `<target>` is an LLVM target triple, which is specified as `<isa>-<vendor>-<os>-<abi>`. `<abi>` is left empty for AMD targets.
+3. The device object files are combined into an offload bundle using `clang-offload-bundler`. This requires specifying the target as well as the offload kind for each device, in the form `<offload-kind>-<target>[-<target id>[:<target features>]]`. For HIP device code, `<offload-kind>` is `hipv4`. Note that this command requires an (empty) entry for the host to also be present, with `<offload-kind>` `host`. The order of targets and inputs must match. `<target>` is an LLVM target 4-tuple, which is specified as `<arch>-<vendor>-<os>-<env>`. 
 
     ```shell
     $ROCM_INSTALL_DIR/llvm/bin/clang-offload-bundler -type=o -bundle-align=4096 \
-            -targets=host-x86_64-unknown-linux,hipv4-amdgcn-amd-amdhsa--gfx1030,hipv4-... \
+            -targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa--gfx1030,hipv4-... \
             -input=/dev/null \
             -input=main_gfx1030.o -input=... \
             -output=offload_bundle.hipfb

--- a/HIP-Basic/llvm_ir_to_executable/README.md
+++ b/HIP-Basic/llvm_ir_to_executable/README.md
@@ -54,7 +54,7 @@ A HIP binary consists of a regular host executable, which has an offload bundle 
     ...
     ```
 
-3. The device object files are combined into an offload bundle using `clang-offload-bundler`. This requires specifying the target as well as the offload kind for each device, in the form `<offload-kind>-<target>[-<target id>[:<target features>]]`. For HIP device code, `<offload-kind>` is `hipv4`. Note that this command requires an (empty) entry for the host to also be present, with `<offload-kind>` `host`. The order of targets and inputs must match. `<target>` is an LLVM target 4-tuple, which is specified as `<arch>-<vendor>-<os>-<env>`. 
+3. The device object files are combined into an offload bundle using `clang-offload-bundler`. This requires specifying the target as well as the offload kind for each device, in the form `<offload-kind>-<target>[-<target id>[:<target features>]]`. For HIP device code, `<offload-kind>` is `hipv4`. Note that this command requires an (empty) entry for the host to also be present, with `<offload-kind>` `host`. The order of targets and inputs must match. `<target>` is an LLVM target 4-tuple, which is specified as `<arch>-<vendor>-<os>-<env>`.
 
     ```shell
     $ROCM_INSTALL_DIR/llvm/bin/clang-offload-bundler -type=o -bundle-align=4096 \


### PR DESCRIPTION
Change clang-offload-bundler to 4-tuple in the documentation. This PR aims to address: https://github.com/ROCm/rocm-examples/issues/186.