### PR TITLE
Add Windows CI for verifying and building Visual Studio solutions

### DIFF
--- a/.github/workflows/build_applications_vs.yml
+++ b/.github/workflows/build_applications_vs.yml
@@ -1,0 +1,63 @@
+name: Build Applications VS
+
+on:
+  push:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'Applications/**'
+      - '.github/workflows/**'
+      - 'Scripts/VisualStudio/**'
+  pull_request:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'Applications/**'
+      - '.github/workflows/**'
+      - 'Scripts/VisualStudio/**'
+
+env:
+    PLATFORM_TOOLSET_VERSION: 6.2
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
+    HIPSDK_INSTALLER_VERSION: 24.Q4
+
+jobs:
+    build:
+        name: "Build Applications Examples"
+        strategy:
+          matrix:
+            config: [Debug, Release]
+        runs-on: windows-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: microsoft/setup-msbuild@v2
+          - name: Install HIP SDK
+            shell: pwsh
+            run: |
+                  $PSVersionTable
+                  $ProgressPreference = 'SilentlyContinue'
+                  Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
+                  Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe -OutFile Setup.exe
+                  Write-Host "Installing HIP SDK"
+                  Start-Process Setup.exe -ArgumentList '-install','-log',"installer_log.txt" -NoNewWindow -Wait
+                  if (Test-Path -Path "${{ env.HIP_PATH }}") {
+                      Write-Host "HIP_PATH directory exists: ${{ env.HIP_PATH }}"
+                      Write-Host "HIP SDK installed successfully"
+                  } else {
+                      Write-Host "HIP_PATH directory DOES NOT exist: ${{ env.HIP_PATH }}"
+                      Write-Host "HIP SDK installation failed"
+                      Exit 1
+                  }
+                  msbuild -version
+          - name: Install dependencies
+            shell: pwsh
+            run: |
+                  python3 -m pip install rich
+          - name: Check GUID
+            shell: pwsh
+            run: |
+                  python3 Scripts/VisualStudio/check_vs_files.py
+          - name: Build ${{ matrix.config }} x64
+            shell: pwsh
+            run: |
+                  msbuild Scripts\VisualStudio\build.proj -maxCpuCount -detailedSummary -property:"Category=Applications;Configuration=${{ matrix.config }};Platform=x64"
+                  Write-Host "msbuild returned: $LastExitCode"
+                  Exit $LastExitCode

--- a/.github/workflows/build_hip_basic_vs.yml
+++ b/.github/workflows/build_hip_basic_vs.yml
@@ -1,0 +1,63 @@
+name: Build HIP-Basic VS
+
+on:
+  push:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'HIP-Basic/**'
+      - '.github/workflows/**'
+      - 'Scripts/VisualStudio/**'
+  pull_request:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'HIP-Basic/**'
+      - '.github/workflows/**'
+      - 'Scripts/VisualStudio/**'
+
+env:
+    PLATFORM_TOOLSET_VERSION: 6.2
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
+    HIPSDK_INSTALLER_VERSION: 24.Q4
+
+jobs:
+    build:
+        name: "Build HIP Examples"
+        strategy:
+          matrix:
+            config: [Debug, Release]
+        runs-on: windows-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: microsoft/setup-msbuild@v2
+          - name: Install HIP SDK
+            shell: pwsh
+            run: |
+                  $PSVersionTable
+                  $ProgressPreference = 'SilentlyContinue'
+                  Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
+                  Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe -OutFile Setup.exe
+                  Write-Host "Installing HIP SDK"
+                  Start-Process Setup.exe -ArgumentList '-install','-log',"installer_log.txt" -NoNewWindow -Wait
+                  if (Test-Path -Path "${{ env.HIP_PATH }}") {
+                      Write-Host "HIP_PATH directory exists: ${{ env.HIP_PATH }}"
+                      Write-Host "HIP SDK installed successfully"
+                  } else {
+                      Write-Host "HIP_PATH directory DOES NOT exist: ${{ env.HIP_PATH }}"
+                      Write-Host "HIP SDK installation failed"
+                      Exit 1
+                  }
+                  msbuild -version
+          - name: Install dependencies
+            shell: pwsh
+            run: |
+                  python3 -m pip install rich
+          - name: Check GUID
+            shell: pwsh
+            run: |
+                  python3 Scripts/VisualStudio/check_vs_files.py
+          - name: Build ${{ matrix.config }} x64
+            shell: pwsh
+            run: |
+                  msbuild Scripts\VisualStudio\build.proj -maxCpuCount -detailedSummary -property:"Category=HIP-Basic;Configuration=${{ matrix.config }};Platform=x64"
+                  Write-Host "msbuild returned: $LastExitCode"
+                  Exit $LastExitCode

