### PR TITLE
Correction for hipSOLVER workspace

### DIFF
--- a/Libraries/hipSOLVER/gesvd/main.cpp
+++ b/Libraries/hipSOLVER/gesvd/main.cpp
@@ -120,7 +120,7 @@ int main(const int argc, char* argv[])
     // Query working space.
     HIPSOLVER_CHECK(
         hipsolverDgesvd_bufferSize(hipsolver_handle, left_svect, right_svect, m, n, &lwork));
-    HIP_CHECK(hipMalloc(&d_work, lwork));
+    HIP_CHECK(hipMalloc(&d_work, sizeof(double) * lwork));
 
     // Compute the singular values (vector S) and singular vectors (matrices U and V_H) of A.
     HIPSOLVER_CHECK(hipsolverDgesvd(hipsolver_handle,

--- a/Libraries/hipSOLVER/syevd/main.cpp
+++ b/Libraries/hipSOLVER/syevd/main.cpp
@@ -72,7 +72,7 @@ int main(const int /*argc*/, char* /*argv*/[])
                                                lda,
                                                d_W,
                                                &lwork));
-    HIP_CHECK(hipMalloc(&d_work, lwork));
+    HIP_CHECK(hipMalloc(&d_work, sizeof(double) * lwork));
 
     // Compute the eigenvalues (written to d_W).
     HIPSOLVER_CHECK(hipsolverDsyevd(hipsolver_handle,

--- a/Libraries/hipSOLVER/syevdx/main.cpp
+++ b/Libraries/hipSOLVER/syevdx/main.cpp
@@ -92,7 +92,7 @@ int main(const int /*argc*/, char* /*argv*/[])
                                                   &nev,
                                                   d_W,
                                                   &lwork));
-    HIP_CHECK(hipMalloc(&d_work, lwork));
+    HIP_CHECK(hipMalloc(&d_work, sizeof(double) * lwork));
 
     // Compute the eigenvalues (written to d_W) and eigenvectors (written to d_A) of matrix A.
     HIPSOLVER_CHECK(hipsolverDnDsyevdx(hipsolver_handle,

--- a/Libraries/hipSOLVER/syevj_batched/main.cpp
+++ b/Libraries/hipSOLVER/syevj_batched/main.cpp
@@ -119,7 +119,7 @@ int main(const int argc, char* argv[])
                                                       &lwork,
                                                       params,
                                                       batch_count));
-    HIP_CHECK(hipMalloc(&d_work, lwork));
+    HIP_CHECK(hipMalloc(&d_work, sizeof(double) * lwork));
 
     // 7. Invoke hipsolverDsyevjBatched to compute the eigenvalues (written to d_W) and
     // eigenvectors (written to d_A) of the matrices in the batch.

--- a/Libraries/hipSOLVER/sygvd/main.cpp
+++ b/Libraries/hipSOLVER/sygvd/main.cpp
@@ -100,7 +100,7 @@ int main()
                                                ldb,
                                                d_W,
                                                &lwork));
-    HIP_CHECK(hipMalloc(&d_work, lwork));
+    HIP_CHECK(hipMalloc(&d_work, sizeof(double) * lwork));
 
     // Compute the eigenvalues (written to d_W) and eigenvectors (written to d_A) of the pair (A, B).
     HIPSOLVER_CHECK(hipsolverDsygvd(hipsolver_handle,

--- a/Libraries/hipSOLVER/sygvj/main.cpp
+++ b/Libraries/hipSOLVER/sygvj/main.cpp
@@ -102,7 +102,7 @@ int main(const int /*argc*/, char* /*argv*/[])
                                                d_W,
                                                &lwork,
                                                syevj_params));
-    HIP_CHECK(hipMalloc(&d_work, lwork));
+    HIP_CHECK(hipMalloc(&d_work, sizeof(double) * lwork));
 
     // Compute spectrum (written to d_W) and eigenvectors (writtten to d_A).
     HIPSOLVER_CHECK(hipsolverDsygvj(hipsolver_handle,


### PR DESCRIPTION
Due to an oversight on my part, some `bufferSize` methods in hipSOLVER return an incorrect value. We have a PR open to correct this (https://github.com/ROCm/hipSOLVER/pull/357), and it will require the corresponding examples to be updated to prevent breakages.