### PR TITLE
Disable rocSPARSE\preconditioner\csritilu0 and rocSPARSE\level_2\csritsv in CI

### DIFF
--- a/Scripts/VisualStudio/build.proj
+++ b/Scripts/VisualStudio/build.proj
@@ -14,13 +14,13 @@
     <Solution Condition="'$(Category)'=='HIP-Basic'" Include="..\..\HIP-Basic\**\*.sln" Exclude="..\..\HIP-Basic\static_host_library\**\*.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
-    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2017'" Include="..\..\Libraries\**\*_vs2017.sln">
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2017'" Include="..\..\Libraries\**\*_vs2017.sln" Exclude="..\..\Libraries\rocSPARSE\preconditioner\csritilu0\**\*.sln;..\..\Libraries\rocSPARSE\level_2\csritsv\**\*.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
-    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2019'" Include="..\..\Libraries\**\*_vs2019.sln">
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2019'" Include="..\..\Libraries\**\*_vs2019.sln" Exclude="..\..\Libraries\rocSPARSE\preconditioner\csritilu0\**\*.sln;..\..\Libraries\rocSPARSE\level_2\csritsv\**\*.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
-    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2022'" Include="..\..\Libraries\**\*_vs2022.sln">
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2022'" Include="..\..\Libraries\**\*_vs2022.sln" Exclude="..\..\Libraries\rocSPARSE\preconditioner\csritilu0\**\*.sln;..\..\Libraries\rocSPARSE\level_2\csritsv\**\*.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
   </ItemGroup>


### PR DESCRIPTION
## Motivation

Fixes CI failure for Libraries VS. Disable examples using csritsv_solve_ex and csritilu0_compute_ex added in ROCm 6.4 until HIP SDK 6.4 comes out.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
