### PR TITLE
Replace deprecated hipBLAS 3.0 complex types

### DIFF
--- a/Libraries/hipBLAS/gemm_strided_batched/README.md
+++ b/Libraries/hipBLAS/gemm_strided_batched/README.md
@@ -59,8 +59,8 @@ We can apply the same multiplication operator for several matrices if we combine
   - `H`(half-precision: `hipblasHalf`)
   - `S` (single-precision: `float`)
   - `D` (double-precision: `double`)
-  - `C` (single-precision complex: `hipblasComplex`)
-  - `Z` (double-precision complex: `hipblasDoubleComplex`).
+  - `C` (single-precision complex: `hipComplex`)
+  - `Z` (double-precision complex: `hipDoubleComplex`).
 
     Input parameters for `hipblasSgemmStridedBatched`:
     - `hipblasHandle_t handle`

--- a/Libraries/hipBLAS/her/README.md
+++ b/Libraries/hipBLAS/her/README.md
@@ -35,7 +35,7 @@ The application provides the following optional command line arguments:
 - hipBLAS is initialized by calling `hipblasCreate(hipblasHandle_t*)` and it is terminated by calling `hipblasDestroy(hipblasHandle_t)`.
 - The _pointer mode_ controls whether scalar parameters must be allocated on the host (`HIPBLAS_POINTER_MODE_HOST`) or on the device (`HIPBLAS_POINTER_MODE_DEVICE`). It is controlled by `hipblasSetPointerMode`.
 - `hipblasSetVector` and `hipblasSetMatrix` are helper functions provided by the hipBLAS API for writing data to the GPU, whereas `hipblasGetVector` and `hipblasGetMatrix` are intended for retrieving data from the GPU. Note that `hipMemcpy` can also be used to copy/get data to/from the GPU in the usual way.
-- `hipblas[CZ]her2(handle, uplo, n, *alpha, *x, incx, *y, incy, *AP, lda)` computes a Hermitian rank-2 update. The character matched in `[CZ]` denotes the data type of the operation, and can be either `C` (complex float: `hipblasComplex`), or `Z` (complex double: `hipblasDoubleComplex`). The required arguments come as the following:
+- `hipblas[CZ]her2(handle, uplo, n, *alpha, *x, incx, *y, incy, *AP, lda)` computes a Hermitian rank-2 update. The character matched in `[CZ]` denotes the data type of the operation, and can be either `C` (complex float: `hipComplex`), or `Z` (complex double: `hipDoubleComplex`). The required arguments come as the following:
   - `handle`, the hipBLAS API handle.
   - `uplo`. Because a Hermitian matrix is symmetric over the diagonal, except that the values in the upper triangle are the complex conjugate of the values in the lower triangle, the required work can be reduced by only updating a single half of the matrix. The part of the matrix to update is given by `uplo`: `HIPBLAS_FILL_MODE_UPPER` (used in this example) indicates that the upper triangle of $A$ should be updated, `HIPBLAS_FILL_MODE_LOWER` indicates that the lower triangle of $A$ should be updated and `HIPBLAS_FILL_MODE_FULL` indicates that the full matrix will be updated.
   - `n` gives the dimensions of the vector and matrix inputs.
@@ -44,7 +44,7 @@ The application provides the following optional command line arguments:
   - `AP` is the device pointer to matrix $A$ in device memory.
   - `lda` is the _leading dimension_ of $A$, that is, the number of elements between the starts of the columns of $A$. Note that hipBLAS matrices are laid out in _column major_ ordering.
 
-- If `ROCM_MATHLIBS_API_USE_HIP_COMPLEX` is defined (adding `#define ROCM_MATHLIBS_API_USE_HIP_COMPLEX` before `#include <hipblas/hipblas.h>`), the hipBLAS API is exposed as using the hip defined complex types. That is, `hipblasComplex` is a typedef of `hipFloatComplex` (also named `hipComplex`) and they can be used equivalently.
+- If `ROCM_MATHLIBS_API_USE_HIP_COMPLEX` is defined (adding `#define ROCM_MATHLIBS_API_USE_HIP_COMPLEX` before `#include <hipblas/hipblas.h>`), the hipBLAS API is exposed as using the hip defined complex types. That is, `hipComplex` is a typedef of `hipFloatComplex` (also named `hipComplex`) and they can be used equivalently.
 - `hipFloatComplex` and `std::complex<float>` have compatible memory layout, and performing a memory copy between values of these types will correctly perform the expected copy.
 - `hipCaddf(a, b)` adds `hipFloatComplex` values `a` and `b` element-wise together. This function is from a family of host/device HIP functions which operate on complex values.
 
