### PR TITLE
Update GH actions to 6.4, set GPU_TARGETS

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -13,8 +13,9 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: 6.3.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
+    ROCM_VERSION: 6.4
+    AMDGPU_INSTALLER_VERSION: 6.4.60400-1
+    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:
     build:
@@ -24,7 +25,6 @@ jobs:
             image: ubuntu:22.04
         steps:
           - uses: actions/checkout@v4
-
           - name: Install dependencies
             run: |
                   apt-get update -qq &&
@@ -51,5 +51,5 @@ jobs:
             shell: bash
             run: |
               cd Applications && mkdir build && cd build
-              cmake -DGPU_ARCHITECTURES=all -S ..
+              cmake -DGPU_TARGETS="${GPU_TARGETS}" -S ..
               cmake --build . -j 4

--- a/.github/workflows/build_applications_cuda.yml
+++ b/.github/workflows/build_applications_cuda.yml
@@ -13,13 +13,13 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: 6.3.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
+    ROCM_VERSION: 6.4
+    AMDGPU_INSTALLER_VERSION: 6.4.60400-1
 
 jobs:
     build:
         name: "Build Applications Examples"
-        runs-on: ubuntu-latest
+        runs-on: self-hosted
         container:
             image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
 
@@ -40,11 +40,11 @@ jobs:
               wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
               apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
               apt-get update -qq &&
-              apt-get install -y hip-runtime-nvidia hip-dev hipify-clang
+              apt-get install -y cuda hip-dev hipify-clang
               echo "/opt/rocm/bin" >> $GITHUB_PATH
               echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
               echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-            
+
           - name: Configure and Build
             shell: bash
             run: |

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -13,8 +13,9 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: 6.3.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
+    ROCM_VERSION: 6.4
+    AMDGPU_INSTALLER_VERSION: 6.4.60400-1
+    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:
     build:
@@ -24,7 +25,6 @@ jobs:
             image: ubuntu:22.04
         steps:
           - uses: actions/checkout@v4
-
           - name: Install dependencies
             run: |
                   apt-get update -qq &&
@@ -32,7 +32,6 @@ jobs:
                     python3 python3-pip libglfw3-dev libvulkan-dev locales wget
                   python3 -m pip install --upgrade pip
                   python3 -m pip install cmake
-
           - name: Install ROCm Dev
             run: |
                   export DEBIAN_FRONTEND=noninteractive
@@ -44,10 +43,9 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
-
           - name: Configure and Build
             shell: bash
             run: |
               cd HIP-Basic && mkdir build && cd build
-              cmake -DGPU_ARCHITECTURES=all -S ..
+              cmake -DGPU_TARGETS="${GPU_TARGETS}" -S ..
               cmake --build . -j 4

--- a/.github/workflows/build_hip_basic_cuda.yml
+++ b/.github/workflows/build_hip_basic_cuda.yml
@@ -13,13 +13,13 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: 6.3.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
+    ROCM_VERSION: 6.4
+    AMDGPU_INSTALLER_VERSION: 6.4.60400-1
 
 jobs:
     build:
         name: "Build HIP Examples"
-        runs-on: ubuntu-latest
+        runs-on: self-hosted
         container:
             image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
 
@@ -40,7 +40,7 @@ jobs:
               wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
               apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
               apt-get update -qq &&
-              apt-get install -y hip-dev hipify-clang hip-runtime-nvidia
+              apt-get install -y cuda hip-dev hipify-clang
 
           - name: Configure and Build
             shell: bash

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -13,8 +13,9 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: 6.3.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
+    ROCM_VERSION: 6.4
+    AMDGPU_INSTALLER_VERSION: 6.4.60400-1
+    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:
     build:
@@ -55,9 +56,9 @@ jobs:
             shell: bash
             run: |
               cd Libraries && mkdir build && cd build
-              cmake -DGPU_ARCHITECTURES=all -S ..
+              cmake -DGPU_TARGETS="${GPU_TARGETS}" -S ..
               cmake --build . -j 4
