### PR TITLE
Change build libraries workflow to use self hosted runner

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -33,6 +33,11 @@ jobs:
             echo "JSON_ARRAY is"
             echo $JSON_ARRAY
             echo "files=$JSON_ARRAY"  >> $GITHUB_OUTPUT 
+
+        # Clean the workspace here since other jobs may not have the permissions to do so later
+        # (needed for self-hosted runners)
+        - name: Clean the workspace
+          run: find $GITHUB_WORKSPACE -mindepth 1 -delete
     build:  
       name: Build Docker Images
       runs-on: self-hosted  
@@ -53,5 +58,10 @@ jobs:
             context: Dockerfiles/ 
             file: Dockerfiles/${{matrix.file}} 
             push: false          
-            tags: rocm-examples/dockerci:latest  
+            tags: rocm-examples/dockerci:latest
+
+        # Clean the workspace here since other jobs may not have the permissions to do so later
+        # (needed for self-hosted runners)
+        - name: Clean the workspace
+          run: find $GITHUB_WORKSPACE -mindepth 1 -delete  
 

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -19,12 +19,11 @@ env:
 jobs:
     build:
         name: "Build Libraries Examples"
-        runs-on: ubuntu-latest
+        runs-on: self-hosted
         container:
             image: ubuntu:22.04
         steps:
           - uses: actions/checkout@v4
-
           - name: Install dependencies
             run: |
                   apt-get update -qq &&
@@ -58,3 +57,8 @@ jobs:
               cd Libraries && mkdir build && cd build
               cmake -DGPU_ARCHITECTURES=all -S ..
               cmake --build . -j 4
+          
+          # Clean the workspace here since other jobs may not have the permissions to do so later
+          # (needed for self-hosted runners)
+          - name: Clean the workspace
+            run: find $GITHUB_WORKSPACE -mindepth 1 -delete

--- a/.github/workflows/build_libraries_cuda.yml
+++ b/.github/workflows/build_libraries_cuda.yml
@@ -19,14 +19,13 @@ env:
 jobs:  
   build:  
     name: "Build Libraries with CUDA"  
-    runs-on: ubuntu-latest  
+    runs-on: self-hosted  
     container:  
       image:  nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
   
     steps:  
       - name: Checkout Repository  
         uses: actions/checkout@v4  
-  
       - name: Install System Dependencies  
         run: |
           apt-get update -qq && 
@@ -89,4 +88,9 @@ jobs:
         run: |  
           cd Libraries/rocRAND
           make GPU_RUNTIME=CUDA -j4
+
+      # Clean the workspace here since other jobs may not have the permissions to do so later
+      # (needed for self-hosted runners)
+      - name: Clean the workspace
+        run: find $GITHUB_WORKSPACE -mindepth 1 -delete
       


### PR DESCRIPTION
ubuntu-runner does not have enough space for these workflows.

See: https://github.com/ROCm/rocm-examples/actions/runs/13934512198/job/39306162921