### PR TITLE
Fix std::filesystem linking

### DIFF
--- a/Applications/fdtd/CMakeLists.txt
+++ b/Applications/fdtd/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name applications_fdtd)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -63,7 +64,7 @@ endif()
 target_include_directories(${example_name} PRIVATE ${include_dirs})
 
 if(UNIX)
-    target_link_libraries(${example_name} PRIVATE ${CMAKE_DL_LIBS} $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+    target_link_libraries(${example_name} PRIVATE ${CMAKE_DL_LIBS} ${CXX_FS_LIBRARY})
 endif()
 
 set_source_files_properties(main.hip PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})

--- a/Common/FindFilesystem.cmake
+++ b/Common/FindFilesystem.cmake
@@ -20,42 +20,48 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-EXAMPLE := hip_linker_apis_file
-GPU_RUNTIME := HIP
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
-# HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
-HIP_INCLUDE_DIR  := $(ROCM_INSTALL_DIR)/include
+include(CMakePushCheckState)
+include(CheckCXXSourceCompiles)
 
-HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Common variables and flags
-CXX_STD   := c++17
-ICXXFLAGS := -std=$(CXX_STD)
-ICPPFLAGS :=
-ILDFLAGS  :=
-ILDLIBS   := -lstdc++fs
+cmake_push_check_state()
 
-ifeq ($(GPU_RUNTIME), CUDA)
-	ICXXFLAGS += -x cu
-	ICPPFLAGS += -isystem $(HIP_INCLUDE_DIR)
-	ILDLIBS += -lnvrtc -lcuda
-else ifeq ($(GPU_RUNTIME), HIP)
-	CXXFLAGS ?= -Wall -Wextra
-	ILDLIBS += -lhiprtc
-else
-	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be either CUDA or HIP)
-endif
+set(test_code
+[[
+#include <filesystem>
+#include <iostream>
 
-ICXXFLAGS += $(CXXFLAGS)
-ICPPFLAGS += $(CPPFLAGS)
-ILDFLAGS  += $(LDFLAGS)
-ILDLIBS   += $(LDLIBS)
+namespace fs = std::filesystem;
 
-$(EXAMPLE): main.cpp
-	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+int main()
+{
+    std::cout << fs::current_path() << std::endl;
+    return 0;
+}
+]]
+)
+# Check if std::filesystem works without additional libraries
+check_cxx_source_compiles("${test_code}" CXX_FS_NO_LINK)
 
-clean:
-	$(RM) $(EXAMPLE)
+if (CXX_FS_NO_LINK)
+    message(STATUS "No extra linking required to use std::filesystem")
+else()
+    # Check if we can link stdc++fs
+	set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
+	check_cxx_source_compiles("${test_code}" CXX_FS_CAN_LINK)
+    if (CXX_FS_CAN_LINK)
+        set(CXX_FS_LIBRARY stdc++fs CACHE STRING "Additional library required to use std::filesystem" FORCE)
+        message(STATUS "Need explicite linking to stdc++fs")
+    endif()
+endif()
 
-.PHONY: clean
+unset(test_code)
+cmake_pop_check_state()
+
+if(NOT CXX_FS_NO_LINK AND NOT CXX_FS_CAN_LINK)
+    message(FATAL_ERROR "Cannot run simple program using std::filesystem")
+endif()

--- a/HIP-Basic/module_api/CMakeLists.txt
+++ b/HIP-Basic/module_api/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name hip_module_api)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -83,6 +84,7 @@ add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common" "../../External")
 target_include_directories(${example_name} PRIVATE ${include_dirs})
+target_link_libraries(${example_name} PRIVATE ${CXX_FS_LIBRARY})
 set_source_files_properties(main.hip PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})

--- a/HIP-Basic/module_api/Makefile
+++ b/HIP-Basic/module_api/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,10 +37,15 @@ HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
 # Common variables and flags
 CXX_STD   := c++17
 CXXFLAGS  ?= -Wall -Wextra
-ICXXFLAGS := -std=$(CXX_STD) $(CXXFLAGS)
-ICPPFLAGS := -I $(COMMON_INCLUDE_DIR) $(CPPFLAGS)
-ILDFLAGS  := $(LDFLAGS)
-ILDLIBS   := $(LDLIBS)
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -I $(COMMON_INCLUDE_DIR)
+ILDFLAGS  :=
+ILDLIBS   :=  -lstdc++fs
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
 
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp module.co
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name hip_linker_apis_file)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
 select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
@@ -66,7 +67,8 @@ set_target_properties(${example_name} PROPERTIES $<$<COMPILE_LANGUAGE:CUDA>:CUDA
 target_compile_features(${example_name} PRIVATE cuda_std_17 cxx_std_17)
 target_include_directories(${example_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${ROCM_ROOT}/include>)
 target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>
-                                              $<$<LINK_LANGUAGE:CUDA>:CUDA::nvrtc>)
+                                              $<$<LINK_LANGUAGE:CUDA>:CUDA::nvrtc>
+                                              ${CXX_FS_LIBRARY})
 if(USED_LANGUAGE STREQUAL "CXX")
     target_link_libraries(${example_name} PRIVATE hip::host hiprtc::hiprtc)
 endif()


### PR DESCRIPTION
## Motivation

Properly link to `stdc++fs` when needed (`fdtd`, `module_api`, and `linker_apis_file`).

## Technical Details

Clang, GCC (or any other compiler) using a `libstdc++` prior to GCC 9.2 needs to explicitly link against `stdc++fs` to use `std::filesystem`.

This change adds a cmake file that when included, checks if a simple program can be compiled to use `std::filesystem`. The cmake file determines if additional linking to `stdc++fs` is needed through `CXX_FS_LIBRARY`.
`CXX_FS_LIBRARY` is either empty if no additional linking is required (for GCC >= 9.2) or set to `stdc++fs` if the library is available on the system. Otherwise CMake will fail with proper error message.

Adds `-lstdc++fs` to Makefiles, assume library exists. (Modern GCC still ships `stdc++fs`, older GCC versions <=  5.3 not supported)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tested with GCC 8.5 on Rocky Linux 8.8 and GCC 13.3 on Ubuntu 24. Builds `fdtd`, `module_api`, and `linker_apis_file` correctly.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