@@ -55,7 +55,7 @@ The application provides the following optional command line arguments:
 - `HIPBLAS_FILL_MODE_UPPER`
 - `HIPBLAS_POINTER_MODE_HOST`
 - `hipblasCher2`
-- `hipblasComplex`
+- `hipComplex`
 - `hipblasCreate`
 - `hipblasDestroy`
 - `hipblasFillMode_t`

--- a/Libraries/hipBLAS/her/main.hip
+++ b/Libraries/hipBLAS/her/main.hip
@@ -24,7 +24,11 @@
 #include "example_utils.hpp"
 #include "hipblas_utils.hpp"
 
-#define ROCM_MATHLIBS_API_USE_HIP_COMPLEX
+#if hipblasVersionMajor >= 3
+#define HIPBLAS_CHER2 hipblasCher2
+#else
+#define HIPBLAS_CHER2 hipblasCher2_v2
+#endif
 #include <hipblas/hipblas.h>
 
 #include <hip/hip_complex.h>
@@ -98,7 +102,7 @@ int main(const int argc, const char** argv)
 
     // Scalar multiplier.
     const float          alpha   = parser.get<float>("a");
-    const hipblasComplex h_alpha = hipblasComplex(alpha, 0.0f);
+    const hipComplex h_alpha = hipComplex(alpha, 0.0f);
 
     // The leading dimension (the stride between column starts) of the matrix A.
     // The matrix is packed into memory, so the leading dimension is equal to
