### PR TITLE
Fix Makefiles

### DIFF
--- a/Applications/sobel_filter/Makefile
+++ b/Applications/sobel_filter/Makefile
@@ -55,7 +55,7 @@ ILDLIBS   += $(LDLIBS)
 SRCS := main.hip $(EXTERNAL_DIR)/glad/glad.cpp
 
 $(EXAMPLE): $(SRCS) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
-	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SRCS) $(ILDLIBS)
+	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(abspath $(SRCS)) $(ILDLIBS)
 
 $(EXTERNAL_DIR)/glad/glad.cpp: $(EXTERNAL_DIR)/glad/glad.h
 

--- a/HIP-Basic/vulkan_interop_mipmap/Makefile
+++ b/HIP-Basic/vulkan_interop_mipmap/Makefile
@@ -59,16 +59,16 @@ ILDFLAGS   += $(LDFLAGS)
 ILDLIBS    += $(LDLIBS)
 IGLSLFLAGS += $(GLSLFLAGS)
 
-$(EXAMPLE): main.hip vulkan_utils.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp sinewave.frag.spv.h sinewave.vert.spv.h
+$(EXAMPLE): main.hip vulkan_utils.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp texture.frag.spv.h texture.vert.spv.h
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.hip vulkan_utils.hip $(ILDLIBS)
 
-sinewave.vert.spv.h: sinewave.vert
-	glslangValidator $< -o $@ $(IGLSLFLAGS) --vn sinewave_vert
+texture.vert.spv.h: texture.vert
+	glslangValidator $< -o $@ $(IGLSLFLAGS) --vn texture_vert
 
-sinewave.frag.spv.h: sinewave.frag
-	glslangValidator $< -o $@ $(IGLSLFLAGS) --vn sinewave_frag
+texture.frag.spv.h: texture.frag
+	glslangValidator $< -o $@ $(IGLSLFLAGS) --vn texture_frag
 
 clean:
-	$(RM) $(EXAMPLE) sinewave.frag.spv.h sinewave.vert.spv.h
+	$(RM) $(EXAMPLE) texture.frag.spv.h texture.vert.spv.h
 
 .PHONY: clean


### PR DESCRIPTION
## Motivation

Fix broken Makefiles

## Technical Details

- `Applications/sobel_filter`
  - Make source file path absolute so `test.pgm` can be found properly with `make`
- `HIP-Basic/vulkan_interop_mipmap`
  - Fix wrong shader names
- `Libraries/hipRAND/device_api/quasirandom_generations`
  - Will be added by StreamHPC along other fixes
- `Libraries/hipRAND/device_api/pseudorandom_generations`
  - Will be added by StreamHPC along other fixes

## Test Plan

Manually run `make` at different levels. There's currently no CI that tests Makefiles.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
