### PR TITLE
Update GH Actions for new branch names

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -2,19 +2,19 @@ name: Build Applications
 
 on:
   push:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Applications/**'
       - '.github/workflows/**'
   pull_request:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Applications/**'
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: 6.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60300-1
+    ROCM_VERSION: 6.3.3
+    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
 
 jobs:
     build:

--- a/.github/workflows/build_applications_cuda.yml
+++ b/.github/workflows/build_applications_cuda.yml
@@ -2,12 +2,12 @@ name: Build Applications CUDA
 
 on:
   push:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Applications/**'
       - '.github/workflows/**'
   pull_request:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Applications/**'
       - '.github/workflows/**'

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,12 +1,13 @@
 name: Build Docker
+
 on:
   push:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Dockerfiles/**'
       - '.github/workflows/**'
   pull_request:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Dockerfiles/**'
       - '.github/workflows/**'

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -2,12 +2,12 @@ name: Build HIP-Basic
 
 on:
   push:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'HIP-Basic/**'
       - '.github/workflows/**'
   pull_request:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'HIP-Basic/**'
       - '.github/workflows/**'

--- a/.github/workflows/build_hip_basic_cuda.yml
+++ b/.github/workflows/build_hip_basic_cuda.yml
@@ -2,12 +2,12 @@ name: Build HIP-Basic CUDA
 
 on:
   push:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'HIP-Basic/**'
       - '.github/workflows/**'
   pull_request:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'HIP-Basic/**'
       - '.github/workflows/**'

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -2,12 +2,12 @@ name: Build Libraries
 
 on:
   push:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Libraries/**'
       - '.github/workflows/**'
   pull_request:
-    branches: [ develop, release/** ]
+    branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - 'Libraries/**'
       - '.github/workflows/**'

--- a/.github/workflows/build_libraries_cuda.yml
+++ b/.github/workflows/build_libraries_cuda.yml
@@ -2,12 +2,12 @@ name: Build Libraries CUDA
   
 on:  
   push:  
-    branches: [ develop, release/** ]  
+    branches: [ amd-staging, amd-mainline, release/** ]  
     paths:  
       - 'Libraries/**'  
       - '.github/workflows/**'  
   pull_request:  
-    branches: [ develop, release/** ]  
+    branches: [ amd-staging, amd-mainline, release/** ]  
     paths:  
       - 'Libraries/**'  
       - '.github/workflows/**'  

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,13 +3,13 @@ name: Linting
 on:
   push:
     branches:
-      - develop
-      - main
+      - amd-staging
+      - amd-mainline
       - 'release/rocm-rel*'
   pull_request:
     branches:
-      - develop
-      - main
+      - amd-staging
+      - amd-mainline
       - 'release/rocm-rel*'
 
 env:


### PR DESCRIPTION
Sets `amd-staging` and `amd-mainline` branches as workflow triggers.
Update `build_applications` ROCm version to 6.3.3.