### PR TITLE
Remove rocSOLVER header include that was incorrectly added to rocSPARSE example

### DIFF
--- a/Libraries/rocSPARSE/level_2/gemvi/main.cpp
+++ b/Libraries/rocSPARSE/level_2/gemvi/main.cpp
@@ -24,7 +24,6 @@
 #include "rocsparse_utils.hpp"
 
 #include <cstddef>
-#include <rocsolver/rocsolver.h>
 #include <rocsparse/rocsparse.h>
 
 #include <hip/hip_runtime.h>


### PR DESCRIPTION
Remove rocSOLVER header include that was incorrectly added to rocSPARSE gemvi example in https://github.com/ROCm/rocm-examples/pull/235