### PR TITLE
memset d_y to 0

### DIFF
--- a/Libraries/rocSPARSE/level_2/csritsv/main.cpp
+++ b/Libraries/rocSPARSE/level_2/csritsv/main.cpp
@@ -94,7 +94,7 @@ int main()
     HIP_CHECK(hipMemcpy(d_csr_col_ind, h_csr_col_ind.data(), col_ind_size, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(d_csr_val, h_csr_val.data(), val_size, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(d_x, h_x.data(), x_size, hipMemcpyHostToDevice));
-    HIP_CHECK(hipMemcpy(d_y, h_y.data(), y_size, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(d_y, 0, y_size));
 
     // 3. Initialize rocSPARSE by creating a handle.
     rocsparse_handle handle;


### PR DESCRIPTION
csritsv is an iterative solver that can be impacted by the initial guess of the solution.
As we want to use a zero initial guess for this example, it is a better practice to use directly a memset on the device memory instead of copying a host vector.