### PR TITLE
Fix rocSPARSE csritilu0 example which was performing the convergence check incorrectly

### DIFF
--- a/Libraries/rocSPARSE/preconditioner/csritilu0/main.cpp
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/main.cpp
@@ -81,7 +81,6 @@ int main()
     rocsparse_int* d_csr_col_ind{};
     double*        d_csr_val{};
     double*        d_LU{};
-    double*        d_data{};
 
     constexpr size_t size_csr_row_ptr = sizeof(*d_csr_row_ptr) * (n + 1);
     constexpr size_t size_csr_col_ind = sizeof(*d_csr_col_ind) * nnz;
@@ -90,13 +89,11 @@ int main()
     constexpr size_t size_LU          = sizeof(*d_LU) * length_LU;
     rocsparse_int    max_iter         = 100; /*maximum number of iterations*/
     const size_t     length_data      = 2 * max_iter;
-    const size_t     size_data        = sizeof(*d_data) * length_data;
 
     HIP_CHECK(hipMalloc(&d_csr_row_ptr, size_csr_row_ptr));
     HIP_CHECK(hipMalloc(&d_csr_col_ind, size_csr_col_ind));
     HIP_CHECK(hipMalloc(&d_csr_val, size_csr_val));
     HIP_CHECK(hipMalloc(&d_LU, size_LU));
-    HIP_CHECK(hipMalloc(&d_data, size_data));
 
     HIP_CHECK(
         hipMemcpy(d_csr_row_ptr, h_csr_row_ptr.data(), size_csr_row_ptr, hipMemcpyHostToDevice));
@@ -224,19 +221,15 @@ int main()
     // 8. Fetch the convergence data.
     std::cout << "Iterations performed: " << max_iter << std::endl;
 
-    ROCSPARSE_CHECK(
-        rocsparse_dcsritilu0_history(handle, alg, &max_iter, d_data, buffer_size, temp_buffer));
-
     // The history vector has space for the corrections and the residual of each iteration (whether
     // they are computed or not).
     // Therefore, the size of the data collected is twice the number of iterations needed.
-    std::vector<double> data(length_data);
+    std::vector<double> history(2 * max_iter);
+    ROCSPARSE_CHECK(
+        rocsparse_dcsritilu0_history(handle, alg, &max_iter, history.data(), buffer_size, temp_buffer));
 
-    // Check last residual computed to confirm that convergence was successful.
-    HIP_CHECK(hipMemcpy(data.data(), d_data, size_data, hipMemcpyDeviceToHost));
-
-    const double last_residual       = data[2 * max_iter - 1];
-    const bool   csritilu0_converges = last_residual < tol;
+    const double last_residual       = history.back();
+    const bool   csritilu0_converges = last_residual <= tol;
 
     int errors{};
 
@@ -303,7 +296,6 @@ int main()
     HIP_CHECK(hipFree(d_csr_col_ind));
     HIP_CHECK(hipFree(d_csr_val));
     HIP_CHECK(hipFree(d_LU));
-    HIP_CHECK(hipFree(d_data));
     HIP_CHECK(hipFree(perm));
     HIP_CHECK(hipFree(sort_temp_buffer));
     HIP_CHECK(hipFree(temp_buffer));

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/main.cpp
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/main.cpp
@@ -228,7 +228,7 @@ int main()
     ROCSPARSE_CHECK(
         rocsparse_dcsritilu0_history(handle, alg, &max_iter, history.data(), buffer_size, temp_buffer));
 
-    const double last_residual       = history.back();
+    const double last_residual       = history[2 * max_iter - 1];
     const bool   csritilu0_converges = last_residual <= tol;
 
     int errors{};

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/main.cpp
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/main.cpp
@@ -234,7 +234,8 @@ int main()
 
     // Check last residual computed to confirm that convergence was successful.
     HIP_CHECK(hipMemcpy(data.data(), d_data, size_data, hipMemcpyDeviceToHost));
-    const double last_residual       = data.back();
+
+    const double last_residual       = data[2 * max_iter - 1];
     const bool   csritilu0_converges = last_residual < tol;
 
     int errors{};


### PR DESCRIPTION
- This fixes an issue that often passed but on some machines would regularly fail.
- Fix csritilu0 convergence check which was incorrectly grabbing the end of the convergence history array when it should grab the `2*iter-1` entry (where `iter` is the actual number of iterations that was required). The error is very easy to reproduce if the `d_data` array is explicitly filled with large numbers after it is allocated. I think this often passed because if `d_data` happened to be initialized with zeros, grabbing the end of the array would grab zero and so always pass as `0<tol`.