### PR TITLE
Explicitely link stdc++fs for GCC 8

### DIFF
--- a/Applications/fdtd/CMakeLists.txt
+++ b/Applications/fdtd/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 target_include_directories(${example_name} PRIVATE ${include_dirs})
 
 if(UNIX)
-    target_link_libraries(${example_name} PRIVATE ${CMAKE_DL_LIBS})
+    target_link_libraries(${example_name} PRIVATE ${CMAKE_DL_LIBS} $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 endif()
 
 set_source_files_properties(main.hip PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})

--- a/Applications/fdtd/Makefile
+++ b/Applications/fdtd/Makefile
@@ -36,7 +36,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  :=
-ILDLIBS   :=
+ILDLIBS   := -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), CUDA)
 	ICXXFLAGS += -x cu


### PR DESCRIPTION
## Motivation

Fix fdtd compilation failure with GCC 8

## Technical Details

fdtd uses `std::filesystem` which requires explicit linking to `stdc++fs` when using GCC 8, see note at end of https://en.cppreference.com/w/cpp/filesystem.html.
`-lstdc++fs` is compatible with later GCC versions since they still ship `libstdc++fs`.
This does not cover use cases with `libc++` since ROCm LLVM is newer than 9.0.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tested on EL 8.8 (Rocky), fdtd builds successfully with this PR, fails otherwise. (with both cmake and make)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
