### PR TITLE
Fix std::filesystem linking (#295)

### DIFF
--- a/Common/FindFilesystem.cmake
+++ b/Common/FindFilesystem.cmake
@@ -1,0 +1,67 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+include(CMakePushCheckState)
+include(CheckCXXSourceCompiles)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+cmake_push_check_state()
+
+set(test_code
+[[
+#include <filesystem>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+int main()
+{
+    std::cout << fs::current_path() << std::endl;
+    return 0;
+}
+]]
+)
+# Check if std::filesystem works without additional libraries
+check_cxx_source_compiles("${test_code}" CXX_FS_NO_LINK)
+
+if (CXX_FS_NO_LINK)
+    message(STATUS "No extra linking required to use std::filesystem")
+else()
+    # Check if we can link stdc++fs
+	set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
+	check_cxx_source_compiles("${test_code}" CXX_FS_CAN_LINK)
+    if (CXX_FS_CAN_LINK)
+        set(CXX_FS_LIBRARY stdc++fs CACHE STRING "Additional library required to use std::filesystem" FORCE)
+        message(STATUS "Need explicite linking to stdc++fs")
+    endif()
+endif()
+
+unset(test_code)
+cmake_pop_check_state()
+
+if(NOT CXX_FS_NO_LINK AND NOT CXX_FS_CAN_LINK)
+    message(FATAL_ERROR "Cannot run simple program using std::filesystem")
+endif()

--- a/HIP-Basic/module_api/CMakeLists.txt
+++ b/HIP-Basic/module_api/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name hip_module_api)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -83,9 +84,7 @@ add_test(NAME ${example_name} COMMAND ${example_name})
 
 set(include_dirs "../../Common" "../../External")
 target_include_directories(${example_name} PRIVATE ${include_dirs})
-set_source_files_properties(
-    main.hip
-    PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
-)
+target_link_libraries(${example_name} PRIVATE ${CXX_FS_LIBRARY})
+set_source_files_properties(main.hip PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})

--- a/HIP-Basic/module_api/Makefile
+++ b/HIP-Basic/module_api/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,10 +37,15 @@ HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
 # Common variables and flags
 CXX_STD   := c++17
 CXXFLAGS  ?= -Wall -Wextra
-ICXXFLAGS := -std=$(CXX_STD) $(CXXFLAGS)
-ICPPFLAGS := -I $(COMMON_INCLUDE_DIR) $(CPPFLAGS)
-ILDFLAGS  := $(LDFLAGS)
-ILDLIBS   := $(LDLIBS)
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -I $(COMMON_INCLUDE_DIR)
+ILDFLAGS  :=
+ILDLIBS   :=  -lstdc++fs
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
 
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp module.co
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)


### PR DESCRIPTION
(cherry picked from commit 39b15b04599487949c76033c3ddde3bc5c2e6959)

Removed HIP-Doc and `fdtd` related changes as they are not available in `release/rocm-rel-7.0` branch yet.