### PR TITLE
Set hipfft_callback default CMake build type to Release

### DIFF
--- a/Libraries/hipFFT/callback/CMakeLists.txt
+++ b/Libraries/hipFFT/callback/CMakeLists.txt
@@ -36,6 +36,12 @@ endif()
 
 project(hipfft_callback LANGUAGES CXX HIP)
 
+# Set default build type to Release
+# to workaround a compiler issue when building with -O0
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 set(CMAKE_HIP_STANDARD 17)
 set(CMAKE_HIP_EXTENSIONS OFF)
 set(CMAKE_HIP_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Motivation

Fix `hipfft_callback` having the same issue as `rocfft_callback` at O0

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
