### PR TITLE
Fix unresolved symbols in mcin files

### DIFF
--- a/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
@@ -8,18 +8,26 @@
 #
 # Input: Bundled Object file .hipfb file
 # Output: Host Bundled Object File .o
+    
+    .section .hip_gpubin_handle,"dw"
+    .globl __hip_gpubin_handle_
+    .p2align 12
+__hip_gpubin_handle_:
+     .zero 8
 
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"
     # Make the symbol that addresses the binary public.
     .globl __hip_fatbin
-    # Define __hip_fatbin_ due to bug in some LLVM versions before ROCm 6.3
-    .globl __hip_fatbin_
     # Give the bundle the required alignment of 4096 (2 ^ 12).
     .p2align 12
     # Include the offload bundle
 __hip_fatbin:
     .incbin "offload_bundle.hipfb"
-    # Also include for __hip_fatbin_ due to aforementioned LLVM bug
+
+    # Duplicate for __hip_fatbin_ due to bug in some LLVM versions before ROCm 6.3
+    .section .hip_fatbin_,"dw"
+    .globl __hip_fatbin_
+    .p2align 12
 __hip_fatbin_:
     .incbin "offload_bundle.hipfb"

--- a/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/assembly_to_executable/hip_obj_gen_win.mcin
@@ -13,7 +13,7 @@
     .globl __hip_gpubin_handle_
     .p2align 12
 __hip_gpubin_handle_:
-     .zero 8
+    .zero 8
 
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"

--- a/HIP-Basic/llvm_ir_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/llvm_ir_to_executable/hip_obj_gen_win.mcin
@@ -13,13 +13,21 @@
     .globl __hip_gpubin_handle_
     .p2align 12
 __hip_gpubin_handle_:
-    .zero 8
+     .zero 8
+
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"
     # Make the symbol that addresses the binary public.
-    .globl __hip_fatbin_
+    .globl __hip_fatbin
     # Give the bundle the required alignment of 4096 (2 ^ 12).
     .p2align 12
+    # Include the offload bundle
+__hip_fatbin:
+    .incbin "offload_bundle.hipfb"
+
+    # Duplicate for __hip_fatbin_ due to bug in some LLVM versions before ROCm 6.3
+    .section .hip_fatbin_,"dw"
+    .globl __hip_fatbin_
+    .p2align 12
 __hip_fatbin_:
-    # Include the offload bundle.
     .incbin "offload_bundle.hipfb"

--- a/HIP-Basic/llvm_ir_to_executable/hip_obj_gen_win.mcin
+++ b/HIP-Basic/llvm_ir_to_executable/hip_obj_gen_win.mcin
@@ -13,7 +13,7 @@
     .globl __hip_gpubin_handle_
     .p2align 12
 __hip_gpubin_handle_:
-     .zero 8
+    .zero 8
 
     # Tell the assembler to place the offload bundle in the appropriate section.
     .section .hip_fatbin,"dw"


### PR DESCRIPTION
Address regression caused by removing hip_gpubin_handle from mcin