-          
+
           # Clean the workspace here since other jobs may not have the permissions to do so later
           # (needed for self-hosted runners)
           - name: Clean the workspace

--- a/.github/workflows/build_libraries_cuda.yml
+++ b/.github/workflows/build_libraries_cuda.yml
@@ -1,46 +1,46 @@
-name: Build Libraries CUDA  
-  
-on:  
-  push:  
-    branches: [ amd-staging, amd-mainline, release/** ]  
-    paths:  
-      - 'Libraries/**'  
-      - '.github/workflows/**'  
-  pull_request:  
-    branches: [ amd-staging, amd-mainline, release/** ]  
-    paths:  
-      - 'Libraries/**'  
-      - '.github/workflows/**'  
-  
+name: Build Libraries CUDA
+
+on:
+  push:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'Libraries/**'
+      - '.github/workflows/**'
+  pull_request:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'Libraries/**'
+      - '.github/workflows/**'
+
 env:
-    ROCM_VERSION: 6.3.3
-    AMDGPU_INSTALLER_VERSION: 6.3.60303-1
-  
-jobs:  
-  build:  
-    name: "Build Libraries with CUDA"  
-    runs-on: self-hosted  
-    container:  
+    ROCM_VERSION: 6.4
+    AMDGPU_INSTALLER_VERSION: 6.4.60400-1
+
+jobs:
+  build:
+    name: "Build Libraries with CUDA"
+    runs-on: self-hosted
+    container:
       image:  nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
-  
-    steps:  
-      - name: Checkout Repository  
-        uses: actions/checkout@v4  
-      - name: Install System Dependencies  
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Install System Dependencies
         run: |
-          apt-get update -qq && 
+          apt-get update -qq &&
           apt-get install -y build-essential g++ glslang-tools python3 python3-pip libglfw3-dev libvulkan-dev locales wget git
-          python3 -m pip install --upgrade pip  
-          python3 -m pip install cmake  
-      
+          python3 -m pip install --upgrade pip
+          python3 -m pip install cmake
+
       - name: Install Hip for CUDA
         run: |
           export DEBIAN_FRONTEND=noninteractive
           wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
           apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
           apt-get update -qq &&
-          apt-get install -y hip-runtime-nvidia hip-dev
-      
+          apt-get install -y cuda hip-dev
+
       - name: Build and install hipCUB
         run: |
           mkdir tmp && cd tmp
@@ -50,13 +50,13 @@ jobs:
           make -j4
           make install
           cd ../ && rm -rf tmp
-      
+
       - name: Build hipCUB example
-        shell: bash  
-        run: |  
+        shell: bash
+        run: |
           cd Libraries/hipCUB
           make GPU_RUNTIME=CUDA -j4
-      
+
       - name: Build and install hipFFT
         run: |
           mkdir tmp && cd tmp
@@ -66,10 +66,10 @@ jobs:
           make -j4
           make install
           cd ../ && rm -rf tmp
-      
+
       - name: Build hipFFT example
-        shell: bash  
-        run: |  
+        shell: bash
+        run: |
           cd Libraries/hipFFT
           make GPU_RUNTIME=CUDA -j4
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build rocRAND example
         shell: bash
-        run: |  
+        run: |
           cd Libraries/rocRAND
           make GPU_RUNTIME=CUDA -j4
 
@@ -93,4 +93,4 @@ jobs:
       # (needed for self-hosted runners)
       - name: Clean the workspace
         run: find $GITHUB_WORKSPACE -mindepth 1 -delete
-      
+


### PR DESCRIPTION
Updated the ROCm version in GitHub actions to 6.4.

On 6.4, `hip-dev` introduces a dependency on `hipcc`, which was not present in 6.3.3. `hipcc` conflicts with the `hipcc-nvidia` package, which is installed through `hip-runtime-nvidia`.

`hip-runtime-nvidia` is simply a meta-package that installs `cuda` and some rocm utils, so just skip it and install `cuda` directly to get builds working.

Added a `GPU_TARGETS` CMake flags to specify which archs to build for, the arch list was taken from the generated files here:
https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/assembly_to_executable