### PR TITLE
fix: round up WarpCount in reduction to avoid 0 length array in HIP device code

### DIFF
--- a/Tutorials/reduction/example/v8.hip
+++ b/Tutorials/reduction/example/v8.hip
@@ -46,7 +46,7 @@ template<uint32_t BlockSize, uint32_t WarpSize, typename T, typename F>
 __global__ __launch_bounds__(BlockSize) void kernel(
     T* front, T* back, F op, T zero_elem, uint32_t front_size)
 {
-    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    static constexpr uint32_t WarpCount = (BlockSize + WarpSize - 1) / WarpSize;
 
     __shared__ T shared[WarpCount];
 

--- a/Tutorials/reduction/example/v9.hip
+++ b/Tutorials/reduction/example/v9.hip
@@ -46,7 +46,7 @@ template<uint32_t BlockSize, uint32_t WarpSize, uint32_t ItemsPerThread, typenam
 __global__ __launch_bounds__(BlockSize) void kernel(
     T* front, T* back, F op, T zero_elem, uint32_t front_size)
 {
-    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    static constexpr uint32_t WarpCount = (BlockSize + WarpSize - 1) / WarpSize;
 
     __shared__ T shared[WarpCount];
 

--- a/Tutorials/reduction/include/Reduction/v10.hpp
+++ b/Tutorials/reduction/include/Reduction/v10.hpp
@@ -53,7 +53,7 @@ template<typename T, typename F, uint32_t BlockSize, uint32_t WarpSize>
 __global__ static __launch_bounds__(BlockSize) void kernel(
     T* front, T* back, F op, T zero_elem, uint32_t front_size)
 {
-    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    static constexpr uint32_t WarpCount = (BlockSize + WarpSize - 1) / WarpSize;
     __shared__ T              shared[WarpCount];
 
     auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };

--- a/Tutorials/reduction/include/Reduction/v8.hpp
+++ b/Tutorials/reduction/include/Reduction/v8.hpp
@@ -53,7 +53,7 @@ template<typename T, typename F, uint32_t BlockSize, uint32_t WarpSize>
 __global__ static __launch_bounds__(BlockSize) void kernel(
     T* front, T* back, F op, T zero_elem, uint32_t front_size)
 {
-    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    static constexpr uint32_t WarpCount = (BlockSize + WarpSize - 1) / WarpSize;
     __shared__ T              shared[WarpCount];
 
     auto read_global_safe = [&](const uint32_t i) { return i < front_size ? front[i] : zero_elem; };

--- a/Tutorials/reduction/include/Reduction/v9.hpp
+++ b/Tutorials/reduction/include/Reduction/v9.hpp
@@ -54,7 +54,7 @@ template<typename T, typename F, uint32_t BlockSize, uint32_t WarpSize, uint32_t
 __global__ static __launch_bounds__(BlockSize) void kernel(
     T* front, T* back, F op, T zero_elem, uint32_t front_size)
 {
-    static constexpr uint32_t WarpCount = BlockSize / WarpSize;
+    static constexpr uint32_t WarpCount = (BlockSize + WarpSize - 1) / WarpSize;
 
     __shared__ T shared[WarpCount];
 


### PR DESCRIPTION
Fixes `error: zero-length arrays are not permitted in HIP device code` introduced by https://github.com/ROCm/llvm-project/commit/aa5be056b2e760a9bb25c01a8b91a61fd58d26db