### PR TITLE
Add ROCM_ROOT to CMAKE_PREFIX_PATH before find_package

### DIFF
--- a/HIP-Doc/Programming-Guide/HIP-Porting-Guide/host_code_feature_identification/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/HIP-Porting-Guide/host_code_feature_identification/CMakeLists.txt
@@ -30,13 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -52,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/HIP-Porting-Guide/identifying_compilation_target_platform/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/HIP-Porting-Guide/identifying_compilation_target_platform/CMakeLists.txt
@@ -30,13 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -52,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/address_retrieval/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/address_retrieval/CMakeLists.txt
@@ -30,14 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -53,6 +45,14 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/per_thread_default_stream/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/per_thread_default_stream/CMakeLists.txt
@@ -30,14 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -53,6 +45,14 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/pointer_memory_type/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/pointer_memory_type/CMakeLists.txt
@@ -30,14 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -53,6 +45,14 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/compilation_apis/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/compilation_apis/CMakeLists.txt
@@ -30,15 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-    find_package(hiprtc REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -54,6 +45,15 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+    find_package(hiprtc REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/CMakeLists.txt
@@ -30,15 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-    find_package(hiprtc REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -54,6 +45,15 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+    find_package(hiprtc REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/CMakeLists.txt
@@ -30,15 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-    find_package(hiprtc REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -54,6 +45,15 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+    find_package(hiprtc REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/CMakeLists.txt
@@ -30,15 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-    find_package(hiprtc REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -54,6 +45,15 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+    find_package(hiprtc REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/lowered_names/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/lowered_names/CMakeLists.txt
@@ -30,15 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-    find_package(hiprtc REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -54,6 +45,15 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+    find_package(hiprtc REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/rtc_error_handling/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/rtc_error_handling/CMakeLists.txt
@@ -30,15 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-    find_package(hiprtc REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -54,6 +45,15 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+    find_package(hiprtc REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+    find_package(CUDAToolkit REQUIRED) # We must explicitly link the CUDA driver library and NVRTC.
+endif()
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${USED_LANGUAGE})
 

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/call_stack_management/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/call_stack_management/CMakeLists.txt
@@ -27,14 +27,6 @@ project(${example_name} LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
@@ -53,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/simple_device_query/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/simple_device_query/CMakeLists.txt
@@ -27,14 +27,6 @@ project(${example_name} LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
@@ -53,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/explicit_copy/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/explicit_copy/CMakeLists.txt
@@ -27,14 +27,6 @@ project(${example_name} LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
@@ -53,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pageable_host_memory/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pageable_host_memory/CMakeLists.txt
@@ -27,14 +27,6 @@ project(${example_name} LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
@@ -53,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pinned_host_memory/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pinned_host_memory/CMakeLists.txt
@@ -27,14 +27,6 @@ project(${example_name} LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
@@ -53,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_resource_usage_statistics/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_resource_usage_statistics/CMakeLists.txt
@@ -31,6 +31,12 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+select_hip_platform()
+
+set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
     set(USED_LANGUAGE "CXX")
@@ -38,13 +44,6 @@ if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
 else()
     set(USED_LANGUAGE "CUDA")
 endif()
-
-enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
-select_hip_platform()
-
-set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
-
-list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_trim/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_trim/CMakeLists.txt
@@ -31,6 +31,12 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+select_hip_platform()
+
+set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
     set(USED_LANGUAGE "CXX")
@@ -38,13 +44,6 @@ if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
 else()
     set(USED_LANGUAGE "CUDA")
 endif()
-
-enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
-select_hip_platform()
-
-set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
-
-list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/device_enumeration/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/device_enumeration/CMakeLists.txt
@@ -27,14 +27,6 @@ project(${example_name} LANGUAGES CXX)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
-    set(USED_LANGUAGE "CXX")
-    find_package(hip REQUIRED)
-else()
-    set(USED_LANGUAGE "CUDA")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
@@ -53,6 +45,13 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "HIP")
+    set(USED_LANGUAGE "CXX")
+    find_package(hip REQUIRED)
+else()
+    set(USED_LANGUAGE "CUDA")
+endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipCUB/device_radix_sort/CMakeLists.txt
+++ b/Libraries/hipCUB/device_radix_sort/CMakeLists.txt
@@ -41,9 +41,21 @@ set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
 set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
 set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
 
-if(NOT CMAKE_PREFIX_PATH)
-    set(CMAKE_PREFIX_PATH "/opt/rocm")
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(ROCM_ROOT
+        "$ENV{HIP_PATH}"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
 endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(hipcub REQUIRED)
 

--- a/Libraries/hipCUB/device_sum/CMakeLists.txt
+++ b/Libraries/hipCUB/device_sum/CMakeLists.txt
@@ -41,9 +41,21 @@ set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
 set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
 set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
 
-if(NOT CMAKE_PREFIX_PATH)
-    set(CMAKE_PREFIX_PATH "/opt/rocm")
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(ROCM_ROOT
+        "$ENV{HIP_PATH}"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
 endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(hipcub REQUIRED)
 


### PR DESCRIPTION
## Motivation

`CMAKE_PREFIX_PATH` needs `ROCM_ROOT` to find ROCm packages such as `hiprtc`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
