### PR TITLE
External CI: update branch triggers to new staging+mainline

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -13,7 +13,8 @@ trigger:
   batch: true
   branches:
     include:
-    - develop
+    - amd-staging
+    - amd-mainline
   paths:
     exclude:
     - .githooks
@@ -30,7 +31,8 @@ pr:
   autoCancel: true
   branches:
     include:
-    - develop
+    - amd-staging
+    - amd-mainline
   paths:
     exclude:
     - .githooks


### PR DESCRIPTION
Enables triggers for new amd-staging and amd-mainline branches.