@@ -149,12 +153,12 @@ int main(const int argc, const char** argv)
     HIPBLAS_CHECK(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
 
     // Allocate device memory using hipMalloc.
-    hipblasComplex* d_a{};
-    hipblasComplex* d_x{};
-    hipblasComplex* d_y{};
-    HIP_CHECK(hipMalloc(&d_a, size_a * sizeof(hipblasComplex)));
-    HIP_CHECK(hipMalloc(&d_x, size_x * sizeof(hipblasComplex)));
-    HIP_CHECK(hipMalloc(&d_y, size_y * sizeof(hipblasComplex)));
+    hipComplex* d_a{};
+    hipComplex* d_x{};
+    hipComplex* d_y{};
+    HIP_CHECK(hipMalloc(&d_a, size_a * sizeof(hipComplex)));
+    HIP_CHECK(hipMalloc(&d_x, size_x * sizeof(hipComplex)));
+    HIP_CHECK(hipMalloc(&d_y, size_y * sizeof(hipComplex)));
 
     // Copy the input vectors from the host to the device. The layout of std::complex<float> is
     // compatible with that of hipFloatComplex.
@@ -164,7 +168,7 @@ int main(const int argc, const char** argv)
     // Copy the input matrix from the host to the device, invoke hipBLAS HER2 function and
     // fetch the results from the device to the host.
     HIPBLAS_CHECK(hipblasSetMatrix(n, n, sizeof(hipFloatComplex), h_a.data(), lda, d_a, lda));
-    HIPBLAS_CHECK(hipblasCher2(handle, fill, n, &h_alpha, d_x, incx, d_y, incy, d_a, lda));
+    HIPBLAS_CHECK(HIPBLAS_CHER2(handle, fill, n, &h_alpha, d_x, incx, d_y, incy, d_a, lda));
     HIPBLAS_CHECK(hipblasGetMatrix(n, n, sizeof(hipFloatComplex), d_a, lda, h_a.data(), lda));
 
     // Destroy the hipBLAS handle.

--- a/Libraries/hipBLAS/scal/README.md
+++ b/Libraries/hipBLAS/scal/README.md
@@ -32,8 +32,8 @@ The application provides the following optional command line arguments:
 - `hipblas[SDCZ]scal` multiplies each element of the vector by a scalar. Depending on the character matched in `[SDCZ]`, the scaling can be obtained with different precisions:
   - `S` (single-precision: `float`)
   - `D` (double-precision: `double`)
-  - `C` (single-precision complex: `hipblasComplex`)
-  - `Z` (double-precision complex: `hipblasDoubleComplex`).
+  - `C` (single-precision complex: `hipComplex`)
+  - `Z` (double-precision complex: `hipDoubleComplex`).
 
 ## Demonstrated API Calls
 

--- a/Libraries/hipSOLVER/gesvd/README.md
+++ b/Libraries/hipSOLVER/gesvd/README.md
@@ -96,8 +96,8 @@ The application provides the following optional command line arguments:
 
     - `S` (single-precision real: `float`)
     - `D` (double-precision real: `double`)
-    - `C` (single-precision complex: `hipblasComplex`)
-    - `Z` (double-precision complex: `hipblasDoubleComplex`).
+    - `C` (single-precision complex: `hipComplex`)
+    - `Z` (double-precision complex: `hipDoubleComplex`).
 
     Return type: `hipblasStatus_t`.
 

--- a/Libraries/hipSOLVER/syevdx/README.md
+++ b/Libraries/hipSOLVER/syevdx/README.md
@@ -116,8 +116,8 @@ $A x_i = \lambda_i x_i$  for $i = 0, \dots, n-1$.
 
     - `S` (single-precision real: `float`)
     - `D` (double-precision real: `double`)
-    - `C` (single-precision complex: `hipblasComplex`)
-    - `Z` (double-precision complex: `hipblasDoubleComplex`).
+    - `C` (single-precision complex: `hipComplex`)
+    - `Z` (double-precision complex: `hipDoubleComplex`).
 
     Return type: `hipblasStatus_t`.
 

--- a/Libraries/hipSOLVER/syevj_batched/README.md
+++ b/Libraries/hipSOLVER/syevj_batched/README.md
@@ -111,8 +111,8 @@ The application provides the following command line arguments:
     The correct function signature should be chosen based on the datatype of the input matrices:
     - `S` (single-precision real: `float`)
     - `D` (double-precision real: `double`)
-    - `C` (single-precision complex: `hipblasComplex`)
-    - `Z` (double-precision complex: `hipblasDoubleComplex`).
+    - `C` (single-precision complex: `hipComplex`)
+    - `Z` (double-precision complex: `hipDoubleComplex`).
 
     Return type: `hipblasStatus_t`.
 - The `hipblasPointerMode_t` type controls whether scalar parameters must be allocated on the host (`HIPBLAS_POINTER_MODE_HOST`) or on the device (`HIPBLAS_POINTER_MODE_DEVICE`). It is set by using `hipblasSetPointerMode`.

--- a/Libraries/hipSOLVER/sygvd/README.md
+++ b/Libraries/hipSOLVER/sygvd/README.md
@@ -114,8 +114,8 @@ $(A - \lambda_i B)x_i = 0$  for $i = 0, \dots, n-1$.
 
     - `S` (single-precision real: `float`)
     - `D` (double-precision real: `double`)
-    - `C` (single-precision complex: `hipblasComplex`)
-    - `Z` (double-precision complex: `hipblasDoubleComplex`).
+    - `C` (single-precision complex: `hipComplex`)
+    - `Z` (double-precision complex: `hipDoubleComplex`).
 
     Return type: `hipblasStatus_t`.
 


### PR DESCRIPTION
Updates the hipBLAS/her example to use `hipComplex` types.
- hipBLAS 3.0 enforced the deprecation and replacement of two datatypes:
  - `hipblasComplex` -> `hipComplex`
  - `hipblasDoubleComplex` -> `hipDoubleComplex`
- Reference:
  - https://github.com/ROCm/hipBLAS/pull/982
  - https://rocm.docs.amd.com/projects/hipBLAS/en/develop/reference/deprecation.html#removed-in-hipblas-3-0

Adds a directive to choose between `hipblasCher2` and `hipblasCher2_v2` depending on the hipBLAS version
- In hipBLAS < 3.0, `hipblasCher2()` accepts `hipblasComplex`, and `hipblasCher2_v2()` accepts `hipComplex`
- Starting in 3.0, `hipblasCher2()` accepts `hipComplex`, and `hipblasCher2_v2()` no longer exists
- Azure CI is on staging hipBLAS, while GH actions is on release ROCm
- To get builds passing in both CIs, we need to check the hipBLAS version and choose the appropriate API call