### PR TITLE
Extra fatbin include for trailing underscore issue

### DIFF
--- a/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
@@ -9,17 +9,17 @@
 # Input: Bundled Object file .hipfb file
 # Output: Host Bundled Object File .o
 
-    .section .hip_gpubin_handle,"dw"
-    .globl __hip_gpubin_handle_
-    .p2align 12
-__hip_gpubin_handle_:
-    .zero 8
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"
     # Make the symbol that addresses the binary public.
+    .globl __hip_fatbin
+    # Define __hip_fatbin_ due to bug in some LLVM versions before ROCm 6.3
     .globl __hip_fatbin_
     # Give the bundle the required alignment of 4096 (2 ^ 12).
     .p2align 12
+    # Include the offload bundle
+__hip_fatbin:
+    .incbin "offload_bundle.hipfb"
+    # Also include for __hip_fatbin_ due to aforementioned LLVM bug
 __hip_fatbin_:
-    # Include the offload bundle.
     .incbin "offload_bundle.hipfb"


### PR DESCRIPTION
Some LLVM versions look for __hip_fatbin\_ instead of __hip_fatbin which causes a build error; this change allows the example to be built independent of LLVM versions.