### PR TITLE
return 1 when package not found

### DIFF
--- a/Libraries/hipBLAS/CMakeLists.txt
+++ b/Libraries/hipBLAS/CMakeLists.txt
@@ -46,7 +46,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(hipblas)
 if(NOT hipblas_FOUND)
     message(STATUS "hipBLAS could not be found, not building hipBLAS examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(gemm_strided_batched)

--- a/Libraries/hipCUB/CMakeLists.txt
+++ b/Libraries/hipCUB/CMakeLists.txt
@@ -46,7 +46,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(hipcub)
 if(NOT hipcub_FOUND)
     message(STATUS "hipCUB could not be found, not building hipCUB examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(device_radix_sort)

--- a/Libraries/hipFFT/CMakeLists.txt
+++ b/Libraries/hipFFT/CMakeLists.txt
@@ -46,7 +46,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(hipfft)
 if(NOT hipfft_FOUND)
     message(STATUS "hipFFT could not be found, not building hipFFT examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(multi_gpu)

--- a/Libraries/hipSOLVER/CMakeLists.txt
+++ b/Libraries/hipSOLVER/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT hipsolver_FOUND)
         STATUS
         "hipSOLVER could not be found, not building hipSOLVER examples"
     )
-    return()
+    return(1)
 endif()
 
 add_subdirectory(gels)

--- a/Libraries/rocBLAS/CMakeLists.txt
+++ b/Libraries/rocBLAS/CMakeLists.txt
@@ -51,7 +51,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(rocblas)
 if(NOT rocblas_FOUND)
     message(STATUS "rocBLAS could not be found, not building rocBLAS examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(level_1)

--- a/Libraries/rocFFT/CMakeLists.txt
+++ b/Libraries/rocFFT/CMakeLists.txt
@@ -51,7 +51,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(rocFFT)
 if(NOT rocFFT_FOUND)
     message(STATUS "rocFFT could not be found, not building rocFFT examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(callback)

--- a/Libraries/rocPRIM/CMakeLists.txt
+++ b/Libraries/rocPRIM/CMakeLists.txt
@@ -51,7 +51,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(rocprim)
 if(NOT rocprim_FOUND)
     message(STATUS "rocPRIM could not be found, not building rocPRIM examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(block_sum)

--- a/Libraries/rocRAND/CMakeLists.txt
+++ b/Libraries/rocRAND/CMakeLists.txt
@@ -46,7 +46,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(rocrand)
 if(NOT rocrand_FOUND)
     message(STATUS "rocRAND could not be found, not building rocRAND examples")
-    return()
+    return(1)
 endif()
 
 add_subdirectory(simple_distributions_cpp)

--- a/Libraries/rocSOLVER/CMakeLists.txt
+++ b/Libraries/rocSOLVER/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT rocblas_FOUND)
         STATUS
         "rocBLAS could not be found, not building rocSOLVER examples"
     )
-    return()
+    return(1)
 endif()
 
 find_package(rocsolver)
@@ -63,7 +63,7 @@ if(NOT rocsolver_FOUND)
         STATUS
         "rocSOLVER could not be found, not building rocSOLVER examples"
     )
-    return()
+    return(1)
 endif()
 
 add_subdirectory(getf2)

--- a/Libraries/rocSPARSE/CMakeLists.txt
+++ b/Libraries/rocSPARSE/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT rocsparse_FOUND)
         STATUS
         "rocSPARSE could not be found, not building rocSPARSE examples"
     )
-    return()
+    return(1)
 endif()
 
 add_subdirectory(level_2)

--- a/Libraries/rocThrust/CMakeLists.txt
+++ b/Libraries/rocThrust/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT rocthrust_FOUND)
         STATUS
         "rocThrust could not be found, not building rocThrust examples"
     )
-    return()
+    return(1)
 endif()
 
 add_subdirectory(device_ptr)


### PR DESCRIPTION
Before when packages are not found it would exit 0 causing CI to report as a pass. Now it will exit 1 and CI will fail.