--- a/.github/workflows/build_libraries_vs.yml
+++ b/.github/workflows/build_libraries_vs.yml
@@ -1,0 +1,64 @@
+name: Build Libraries VS
+
+on:
+  push:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'Libraries/**'
+      - '.github/workflows/**'
+      - 'Scripts/VisualStudio/**'
+  pull_request:
+    branches: [ amd-staging, amd-mainline, release/** ]
+    paths:
+      - 'Libraries/**'
+      - '.github/workflows/**'
+      - 'Scripts/VisualStudio/**'
+
+env:
+    PLATFORM_TOOLSET_VERSION: 6.2
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
+    HIPSDK_INSTALLER_VERSION: 24.Q4
+
+jobs:
+    build:
+        name: "Build Libraries Examples"
+        strategy:
+          matrix:
+            config: [Debug, Release]
+            vsversion: [2017, 2019, 2022]
+        runs-on: windows-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: microsoft/setup-msbuild@v2
+          - name: Install HIP SDK
+            shell: pwsh
+            run: |
+                  $PSVersionTable
+                  $ProgressPreference = 'SilentlyContinue'
+                  Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
+                  Invoke-WebRequest -Uri https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe -OutFile Setup.exe
+                  Write-Host "Installing HIP SDK"
+                  Start-Process Setup.exe -ArgumentList '-install','-log',"installer_log.txt" -NoNewWindow -Wait
+                  if (Test-Path -Path "${{ env.HIP_PATH }}") {
+                      Write-Host "HIP_PATH directory exists: ${{ env.HIP_PATH }}"
+                      Write-Host "HIP SDK installed successfully"
+                  } else {
+                      Write-Host "HIP_PATH directory DOES NOT exist: ${{ env.HIP_PATH }}"
+                      Write-Host "HIP SDK installation failed"
+                      Exit 1
+                  }
+                  msbuild -version
+          - name: Install dependencies
+            shell: pwsh
+            run: |
+                  python3 -m pip install rich
+          - name: Check GUID
+            shell: pwsh
+            run: |
+                  python3 Scripts/VisualStudio/check_vs_files.py
+          - name: Build ${{ matrix.config }} x64 ${{ matrix.vsversion }}
+            shell: pwsh
+            run: |
+                  msbuild Scripts\VisualStudio\build.proj -maxCpuCount -detailedSummary -property:"Category=Libraries;Configuration=${{ matrix.config }};Platform=x64;VSVersion=${{ matrix.vsversion }}" -target:"Build"
+                  Write-Host "msbuild returned: $LastExitCode"
+                  Exit $LastExitCode

--- a/Scripts/VisualStudio/build.proj
+++ b/Scripts/VisualStudio/build.proj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+     <Platform Condition="'$(Platform)' == ''">x64</Platform>
+  </PropertyGroup>
+  <ItemGroup>
+    <Solution Condition="'$(Category)'=='All'" Include="..\..\*\**\*.sln" Exclude="..\..\HIP-Basic\vulkan_interop\**\*.sln;..\..\HIP-Basic\opengl_interop\**\*.sln;..\..\HIP-Basic\static_host_library\**\*.sln">
+      <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
+    </Solution>
+    <Solution Condition="'$(Category)'=='Applications'" Include="..\..\Applications\**\*.sln">
+      <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
+    </Solution>
+    <Solution Condition="'$(Category)'=='HIP-Basic'" Include="..\..\HIP-Basic\**\*.sln" Exclude="..\..\HIP-Basic\vulkan_interop\**\*.sln;..\..\HIP-Basic\opengl_interop\**\*.sln;..\..\HIP-Basic\static_host_library\**\*.sln">
+      <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
+    </Solution>
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2017'" Include="..\..\Libraries\**\*_vs2017.sln">
+      <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
+    </Solution>
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2019'" Include="..\..\Libraries\**\*_vs2019.sln">
+      <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
+    </Solution>
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2022'" Include="..\..\Libraries\**\*_vs2022.sln">
+      <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
+    </Solution>
+  </ItemGroup>
+  <Target Name="Build">
+    <MSBuild Projects="@(Solution)" BuildInParallel="true" Targets="Build" />
+    <Message Text="%(Solution.Identity) -> $(Configuration)|$(Platform)" Importance="High"/>
+  </Target>
+  <Target Name="Clean">
+    <MSBuild Projects="@(Solution)" BuildInParallel="true" Targets="Clean" />
+  </Target>
+  <Target Name="Rebuild">
+    <MSBuild Projects="@(Solution)" BuildInParallel="true" Targets="Rebuild" />
+  </Target>
+</Project>

--- a/Scripts/VisualStudio/check_vs_files.py
+++ b/Scripts/VisualStudio/check_vs_files.py
@@ -138,7 +138,7 @@ class SlnChecker(GuidTools):
                     list_of_configurations.remove([config, mode])
                 except ValueError:
                     print(f'[red]Incorrect configuration in [yellow]{sln_file_path}[/yellow]:[/red]')
-                    print(f'    {config} = {mode}')
+                    print(f'    {guid}: {config} = {mode}')
                     self.error_counter += 1
         if len(list_of_configurations):
             print(f'[red]Missing configuration(s) in [yellow]{sln_file_path}[/yellow] for [yellow]{reference_guid}[/yellow]:[/red]')


### PR DESCRIPTION
Adds a GitHub action using Github-hosted Windows runner
- Update and use `check_vs_files.py` script to validate GUIDs in top-level solution files
- Adds `build.proj` project file to find and build individual example's `.sln` file using msbuild (task batch parallel build)
- Excludes `vulkan_interop`, `opengl_interop`, and `static_host_library` examples due to additional dependency requirements
- Build triggers independently for each category (Applications, HIP-Basic, Libraries)
- Builds both Debug and Release on x64 in parallel using matrix strategy
- HIP SDK installation will take ~15 to 20 mins
- For Libraries, parallelize build further for vs2017, 2019, and 2022 to reduce runtime to ~20min