### PR TITLE
Add `CMakeUserPresets.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.vcxproj.user
 [Bb]uild
 *.pdb
+CMakeUserPresets.json


### PR DESCRIPTION
In the ROCm documentation, we demonstrate how to create a `CMakeUserPresets.json` which can build the ROCm examples: https://rocm.docs.amd.com/en/docs-6.4.1/conceptual/cmake-packages.html#using-hip-with-presets

Consequently, we should add this file to `.gitignore` since it contains user-defined environment settings.