### PR TITLE
Update CI HIP SDK version to 6.4.2

### DIFF
--- a/.github/workflows/build_applications_vs.yml
+++ b/.github/workflows/build_applications_vs.yml
@@ -15,9 +15,9 @@ on:
       - 'Scripts/VisualStudio/**'
 
 env:
-    PLATFORM_TOOLSET_VERSION: 6.2
-    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
-    HIPSDK_INSTALLER_VERSION: 24.Q4
+    PLATFORM_TOOLSET_VERSION: 6.4
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.4\
+    HIPSDK_INSTALLER_VERSION: 25.Q3
     GLFW_DIR: C:\glfw-3.4.bin.WIN64\
 
 jobs:

--- a/.github/workflows/build_hip_basic_vs.yml
+++ b/.github/workflows/build_hip_basic_vs.yml
@@ -15,9 +15,9 @@ on:
       - 'Scripts/VisualStudio/**'
 
 env:
-    PLATFORM_TOOLSET_VERSION: 6.2
-    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
-    HIPSDK_INSTALLER_VERSION: 24.Q4
+    PLATFORM_TOOLSET_VERSION: 6.4
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.4\
+    HIPSDK_INSTALLER_VERSION: 25.Q3
     VULKAN_SDK: C:\VulkanSDK\1.4.313.2\
     GLFW_DIR: C:\glfw-3.4.bin.WIN64\
 
@@ -67,6 +67,13 @@ jobs:
                       Exit 1
                   }
                   msbuild -version
+          - name: Apply patch
+            shell: pwsh
+            run: |
+                  Write-Host "Applying patches $(Get-ChildItem -File Scripts\VisualStudio\*.patch)"
+                  git apply (Get-ChildItem -File Scripts\VisualStudio\*.patch).FullName
+                  Write-Host "Patches applied. Showing diff"
+                  git diff
           - name: Build ${{ matrix.config }} x64
             shell: pwsh
             run: |

--- a/.github/workflows/build_hip_documentation_vs.yml
+++ b/.github/workflows/build_hip_documentation_vs.yml
@@ -15,9 +15,9 @@ on:
       - 'Scripts/VisualStudio/**'
 
 env:
-    PLATFORM_TOOLSET_VERSION: 6.2
-    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
-    HIPSDK_INSTALLER_VERSION: 24.Q4
+    PLATFORM_TOOLSET_VERSION: 6.4
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.4\
+    HIPSDK_INSTALLER_VERSION: 25.Q3
     VULKAN_SDK: C:\VulkanSDK\1.4.313.2\
     GLFW_DIR: C:\glfw-3.4.bin.WIN64\
 

--- a/.github/workflows/build_libraries_vs.yml
+++ b/.github/workflows/build_libraries_vs.yml
@@ -15,9 +15,9 @@ on:
       - 'Scripts/VisualStudio/**'
 
 env:
-    PLATFORM_TOOLSET_VERSION: 6.2
-    HIP_PATH: C:\Program Files\AMD\ROCm\6.2\
-    HIPSDK_INSTALLER_VERSION: 24.Q4
+    PLATFORM_TOOLSET_VERSION: 6.4
+    HIP_PATH: C:\Program Files\AMD\ROCm\6.4\
+    HIPSDK_INSTALLER_VERSION: 25.Q3
 
 jobs:
     build:

--- a/Scripts/VisualStudio/0001-Set-cooperative_groups-debug-optimization-to-MinSize.patch
+++ b/Scripts/VisualStudio/0001-Set-cooperative_groups-debug-optimization-to-MinSize.patch
@@ -1,0 +1,53 @@
+From b4a91a5d5c6a2dea9bcca9bba029d44cc4a96b66 Mon Sep 17 00:00:00 2001
+From: zichguan-amd <zichuan.guan@amd.com>
+Date: Tue, 19 Aug 2025 11:41:59 -0400
+Subject: [PATCH] Set cooperative_groups debug optimization to MinSize
+
+Workaround cooperative_groups O0 compilation issue until HIP SDK 7
+
+Signed-off-by: zichguan-amd <zichuan.guan@amd.com>
+---
+ HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj | 1 +
+ HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj | 1 +
+ HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj b/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
+index 69d07721..4d85f7b4 100644
+--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
++++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2017.vcxproj
+@@ -76,6 +76,7 @@
+       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <LanguageStandard>stdcpp17</LanguageStandard>
+       <RuntimeTypeInfo>true</RuntimeTypeInfo>
++      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MinSize</Optimization>
+     </ClCompile>
+     <Link>
+       <SubSystem>Console</SubSystem>
+diff --git a/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj b/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
+index 10e1156b..eb45b707 100644
+--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
++++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2019.vcxproj
+@@ -76,6 +76,7 @@
+       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <LanguageStandard>stdcpp17</LanguageStandard>
+       <RuntimeTypeInfo>true</RuntimeTypeInfo>
++      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MinSize</Optimization>
+     </ClCompile>
+     <Link>
+       <SubSystem>Console</SubSystem>
+diff --git a/HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj b/HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj
+index 7447dfa2..65e2e352 100644
+--- a/HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj
++++ b/HIP-Basic/cooperative_groups/cooperative_groups_vs2022.vcxproj
+@@ -76,6 +76,7 @@
+       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..\..\Common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <LanguageStandard>stdcpp17</LanguageStandard>
+       <RuntimeTypeInfo>true</RuntimeTypeInfo>
++      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MinSize</Optimization>
+     </ClCompile>
+     <Link>
+       <SubSystem>Console</SubSystem>
+-- 
+2.43.0
+

--- a/Scripts/VisualStudio/build.proj
+++ b/Scripts/VisualStudio/build.proj
@@ -17,13 +17,13 @@
     <Solution Condition="'$(Category)'=='HIP-Doc'" Include="..\..\HIP-Doc\**\*.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
-    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2017'" Include="..\..\Libraries\**\*_vs2017.sln" Exclude="..\..\Libraries\rocSPARSE\preconditioner\csritilu0\**\*.sln;..\..\Libraries\rocSPARSE\level_2\csritsv\**\*.sln">
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2017'" Include="..\..\Libraries\**\*_vs2017.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
-    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2019'" Include="..\..\Libraries\**\*_vs2019.sln" Exclude="..\..\Libraries\rocSPARSE\preconditioner\csritilu0\**\*.sln;..\..\Libraries\rocSPARSE\level_2\csritsv\**\*.sln">
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2019'" Include="..\..\Libraries\**\*_vs2019.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
-    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2022'" Include="..\..\Libraries\**\*_vs2022.sln" Exclude="..\..\Libraries\rocSPARSE\preconditioner\csritilu0\**\*.sln;..\..\Libraries\rocSPARSE\level_2\csritsv\**\*.sln">
+    <Solution Condition="'$(Category)'=='Libraries' and '$(VSVersion)'=='2022'" Include="..\..\Libraries\**\*_vs2022.sln">
       <Properties>IntDir=Build\$(Configuration)\%(Solution.Filename)\tmp\;OutDir=Build\$(Configuration)\%(Solution.Filename)\</Properties>
     </Solution>
   </ItemGroup>


### PR DESCRIPTION
## Motivation

Update CI to use HIP SDK 6.4.2 GA

## Technical Details

Enables previously disabled rocSPARSE examples that use 6.4 APIs
Workaround `cooperative_groups` O0 issue until ROCm 7 by patching `cooperative_groups` project's debug build optimization level to `MinSize`. 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
