### PR TITLE
Bump google test version to v1.12.0

### DIFF
--- a/Tutorials/reduction/test/CMakeLists.txt
+++ b/Tutorials/reduction/test/CMakeLists.txt
@@ -146,8 +146,7 @@ if(NOT TARGET GTest::GTest AND NOT TARGET GTest::gtest)
         FetchContent_Declare(
             googletest
             GIT_REPOSITORY https://github.com/google/googletest.git
-            GIT_TAG
-                e2239ee6043f73722e7aa812a459f54a28552929 # release-1.11.0
+            GIT_TAG v1.12.0
         )
     endif()
     FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
Support cmake 4 which is not compatible with cmake minimum < 3.5 used in google test 1.11.0