### PR TITLE
Add README files and make files to hiprand examples

### DIFF
--- a/Libraries/hipRAND/Makefile
+++ b/Libraries/hipRAND/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-LIBRARIES := \
-	hipBLAS \
-	hipCUB \
-	hipFFT \
-	hipSOLVER \
-	rocRAND \
-	hipRAND
+EXAMPLES := \
+	c_cpp_api \
+	device_api
 
-ifneq ($(GPU_RUNTIME), CUDA)
-LIBRARIES += \
-	rocBLAS \
-	rocFFT \
-	rocPRIM \
-	rocSOLVER \
-	rocSPARSE \
-	rocThrust
-endif
-
-all: $(LIBRARIES)
+all: $(EXAMPLES)
 
 clean: TARGET=clean
 clean: all
 
-$(LIBRARIES):
+$(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(LIBRARIES)
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipRAND/README.md
+++ b/Libraries/hipRAND/README.md
@@ -1,0 +1,61 @@
+# hipRAND Examples
+
+## Summary
+
+The examples in this subdirectory showcase the functionality of the [hipRAND](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand) library. The examples build on both Linux and Windows for both the ROCm (AMD GPU) and CUDA (NVIDIA GPU) backends.
+
+## Prerequisites
+
+### Linux
+
+- [CMake](https://cmake.org/download/) (at least version 3.21) OR GNU Make - available via the distribution's package manager
+- [ROCm](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html) (at least version 6.x.x)
+- [hipRAND](https://github.com/ROCm/hipRAND)
+  - ROCm platform: `hipRAND-dev` package available from [repo.radeon.com](https://repo.radeon.com/rocm/). The repository is added during the standard ROCm [install procedure](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html).
+  - CUDA platform: Install hipRAND from source: [instructions](https://github.com/ROCm/hipRAND#build-and-install).
+    - [cuRAND](https://developer.nvidia.com/curand) is a dependency of hipRAND for NVIDIA platforms. CUB is part of the NVIDIA CUDA Toolkit.
+
+### Windows
+
+- [Visual Studio](https://visualstudio.microsoft.com/) 2019 or 2022 with the "Desktop Development with C++" workload
+- ROCm toolchain for Windows
+  - The Visual Studio ROCm extension needs to be installed to build with the solution files.
+- [hipRAND](https://github.com/ROCm/hipRAND)
+  - ROCm platform: Installed as part of the ROCm SDK on Windows for ROCm platform.
+  - CUDA platform: Install hipRAND from source: [instructions](https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand#build-and-install).
+    - [cuRAND](https://developer.nvidia.com/curand) is a dependency of hipRAND for NVIDIA platforms. cuRAND is part of the NVIDIA CUDA Toolkit.
+- [CMake](https://cmake.org/download/) (optional, to build with CMake. Requires at least version 3.21)
+- [Ninja](https://ninja-build.org/) (optional, to build with CMake)
+
+## Building
+
+### Linux
+
+Make sure that the dependencies are installed, or use one of the [provided Dockerfiles](../../Dockerfiles/) to build and run the examples in a containerized environment.
+
+#### Using CMake
+
+All examples in the `hipRAND` subdirectory can either be built by a single CMake project or be built independently.
+
+- `$ cd Libraries/hipRAND`
+- `$ cmake -S . -B build` (on ROCm) or `$ cmake -S . -B build -D GPU_RUNTIME=CUDA` (on CUDA)
+- `$ cmake --build build`
+
+#### Using Make
+
+All examples can be built by a single invocation to Make or be built independently.
+
+- `$ cd Libraries/hipRAND`
+- `$ make` (on ROCm) or `$ make GPU_RUNTIME=CUDA` (on CUDA)
+
+### Windows
+
+#### Visual Studio
+
+Visual Studio solution files are available for the individual examples. To build all examples for hipRAND open the top level solution file [ROCm-Examples-VS2019.sln](../../ROCm-Examples-VS2019.sln) and filter for hipRAND.
+
+For more detailed build instructions refer to the top level [README.md](../../README.md#visual-studio).
+
+#### CMake
+
+All examples in the `hipRAND` subdirectory can either be built by a single CMake project or be built independently. For build instructions refer to the top-level [README.md](../../README.md#cmake-2).

--- a/Libraries/hipRAND/c_cpp_api/Makefile
+++ b/Libraries/hipRAND/c_cpp_api/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-LIBRARIES := \
-	hipBLAS \
-	hipCUB \
-	hipFFT \
-	hipSOLVER \
-	rocRAND \
-	hipRAND
+EXAMPLES := \
+	simple_distributions_cpp
 
-ifneq ($(GPU_RUNTIME), CUDA)
-LIBRARIES += \
-	rocBLAS \
-	rocFFT \
-	rocPRIM \
-	rocSOLVER \
-	rocSPARSE \
-	rocThrust
-endif
-
-all: $(LIBRARIES)
+all: $(EXAMPLES)
 
 clean: TARGET=clean
 clean: all
 
-$(LIBRARIES):
+$(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(LIBRARIES)
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp/Makefile
+++ b/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp/Makefile
@@ -1,0 +1,68 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiprand_simple_distributions_cpp
+COMMON_INCLUDE_DIR := ../../../../Common
+EXTERNAL_DIR := ../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+CUDA_INSTALL_DIR := /usr/local/cuda
+
+HIP_INCLUDE_DIR    := $(ROCM_INSTALL_DIR)/include
+HIPRAND_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX  ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+CUDACXX ?= $(CUDA_INSTALL_DIR)/bin/nvcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPRAND_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiprand
+
+ifeq ($(GPU_RUNTIME), CUDA)
+	ICXXFLAGS += -x cu
+	ICPPFLAGS += -isystem $(HIP_INCLUDE_DIR) -D__HIP_PLATFORM_NVIDIA__
+	COMPILER  := $(CUDACXX)
+else ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS  ?= -Wall -Wextra
+	ICPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER  := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be either CUDA or HIP)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp/README.md
+++ b/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp/README.md
@@ -1,0 +1,45 @@
+# hipRAND c_cpp_api simple_distributions Example
+
+## Description
+
+This example illustrates the use of the hipRAND cpp API. It specifically shows an example for a simple distribution.
+
+### Application flow
+
+1. Parse command-line arguments:
+    - Device ID
+    - Random distribution type
+    - Problem size
+    - Print toggle
+2. Query and set the selected HIP device.
+3. Generate random numbers on the device (GPU) using hipRAND.
+4. Generate random numbers on the host (CPU) using the standard library.
+5. Measure and print execution time for both device and host.
+6. Optionally print the generated random numbers.
+
+## Key APIs and Concepts
+
+### hiprand_cpp
+
+- The host level API of hipRAND is used to generate different random distributions using the GPU (in this case `hiprand_cpp::uniform_int_distribution<unsigned int>`, `hiprand_cpp::uniform_real_distribution<float>`, `hiprand_cpp::normal_distribution<double>` and `hiprand_cpp::poisson_distribution<unsigned int>`).
+
+## Used API surface
+
+### hiprand_cpp
+
+- `default_random_engine`
+- `uniform_int_distribution`
+- `uniform_real_distribution`
+- `normal_distribution`
+- `poisson_distribution`
+
+### HIP runtime
+
+- `HIP_CHECK`
+- `hipSetDevice`
+- `hipDeviceProp_t`
+- `hipGetDeviceProperties`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemcpyDeviceToHost`
+- `hipGetDeviceCount`

--- a/Libraries/hipRAND/device_api/Makefile
+++ b/Libraries/hipRAND/device_api/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-LIBRARIES := \
-	hipBLAS \
-	hipCUB \
-	hipFFT \
-	hipSOLVER \
-	rocRAND \
-	hipRAND
+EXAMPLES := \
+	pseudorandom_generations \
+	quasirandom_generations
 
-ifneq ($(GPU_RUNTIME), CUDA)
-LIBRARIES += \
-	rocBLAS \
-	rocFFT \
-	rocPRIM \
-	rocSOLVER \
-	rocSPARSE \
-	rocThrust
-endif
-
-all: $(LIBRARIES)
+all: $(EXAMPLES)
 
 clean: TARGET=clean
 clean: all
 
-$(LIBRARIES):
+$(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(LIBRARIES)
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipRAND/device_api/pseudorandom_generations/Makefile
+++ b/Libraries/hipRAND/device_api/pseudorandom_generations/Makefile
@@ -1,0 +1,68 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiprand_pseudorandom_generations
+COMMON_INCLUDE_DIR := ../../../../Common
+EXTERNAL_DIR := ../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+CUDA_INSTALL_DIR := /usr/local/cuda
+
+HIP_INCLUDE_DIR    := $(ROCM_INSTALL_DIR)/include
+HIPRAND_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX  ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+CUDACXX ?= $(CUDA_INSTALL_DIR)/bin/nvcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPRAND_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiprand
+
+ifeq ($(GPU_RUNTIME), CUDA)
+	ICXXFLAGS += -x cu
+	ICPPFLAGS += -isystem $(HIP_INCLUDE_DIR) -D__HIP_PLATFORM_NVIDIA__
+	COMPILER  := $(CUDACXX)
+else ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS  ?= -Wall -Wextra
+	ICPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER  := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be either CUDA or HIP)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipRAND/device_api/pseudorandom_generations/README.md
+++ b/Libraries/hipRAND/device_api/pseudorandom_generations/README.md
@@ -1,0 +1,43 @@
+# hipRAND Device API Pseudorandom Generation Example
+
+## Description
+
+This example illustrates the use of the hipRAND device API. It specifically shows an example for a pseudorandom generator inside a kernel.
+
+### Application flow
+
+1. Set pseudorandom generator type (hiprandStateXORWOW).
+2. Allocate device memory for the output buffer.
+3. Launch the hiprand_kernel on the GPU to generate random numbers.
+    - Use `hiprand_init` to initialize the generator.
+    - Use `hiprand` to get the next number from the generator
+4. Copy generated random numbers from device memory to host memory.
+5. Free device memory.
+6. Validate the uniformity of the generated random numbers:
+    - Compute normalized mean of the distribution.
+    - Compare against expected ~0.5.
+    - Report validation result (success or failure).
+
+## Key APIs and Concepts
+
+### hipRAND
+
+- The device level API of hipRAND is used to create a generator for pseudorandom numbers. In this case the `hiprandStateXORWOW` generator is used.
+
+## Used API surface
+
+### hipRAND
+
+- `hiprandStateXORWOW`
+- `hiprand_init`
+- `hiprand`
+
+### HIP runtime
+
+- `HIP_CHECK`
+- `hipMalloc`
+- `hipDeviceSynchronize`
+- `hipGetLastError`
+- `hipMemcpy`
+- `hipMemcpyDeviceToHost`
+- `hipFree`

--- a/Libraries/hipRAND/device_api/quasirandom_generations/Makefile
+++ b/Libraries/hipRAND/device_api/quasirandom_generations/Makefile
@@ -1,0 +1,68 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiprand_quasirandom_generations
+COMMON_INCLUDE_DIR := ../../../../Common
+EXTERNAL_DIR := ../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+CUDA_INSTALL_DIR := /usr/local/cuda
+
+HIP_INCLUDE_DIR    := $(ROCM_INSTALL_DIR)/include
+HIPRAND_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX  ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+CUDACXX ?= $(CUDA_INSTALL_DIR)/bin/nvcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPRAND_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiprand
+
+ifeq ($(GPU_RUNTIME), CUDA)
+	ICXXFLAGS += -x cu
+	ICPPFLAGS += -isystem $(HIP_INCLUDE_DIR) -D__HIP_PLATFORM_NVIDIA__
+	COMPILER  := $(CUDACXX)
+else ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS  ?= -Wall -Wextra
+	ICPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER  := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be either CUDA or HIP)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipRAND/device_api/quasirandom_generations/README.md
+++ b/Libraries/hipRAND/device_api/quasirandom_generations/README.md
@@ -1,0 +1,60 @@
+# hipRAND Device API Quasirandom Generation Example
+
+## Description
+
+This example illustrates the use of the hipRAND device API. It specifically shows an example for a quasirandom generator inside a kernel.
+
+### Application flow
+
+1. Define generator state types:
+    - hiprandStateSobol32 (Sobol).
+    - hiprandStateScrambledSobol32 (Scrambled Sobol).
+2. Allocate device output buffers
+3. Allocate generator states (one per thread).
+4. Get direction vectors
+5. Get scramble constants (Scrambled Sobol only).
+6. Generate Sobol values
+    - Launch sobol_init_kernel to initialize Sobol states.
+    - Launch generate_kernel to produce Sobol random numbers.
+7. Generate Scrambled Sobol values
+    - Launch scrambled_sobol_init_kernel to initialize states.
+    - Launch generate_kernel to produce Scrambled Sobol random numbers.
+8. Copy results back to host and free device memory
+9. Free all allocated device memory (outputs, states, vectors, scramble constants).
+10. Validate results
+    - Check uniformity of Sobol-generated numbers.
+    - Check uniformity of Scrambled Sobol-generated numbers.
+    - Print validation results (success/failure).
+
+## Key APIs and Concepts
+
+### hipRAND
+
+- The device-level hipRAND API is used to create quasirandom number generators directly on the GPU, here with hiprandStateSobol32 and hiprandStateScrambledSobol32.
+- Sobol generators require direction vectors, which are retrieved using hiprandGetDirectionVectors32 and copied to the device for use in state initialization.
+- Scrambled Sobol generators also require scramble constants, provided by hiprandGetScrambleConstants32, to apply an additional randomization to the Sobol sequence.
+
+## Used API surface
+
+### hipRAND
+
+- `hiprand_init`
+- `hiprand`
+- `hiprandStateSobol32`
+- `hiprandStateScrambledSobol32`
+- `hiprandDirectionVectors32_t`
+- `hiprandGetDirectionVectors32`
+- `HIPRAND_DIRECTION_VECTORS_32_JOEKUO6`
+- `HIPRAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6`
+- `hiprandGetScrambleConstants32`
+
+### HIP runtime
+
+- `HIP_CHECK`
+- `hipMalloc`
+- `hipDeviceSynchronize`
+- `hipGetLastError`
+- `hipMemcpy`
+- `hipMemcpyDeviceToHost`
+- `hipMemcpyHostToDevice`
+- `hipFree`

--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ The following options are available when building with CMake.
   - [hipCUB](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipCUB/)
     - [device_radix_sort](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipCUB/device_radix_sort/): Simple program that showcases `hipcub::DeviceRadixSort::SortPairs`.
     - [device_sum](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipCUB/device_sum/): Simple program that showcases `hipcub::DeviceReduce::Sum`.
+  - [hipRAND](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipRAND/)
+    - [c_cpp_api](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipRAND/c_cpp_api) Showcases the use of the hipRAND cpp API.
+      - [simple_distributions_cpp](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp) Shows an example for a simple distribution.
+    - [device_api](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipRAND/device_api) Showcases the use of the hipRAND device API.
+      - [pseudorandom_generations](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipRAND/device_api/pseudorandom_generations) Shows an example for a pseudorandom generator inside a kernel.
+      - [quasirandom_generations](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipRAND/device_api/quasirandom_generations) Shows an example for a quasirandom generator inside a kernel.
   - [hipSOLVER](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipSOLVER/)
     - [gels](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipSOLVER/gels/): Solve a linear system of the form $A\times X=B$.
     - [geqrf](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipSOLVER/geqrf/): Program that showcases how to obtain a QR decomposition with the hipSOLVER API.


### PR DESCRIPTION
## Motivation

Missing README files and make files for hiprand examples.

## Technical Details

Added the files.

## Test Plan

See if they build with make.

## Test Result

They build now with make.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
