### PR TITLE
Fix CUDA + Visual Studio portable example errors

### DIFF
--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/main.hip
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/main.hip
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "popcount.hpp"
+
 #include <hip/hip_runtime.h>
 
 #include <cstddef>
@@ -120,9 +122,9 @@ void generate_and_copy_mask(
             int mask_index = i * numberOfWarp + j;
             mask[mask_index] = distr(eng);
             if constexpr(WarpSize == 32)
-                count += __builtin_popcount(mask[mask_index]);
+                count += popcount(static_cast<std::uint32_t>(mask[mask_index]));
             else
-                count += __builtin_popcountll(mask[mask_index]);
+                count += popcount(mask[mask_index]);
         }
         vectorExpected[i]= count;
     }

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/popcount.hpp
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/popcount.hpp
@@ -20,46 +20,50 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// [sphinx-start]
-#include <hip/hip_runtime.h>
+#ifndef POPCOUNT_HPP
+#define POPCOUNT_HPP
 
-#include <iostream>
+#if __cplusplus >= 202002L
 
-#define HIP_CHECK(expression)              \
-{                                          \
-    const hipError_t err = expression;     \
-    if(err != hipSuccess)                  \
-    {                                      \
-        std::cerr << "HIP error: "         \
-            << hipGetErrorString(err)      \
-            << " at " << __LINE__ << "\n"; \
-    }                                      \
-}
+#include <bit>
 
-// Addition of two values.
-__global__ void add(int *a, int *b, int *c)
+using std::popcount;
+
+#elif defined(__clang__) || defined(__GNUC__)
+
+inline auto popcount(unsigned int x) -> int
 {
-    *c = *a + *b;
+    return __builtin_popcount(x);
 }
 
-// Declare a, b and c as static variables.
-__managed__ int a, b, c;
-
-int main()
+inline auto popcount(unsigned long x) -> int
 {
-    // Setup input values.
-    a = 1;
-    b = 2;
-
-    // Launch add() kernel on GPU.
-    add<<<1, 1>>>(&a, &b, &c);
-
-    // Wait for GPU to finish before accessing on host.
-    HIP_CHECK(hipDeviceSynchronize());
-
-    // Print the result.
-    std::cout << a << " + " << b << " = " << c << std::endl;
-
-    return 0;
+    return __builtin_popcountl(x);
 }
-// [sphinx-end]
+
+inline auto popcount(unsigned long long x) -> int
+{
+    return __builtin_popcountll(x);
+}
+
+#elif defined(_MSC_VER)
+
+#include <intrin.h>
+
+inline auto popcount(unsigned short x) -> unsigned short
+{
+    return __popcnt16(x);
+}
+
+inline auto popcount(unsigned int x) -> unsigned int
+{
+    return __popcnt(x);
+}
+
+inline auto popcount(unsigned __int64 x) -> unsigned __int64
+{
+    return __popcnt64(x);
+}
+#endif
+
+#endif

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2017.vcxproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ClCompile Include="main.hip" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -90,6 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2017.vcxproj.filters
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2017.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2019.vcxproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ClCompile Include="main.hip" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -90,6 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2019.vcxproj.filters
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2019.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2022.vcxproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ClCompile Include="main.hip" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -90,6 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2022.vcxproj.filters
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/template_warp_size_reduction_vs2022.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/timer_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/timer_vs2017.vcxproj
@@ -90,6 +90,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +120,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/timer_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/timer_vs2019.vcxproj
@@ -90,6 +90,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +120,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/timer_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/timer_vs2022.vcxproj
@@ -90,6 +90,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +120,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/main.hip
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/main.hip
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "popcount.hpp"
+
 #include <hip/hip_runtime.h>
 
 #include <cstddef>
@@ -114,9 +116,9 @@ void generate_and_copy_mask(
             int mask_index = i * numberOfWarp + j;
             mask[mask_index] = distr(eng);
             if(warpSizeHost == 32)
-                count += __builtin_popcount(mask[mask_index]);
+                count += popcount(static_cast<std::uint32_t>(mask[mask_index]));
             else
-                count += __builtin_popcountll(mask[mask_index]);
+                count += popcount(mask[mask_index]);
         }
         vectorExpected[i]= count;
     }

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/popcount.hpp
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/popcount.hpp
@@ -20,46 +20,51 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// [sphinx-start]
-#include <hip/hip_runtime.h>
+#ifndef POPCOUNT_HPP
+#define POPCOUNT_HPP
 
-#include <iostream>
+#if __cplusplus >= 202002L
 
-#define HIP_CHECK(expression)              \
-{                                          \
-    const hipError_t err = expression;     \
-    if(err != hipSuccess)                  \
-    {                                      \
-        std::cerr << "HIP error: "         \
-            << hipGetErrorString(err)      \
-            << " at " << __LINE__ << "\n"; \
-    }                                      \
-}
+#include <bit>
 
-// Addition of two values.
-__global__ void add(int *a, int *b, int *c)
+using std::popcount;
+
+#elif defined(__clang__) || defined(__GNUC__)
+
+inline auto popcount(unsigned int x) -> int
 {
-    *c = *a + *b;
+    return __builtin_popcount(x);
 }
 
-// Declare a, b and c as static variables.
-__managed__ int a, b, c;
-
-int main()
+inline auto popcount(unsigned long x) -> int
 {
-    // Setup input values.
-    a = 1;
-    b = 2;
-
-    // Launch add() kernel on GPU.
-    add<<<1, 1>>>(&a, &b, &c);
-
-    // Wait for GPU to finish before accessing on host.
-    HIP_CHECK(hipDeviceSynchronize());
-
-    // Print the result.
-    std::cout << a << " + " << b << " = " << c << std::endl;
-
-    return 0;
+    return __builtin_popcountl(x);
 }
-// [sphinx-end]
+
+inline auto popcount(unsigned long long x) -> int
+{
+    return __builtin_popcountll(x);
+}
+
+#elif defined(_MSC_VER)
+
+#include <intrin.h>
+
+inline auto popcount(unsigned short x) -> unsigned short
+{
+    return __popcnt16(x);
+}
+
+inline auto popcount(unsigned int x) -> unsigned int
+{
+    return __popcnt(x);
+}
+
+inline auto popcount(unsigned __int64 x) -> unsigned __int64
+{
+    return __popcnt64(x);
+}
+
+#endif
+
+#endif

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2017.vcxproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ClCompile Include="main.hip" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -90,6 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2017.vcxproj.filters
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2017.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2019.vcxproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ClCompile Include="main.hip" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -90,6 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2019.vcxproj.filters
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2019.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2022.vcxproj
@@ -20,6 +20,9 @@
   <ItemGroup>
     <ClCompile Include="main.hip" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -90,6 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
@@ -119,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2022.vcxproj.filters
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/warp_size_reduction_vs2022.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="popcount.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/load_module_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/load_module_vs2017.vcxproj
@@ -23,14 +23,22 @@
   <ItemGroup>
     <CustomBuild Include="vcpy.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object vcpy_isa.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)vcpy_isa.hsaco</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object vcpy_isa.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)vcpy_isa.hsaco</Outputs>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object vcpy_isa.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)vcpy_isa.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">"$(NvccToolExe)" -ptx -std=c++17 -o "$(OutDir)vcpy_isa.ptx" -x cu %(Identity)</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">Compiling to PTX file vcpy_isa.ptx</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(OutDir)vcpy_isa.ptx</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object vcpy_isa.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)vcpy_isa.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">"$(NvccToolExe)" -ptx -std=c++17 -o "$(OutDir)vcpy_isa.ptx" -x cu %(Identity)</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">Compiling to PTX file vcpy_isa.ptx</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(OutDir)vcpy_isa.ptx</Outputs>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(BinDir)vcpy_isa.ptx</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(BinDir)vcpy_isa.ptx</ObjectFileName>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -65,9 +73,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
-  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -97,6 +102,20 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -110,6 +129,21 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/load_module_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/load_module_vs2019.vcxproj
@@ -23,14 +23,22 @@
   <ItemGroup>
     <CustomBuild Include="vcpy.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object vcpy_isa.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)vcpy_isa.hsaco</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object vcpy_isa.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)vcpy_isa.hsaco</Outputs>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object vcpy_isa.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)vcpy_isa.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">"$(NvccToolExe)" -ptx -std=c++17 -o "$(OutDir)vcpy_isa.ptx" -x cu %(Identity)</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">Compiling to PTX file vcpy_isa.ptx</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(OutDir)vcpy_isa.ptx</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object vcpy_isa.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)vcpy_isa.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">"$(NvccToolExe)" -ptx -std=c++17 -o "$(OutDir)vcpy_isa.ptx" -x cu %(Identity)</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">Compiling to PTX file vcpy_isa.ptx</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(OutDir)vcpy_isa.ptx</Outputs>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(BinDir)vcpy_isa.ptx</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(BinDir)vcpy_isa.ptx</ObjectFileName>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -65,9 +73,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
-  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -97,6 +102,20 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -110,6 +129,21 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/load_module_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/load_module_vs2022.vcxproj
@@ -23,14 +23,22 @@
   <ItemGroup>
     <CustomBuild Include="vcpy.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object vcpy_isa.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)vcpy_isa.hsaco</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object vcpy_isa.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)vcpy_isa.hsaco</Outputs>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object vcpy_isa.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)vcpy_isa.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">"$(NvccToolExe)" -ptx -std=c++17 -o "$(OutDir)vcpy_isa.ptx" -x cu %(Identity)</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">Compiling to PTX file vcpy_isa.ptx</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(OutDir)vcpy_isa.ptx</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)vcpy_isa.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object vcpy_isa.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)vcpy_isa.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">"$(NvccToolExe)" -ptx -std=c++17 -o "$(OutDir)vcpy_isa.ptx" -x cu %(Identity)</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">Compiling to PTX file vcpy_isa.ptx</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(OutDir)vcpy_isa.ptx</Outputs>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(BinDir)vcpy_isa.ptx</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)vcpy_isa.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">$(BinDir)vcpy_isa.ptx</ObjectFileName>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -65,9 +73,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
-  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -97,6 +102,20 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -110,6 +129,21 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ClCompile>
+      <WarningLevel>Level2</WarningLevel>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>cuda.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/load_module_ex_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/load_module_ex_vs2017.vcxproj
@@ -23,14 +23,14 @@
   <ItemGroup>
     <CustomBuild Include="myKernel.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object myKernel.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)myKernel.hsaco</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object myKernel.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)myKernel.hsaco</Outputs>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)myKernel.hsaco</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(BinDir)myKernel.hsaco</ObjectFileName>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object myKernel.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)myKernel.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object myKernel.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)myKernel.hsaco</Outputs>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)myKernel.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)myKernel.hsaco</ObjectFileName>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/load_module_ex_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/load_module_ex_vs2019.vcxproj
@@ -23,14 +23,14 @@
   <ItemGroup>
     <CustomBuild Include="myKernel.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object myKernel.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)myKernel.hsaco</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object myKernel.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)myKernel.hsaco</Outputs>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)myKernel.hsaco</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(BinDir)myKernel.hsaco</ObjectFileName>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object myKernel.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)myKernel.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object myKernel.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)myKernel.hsaco</Outputs>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)myKernel.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)myKernel.hsaco</ObjectFileName>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/load_module_ex_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/load_module_ex_vs2022.vcxproj
@@ -23,14 +23,14 @@
   <ItemGroup>
     <CustomBuild Include="myKernel.hip">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compiling HIP Code Object myKernel.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)myKernel.hsaco</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compiling HIP Code Object myKernel.hsaco</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)myKernel.hsaco</Outputs>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(BinDir)myKernel.hsaco</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(BinDir)myKernel.hsaco</ObjectFileName>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object myKernel.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)myKernel.hsaco</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">"$(ClangToolPath)$(ClangToolExe)" --cuda-device-only -std=c++17 -o "$(OutDir)myKernel.hsaco" %(Identity) --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx942 --offload-arch=gfx1030 --offload-arch=gfx1100 --offload-arch=gfx1101 --offload-arch=gfx1102</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">Compiling to HSA Code Object myKernel.hsaco</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(OutDir)myKernel.hsaco</Outputs>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)myKernel.hsaco</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">$(BinDir)myKernel.hsaco</ObjectFileName>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/main.cpp
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/main.cpp
@@ -103,11 +103,10 @@ int main()
 
     options[0] = hipJitOptionMaxRegisters;
     unsigned maxRegs = 15;
-    optionValues[0] = (void *)(&maxRegs);
+    optionValues[0] = static_cast<void*>(&maxRegs);
 
-    // hipModuleLoadData(module, imagePtr) will be called on HIP-Clang path, JIT
-    // options will not be used, and cupModuleLoadDataEx(module, imagePtr,
-    // numOptions, options, optionValues) will be called on NVCC path
+    // hipModuleLoadData(module, imagePtr) will be called on HIP-Clang path, JIT options will not be used, and
+    // cuModuleLoadDataEx(module, imagePtr, numOptions, options, optionValues) will be called on NVCC path
     HIP_CHECK(hipModuleLoadDataEx(&module, imagePtr, numOptions, options, optionValues));
 
     // Get kernel function from the module via its name

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/linker_apis_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/linker_apis_vs2017.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/linker_apis_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/linker_apis_vs2019.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/linker_apis_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/linker_apis_vs2022.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/linker_apis_file_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/linker_apis_file_vs2017.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/linker_apis_file_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/linker_apis_file_vs2019.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/linker_apis_file_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/linker_apis_file_vs2022.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/linker_apis_options_vs2017.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/linker_apis_options_vs2017.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/linker_apis_options_vs2019.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/linker_apis_options_vs2019.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/linker_apis_options_vs2022.vcxproj
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/linker_apis_options_vs2022.vcxproj
@@ -63,6 +63,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <PropertyGroup Label="HIP nvcc $(HIPVersion)" Condition="'$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
+    <ProjectExcludedFromBuild>true</ProjectExcludedFromBuild>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -91,20 +94,6 @@
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <PreprocessorDefinitions>__CUDACC__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP clang $(HIPVersion)'">
     <ClCompile>
       <WarningLevel>Level2</WarningLevel>
@@ -119,21 +108,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalDependencies>hiprtc.lib;hiprtc-builtins.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64' and '$(PlatformToolset)'=='HIP nvcc $(HIPVersion)'">
-    <ClCompile>
-      <WarningLevel>Level2</WarningLevel>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>__CUDACC__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>nvrtc.lib;cuda.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/async_kernel_execution/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/async_kernel_execution/README.md
@@ -32,7 +32,6 @@ This example should be compared to the [sequential kernel execution example](../
 * `hipStreamDestroy` destroys a stream.
 * `hipMemcpyAsync` performs a copy operation in a stream. The call returns immediately to the host and the copy
   operation is performed asynchronously.
-* `hipLaunchKernelGGL` can launch a kernel in a stream.
 * `hipStreamSynchronize` blocks the host until all operations in the given stream have finished.
 
 ## Demonstrated API Calls
@@ -50,7 +49,6 @@ This example should be compared to the [sequential kernel execution example](../
 * `hipFree`
 * `hipGetErrorString`
 * `hipMalloc`
-* `hipLaunchKernelGGL`
 * `hipMemcpyAsync`
 * `hipStreamCreate`
 * `hipStreamDestroy`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/async_kernel_execution/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/async_kernel_execution/main.hip
@@ -89,11 +89,11 @@ int main()
         // Stream 2: Host to Device 2
         HIP_CHECK(hipMemcpyAsync(d_dataB, vectorB.data(), arraySize * sizeof(*d_dataB), hipMemcpyHostToDevice, streamB));
         // Stream 1: Kernel 1
-        hipLaunchKernelGGL(kernelA, dim3(numOfBlocks), dim3(threadsPerBlock), 0, streamA, d_dataA, arraySize);
+        kernelA<<<numOfBlocks, threadsPerBlock, 0, streamA>>>(d_dataA, arraySize);
         // Wait for streamA finish
         HIP_CHECK(hipStreamSynchronize(streamA));
         // Stream 2: Kernel 2
-        hipLaunchKernelGGL(kernelB, dim3(numOfBlocks), dim3(threadsPerBlock), 0, streamB, d_dataA, d_dataB, arraySize);
+        kernelB<<<numOfBlocks, threadsPerBlock, 0, streamB>>>(d_dataA, d_dataB, arraySize);
         // Stream 1: Device to Host 2 (after Kernel 1)
         HIP_CHECK(hipMemcpyAsync(vectorA.data(), d_dataA, arraySize * sizeof(*vectorA.data()), hipMemcpyDeviceToHost, streamA));
         // Stream 2: Device to Host 2 (after Kernel 2)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/event_based_synchronization/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/event_based_synchronization/README.md
@@ -40,7 +40,6 @@ This example should be compared to the [sequential kernel execution example](../
 * `hipStreamDestroy` destroys a stream.
 * `hipMemcpyAsync` performs a copy operation in a stream. The call returns immediately to the host and the copy
   operation is performed asynchronously.
-* `hipLaunchKernelGGL` can launch a kernel in a stream.
 * `hipStreamSynchronize` blocks the host until all operations in the given stream have finished.
 
 ## Demonstrated API Calls
@@ -60,7 +59,6 @@ This example should be compared to the [sequential kernel execution example](../
 * `hipFree`
 * `hipGetErrorString`
 * `hipMalloc`
-* `hipLaunchKernelGGL`
 * `hipMemcpyAsync`
 * `hipStreamCreate`
 * `hipStreamDestroy`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/event_based_synchronization/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/event_based_synchronization/main.hip
@@ -93,13 +93,13 @@ int main()
         // Stream 2: Host to Device 2
         HIP_CHECK(hipMemcpyAsync(d_dataB, vectorB.data(), arraySize * sizeof(*d_dataB), hipMemcpyHostToDevice, streamB));
         // Stream 1: Kernel 1
-        hipLaunchKernelGGL(kernelA, dim3(numOfBlocks), dim3(threadsPerBlock), 0, streamA, d_dataA, arraySize);
+        kernelA<<<numOfBlocks, threadsPerBlock, 0, streamA>>>(d_dataA, arraySize);
         // Record event after the GPU kernel in Stream 1
         HIP_CHECK(hipEventRecord(event, streamA));
         // Stream 2: Wait for event before starting Kernel 2
         HIP_CHECK(hipStreamWaitEvent(streamB, event, 0));
         // Stream 2: Kernel 2
-        hipLaunchKernelGGL(kernelB, dim3(numOfBlocks), dim3(threadsPerBlock), 0, streamB, d_dataA, d_dataB, arraySize);
+        kernelB<<<numOfBlocks, threadsPerBlock, 0, streamB>>>(d_dataA, d_dataB, arraySize);
         // Stream 1: Device to Host 2 (after Kernel 1)
         HIP_CHECK(hipMemcpyAsync(vectorA.data(), d_dataA, arraySize * sizeof(*vectorA.data()), hipMemcpyDeviceToHost, streamA));
         // Stream 2: Device to Host 2 (after Kernel 2)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/sequential_kernel_execution/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/sequential_kernel_execution/README.md
@@ -37,5 +37,4 @@ This example should be compared to the [asynchronous kernel execution example](.
 * `hipFree`
 * `hipGetErrorString`
 * `hipMalloc`
-* `hipLaunchKernelGGL`
 * `hipMemcpy`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/sequential_kernel_execution/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/sequential_kernel_execution/main.hip
@@ -84,8 +84,8 @@ int main()
         HIP_CHECK(hipMemcpy(d_dataA, vectorA.data(), arraySize * sizeof(*d_dataA), hipMemcpyHostToDevice));
         HIP_CHECK(hipMemcpy(d_dataB, vectorB.data(), arraySize * sizeof(*d_dataB), hipMemcpyHostToDevice));
         // Launch the GPU kernels
-        hipLaunchKernelGGL(kernelA, dim3(numOfBlocks), dim3(threadsPerBlock), 0, 0, d_dataA, arraySize);
-        hipLaunchKernelGGL(kernelB, dim3(numOfBlocks), dim3(threadsPerBlock), 0, 0, d_dataA, d_dataB, arraySize);
+        kernelA<<<numOfBlocks, threadsPerBlock>>>(d_dataA, arraySize);
+        kernelB<<<numOfBlocks, threadsPerBlock>>>(d_dataA, d_dataB, arraySize);
         // Device to Host copies
         HIP_CHECK(hipMemcpy(vectorA.data(), d_dataA, arraySize * sizeof(*vectorA.data()), hipMemcpyDeviceToHost));
         HIP_CHECK(hipMemcpy(vectorB.data(), d_dataB, arraySize * sizeof(*vectorB.data()), hipMemcpyDeviceToHost));

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/error_handling/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/error_handling/README.md
@@ -40,6 +40,5 @@ on this topic, please refer to the
 * `hipFree`
 * `hipGetErrorString`
 * `hipGetLastError`
-* `hipLaunchKernelGGL`
 * `hipMalloc`
 * `hipMemcpy`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/graph_capture/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/graph_capture/README.md
@@ -52,7 +52,6 @@ This example should be compared to the [graph creation example](../graph_creatio
 * `hipGraphInstantiate`
 * `hipGraphLaunch`
 * `hipMallocAsync`
-* `hipLaunchKernelGGL`
 * `hipMemcpyAsync`
 * `hipStreamBeginCapture`
 * `hipStreamCreate`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/ordinary_memory_allocation/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/ordinary_memory_allocation/CMakeLists.txt
@@ -30,11 +30,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
-    # The example calls hipInit which internally uses the CUDA driver API. We must explicitly link the driver library.
-    find_package(CUDAToolkit REQUIRED)
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"
@@ -61,6 +56,5 @@ set_target_properties(${example_name} PROPERTIES $<$<COMPILE_LANGUAGE:CUDA>:CUDA
                                                  $<$<COMPILE_LANGUAGE:HIP>:HIP_EXTENSIONS OFF>)
 target_compile_features(${example_name} PRIVATE cuda_std_17 hip_std_17)
 target_include_directories(${example_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${ROCM_ROOT}/include>)
-target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
 
 install(TARGETS ${example_name})

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/ordinary_memory_allocation/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/ordinary_memory_allocation/main.hip
@@ -51,9 +51,6 @@ __global__ void myKernel(int* data, std::size_t numElements)
 
 int main()
 {
-    // Initialize HIP.
-    HIP_CHECK(hipInit(0));
-
     // Allocate memory.
     constexpr std::size_t numElements = 1024;
     int* devData;

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/stream_ordered_memory_allocation/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/stream_ordered_memory_allocation/CMakeLists.txt
@@ -34,11 +34,6 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
-    # The example calls hipInit which internally uses the CUDA driver API. We must explicitly link the driver library.
-    find_package(CUDAToolkit REQUIRED)
-endif()
-
 set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
@@ -53,6 +48,5 @@ set_target_properties(${example_name} PROPERTIES $<$<COMPILE_LANGUAGE:CUDA>:CUDA
                                                  $<$<COMPILE_LANGUAGE:HIP>:HIP_EXTENSIONS OFF>)
 target_compile_features(${example_name} PRIVATE cuda_std_17 hip_std_17)
 target_include_directories(${example_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${ROCM_ROOT}/include>)
-target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
 
 install(TARGETS ${example_name})

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/stream_ordered_memory_allocation/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/stream_ordered_memory_allocation/main.hip
@@ -52,9 +52,6 @@ __global__ void myKernel(int* data, std::size_t numElements)
 
 int main()
 {
-    // Initialize HIP.
-    HIP_CHECK(hipInit(0));
-
     // Stream 0.
     constexpr hipStream_t streamId = 0;
 

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/data_prefetching/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/data_prefetching/README.md
@@ -24,7 +24,6 @@ information, please refer to the
 * `hipDeviceSynchronize` is used to synchronize the device with the host.
 * `hipFree` is used to free previously allocated unified memory.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * `hipMallocManaged` is used to allocate unified memory.
 * `hipMemPrefetchAsyc` is used to move data to the device before it is needed.
 
@@ -37,6 +36,5 @@ information, please refer to the
 * `hipDeviceSynchronize`
 * `hipFree`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`
 * `hipMallocManaged`
 * `hipMemPrefetchAsync`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/data_prefetching/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/data_prefetching/main.hip
@@ -63,7 +63,7 @@ int main()
     HIP_CHECK(hipMemPrefetchAsync(c, sizeof(*c), deviceId, 0));
 
     // Launch add() kernel on GPU.
-    hipLaunchKernelGGL(add, dim3(1), dim3(1), 0, 0, a, b, c);
+    add<<<1, 1>>>(a, b, c);
 
     // Prefetch the result back to the CPU.
     HIP_CHECK(hipMemPrefetchAsync(c, sizeof(*c), hipCpuDeviceId, 0));

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/dynamic_unified_memory/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/dynamic_unified_memory/README.md
@@ -20,7 +20,6 @@ more information on this topic, please refer to the
 * `hipDeviceSynchronize` is used to synchronize the device with the host.
 * `hipFree` is used to free previously allocated unified memory.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * `hipMallocManaged` is used to allocate unified memory.
 
 ## Demonstrated API Calls
@@ -32,5 +31,4 @@ more information on this topic, please refer to the
 * `hipDeviceSynchronize`
 * `hipFree`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`
 * `hipMallocManaged`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/dynamic_unified_memory/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/dynamic_unified_memory/main.hip
@@ -56,7 +56,7 @@ int main()
     *b = 2;
 
     // Launch add() kernel on GPU.
-    hipLaunchKernelGGL(add, dim3(1), dim3(1), 0, 0, a, b, c);
+    add<<<1, 1>>>(a, b, c);
 
     // Wait for GPU to finish before accessing on host.
     HIP_CHECK(hipDeviceSynchronize());

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/explicit_memory/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/explicit_memory/README.md
@@ -21,7 +21,6 @@ bytes between the host and the device. It should be compared to the various unif
 
 * `hipFree` is used to free previously allocated device memory.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * `hipMalloc` is used to allocate device memory.
 * `hipMemcpy` is used to transfer bytes between the host and the device.
 
@@ -34,6 +33,5 @@ bytes between the host and the device. It should be compared to the various unif
 * `hipDeviceSynchronize`
 * `hipFree`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`
 * `hipMalloc`
 * `hipMemcpy`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/explicit_memory/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/explicit_memory/main.hip
@@ -61,7 +61,7 @@ int main()
     HIP_CHECK(hipMemcpy(d_b, &b, sizeof(*d_b), hipMemcpyHostToDevice));
 
     // Launch add() kernel on GPU.
-    hipLaunchKernelGGL(add, dim3(1), dim3(1), 0, 0, d_a, d_b, d_c);
+    add<<<1, 1>>>(d_a, d_b, d_c);
 
     // Copy the result back to the host.
     HIP_CHECK(hipMemcpy(&c, d_c, sizeof(*d_c), hipMemcpyDeviceToHost));

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/memory_range_attributes/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/memory_range_attributes/README.md
@@ -30,7 +30,6 @@ works on Linux.
 * `hipDeviceSynchronize` is used to synchronize the device with the host.
 * `hipFree` is used to free previously allocated unified memory.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * `hipMallocManaged` is used to allocate unified memory.
 * `hipMemAdvise` is used to set advice for variables in the unified memory space.
 * `hipMemRangeGetAttribute` is used to query for memory range attributes.
@@ -44,7 +43,6 @@ works on Linux.
 * `hipDeviceSynchronize`
 * `hipFree`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`
 * `hipMallocManaged`
 * `hipMemAdvise`
 * `hipMemRangeGetAttribute`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/memory_range_attributes/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/memory_range_attributes/main.hip
@@ -64,7 +64,7 @@ int main()
     HIP_CHECK(hipMemAdvise(a, sizeof(*a), hipMemAdviseSetReadMostly, deviceId));
 
     // Launch add() kernel on GPU.
-    hipLaunchKernelGGL(add, dim3(1), dim3(1), 0, 0, a, b, c);
+    add<<<1, 1>>>(a, b, c);
 
     // Wait for GPU to finish before accessing on host.
     HIP_CHECK(hipDeviceSynchronize());

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/standard_unified_memory/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/standard_unified_memory/README.md
@@ -24,7 +24,6 @@ environment variable `HSA_XNACK` must be set to `1`.
 
 * `hipDeviceSynchronize` is used to synchronize the device with the host.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * The standard C++ operators `new` and `delete` are used to manage unified memory allocations.
 
 ## Demonstrated API Calls
@@ -35,4 +34,3 @@ environment variable `HSA_XNACK` must be set to `1`.
 
 * `hipDeviceSynchronize`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/standard_unified_memory/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/standard_unified_memory/main.hip
@@ -55,7 +55,7 @@ int main()
     *b = 2;
 
     // Launch add() kernel on GPU.
-    hipLaunchKernelGGL(add, dim3(1), dim3(1), 0, 0, a, b, c);
+    add<<<1, 1>>>(a, b, c);
 
     // Wait for GPU to finish before accessing on host.
     HIP_CHECK(hipDeviceSynchronize());

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/static_unified_memory/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/static_unified_memory/README.md
@@ -19,7 +19,6 @@ more information on this topic, please refer to the
 
 * `hipDeviceSynchronize` is used to synchronize the device with the host.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * The `__managed__` attribute is used to statically allocate memory in the unified memory space.
 
 ## Demonstrated API Calls
@@ -30,4 +29,3 @@ more information on this topic, please refer to the
 
 * `hipDeviceSynchronize`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/unified_memory_advice/README.md
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/unified_memory_advice/README.md
@@ -23,7 +23,6 @@ the
 * `hipDeviceSynchronize` is used to synchronize the device with the host.
 * `hipFree` is used to free previously allocated unified memory.
 * `hipGetErrorString` transforms a HIP error code into a human-readable string.
-* `hipLaunchKernelGGL` is used to launch a kernel on the device.
 * `hipMallocManaged` is used to allocate unified memory.
 * `hipMemAdvise` is used to set advice for variables in the unified memory space.
 
@@ -36,6 +35,5 @@ the
 * `hipDeviceSynchronize`
 * `hipFree`
 * `hipGetErrorString`
-* `hipLaunchKernelGGL`
 * `hipMallocManaged`
 * `hipMemAdvise`

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/unified_memory_advice/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/unified_memory_advice/main.hip
@@ -71,7 +71,7 @@ int main()
     *b = 2;
 
     // Launch add() kernel on GPU.
-    hipLaunchKernelGGL(add, dim3(1), dim3(1), 0, 0, a, b, c);
+    add<<<1, 1>>>(a, b, c);
 
     // Wait for GPU to finish before accessing on host.
     HIP_CHECK(hipDeviceSynchronize());

--- a/ROCm-Examples-Portable-VS2017.sln
+++ b/ROCm-Examples-Portable-VS2017.sln
@@ -190,8 +190,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "address_retrieval_vs2017", 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "load_module_vs2017", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\load_module\load_module_vs2017.vcxproj", "{26023EC2-B298-459C-8D05-CB9B185752CB}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "load_module_ex_vs2017", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\load_module_ex\load_module_ex_vs2017.vcxproj", "{F26935E2-D711-4EB5-8608-4F53E909512F}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "per_thread_default_stream_vs2017", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\per_thread_default_stream\per_thread_default_stream_vs2017.vcxproj", "{0B4B7EA7-8A50-4946-8C62-45C79D3426FE}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pointer_memory_type_vs2017", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\pointer_memory_type\pointer_memory_type_vs2017.vcxproj", "{35E3ACD9-51BD-49DF-99A4-DB745ACB491B}"
@@ -201,20 +199,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "event_based_synchronization_vs2017", "HIP-Doc\Programming-Guide\Using-HIP-Runtime-API\Asynchronous-Concurrent-Execution\event_based_synchronization\event_based_synchronization_vs2017.vcxproj", "{54C05E77-0E5D-449E-B048-8166D2EE97E7}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sequential_kernel_execution_vs2017", "HIP-Doc\Programming-Guide\Using-HIP-Runtime-API\Asynchronous-Concurrent-Execution\sequential_kernel_execution\sequential_kernel_execution_vs2017.vcxproj", "{FEE9F556-803D-43D9-BB9F-92D1465D86BE}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Programming-for-HIP-Runtime-Compiler", "Programming-for-HIP-Runtime-Compiler", "{2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "compilation_apis_vs2017", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\compilation_apis\compilation_apis_vs2017.vcxproj", "{A41A41EE-9D9C-4131-AA27-531660CD85A4}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_vs2017", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis\linker_apis_vs2017.vcxproj", "{1DF27E91-74C1-43E8-9443-09296169D55F}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_file_vs2017", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis_file\linker_apis_file_vs2017.vcxproj", "{67489C46-E97E-4C91-9636-79854DC5EAD1}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_options_vs2017", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis_options\linker_apis_options_vs2017.vcxproj", "{1DC058BF-4C29-46EC-A856-D0707D772445}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rtc_error_handling_vs2017", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\rtc_error_handling\rtc_error_handling_vs2017.vcxproj", "{DCF80A40-6BC2-4629-BF87-11699A465E3D}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lowered_names_vs2017", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\lowered_names\lowered_names_vs2017.vcxproj", "{B514436C-B525-48DE-A82C-0110FE55943B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -502,10 +486,6 @@ Global
 		{26023EC2-B298-459C-8D05-CB9B185752CB}.Debug|x64.Build.0 = Debug|x64
 		{26023EC2-B298-459C-8D05-CB9B185752CB}.Release|x64.ActiveCfg = Release|x64
 		{26023EC2-B298-459C-8D05-CB9B185752CB}.Release|x64.Build.0 = Release|x64
-		{F26935E2-D711-4EB5-8608-4F53E909512F}.Debug|x64.ActiveCfg = Debug|x64
-		{F26935E2-D711-4EB5-8608-4F53E909512F}.Debug|x64.Build.0 = Debug|x64
-		{F26935E2-D711-4EB5-8608-4F53E909512F}.Release|x64.ActiveCfg = Release|x64
-		{F26935E2-D711-4EB5-8608-4F53E909512F}.Release|x64.Build.0 = Release|x64
 		{0B4B7EA7-8A50-4946-8C62-45C79D3426FE}.Debug|x64.ActiveCfg = Debug|x64
 		{0B4B7EA7-8A50-4946-8C62-45C79D3426FE}.Debug|x64.Build.0 = Debug|x64
 		{0B4B7EA7-8A50-4946-8C62-45C79D3426FE}.Release|x64.ActiveCfg = Release|x64
@@ -526,30 +506,6 @@ Global
 		{FEE9F556-803D-43D9-BB9F-92D1465D86BE}.Debug|x64.Build.0 = Debug|x64
 		{FEE9F556-803D-43D9-BB9F-92D1465D86BE}.Release|x64.ActiveCfg = Release|x64
 		{FEE9F556-803D-43D9-BB9F-92D1465D86BE}.Release|x64.Build.0 = Release|x64
-		{A41A41EE-9D9C-4131-AA27-531660CD85A4}.Debug|x64.ActiveCfg = Debug|x64
-		{A41A41EE-9D9C-4131-AA27-531660CD85A4}.Debug|x64.Build.0 = Debug|x64
-		{A41A41EE-9D9C-4131-AA27-531660CD85A4}.Release|x64.ActiveCfg = Release|x64
-		{A41A41EE-9D9C-4131-AA27-531660CD85A4}.Release|x64.Build.0 = Release|x64
-		{1DF27E91-74C1-43E8-9443-09296169D55F}.Debug|x64.ActiveCfg = Debug|x64
-		{1DF27E91-74C1-43E8-9443-09296169D55F}.Debug|x64.Build.0 = Debug|x64
-		{1DF27E91-74C1-43E8-9443-09296169D55F}.Release|x64.ActiveCfg = Release|x64
-		{1DF27E91-74C1-43E8-9443-09296169D55F}.Release|x64.Build.0 = Release|x64
-		{67489C46-E97E-4C91-9636-79854DC5EAD1}.Debug|x64.ActiveCfg = Debug|x64
-		{67489C46-E97E-4C91-9636-79854DC5EAD1}.Debug|x64.Build.0 = Debug|x64
-		{67489C46-E97E-4C91-9636-79854DC5EAD1}.Release|x64.ActiveCfg = Release|x64
-		{67489C46-E97E-4C91-9636-79854DC5EAD1}.Release|x64.Build.0 = Release|x64
-		{1DC058BF-4C29-46EC-A856-D0707D772445}.Debug|x64.ActiveCfg = Debug|x64
-		{1DC058BF-4C29-46EC-A856-D0707D772445}.Debug|x64.Build.0 = Debug|x64
-		{1DC058BF-4C29-46EC-A856-D0707D772445}.Release|x64.ActiveCfg = Release|x64
-		{1DC058BF-4C29-46EC-A856-D0707D772445}.Release|x64.Build.0 = Release|x64
-		{DCF80A40-6BC2-4629-BF87-11699A465E3D}.Debug|x64.ActiveCfg = Debug|x64
-		{DCF80A40-6BC2-4629-BF87-11699A465E3D}.Debug|x64.Build.0 = Debug|x64
-		{DCF80A40-6BC2-4629-BF87-11699A465E3D}.Release|x64.ActiveCfg = Release|x64
-		{DCF80A40-6BC2-4629-BF87-11699A465E3D}.Release|x64.Build.0 = Release|x64
-		{B514436C-B525-48DE-A82C-0110FE55943B}.Debug|x64.ActiveCfg = Debug|x64
-		{B514436C-B525-48DE-A82C-0110FE55943B}.Debug|x64.Build.0 = Debug|x64
-		{B514436C-B525-48DE-A82C-0110FE55943B}.Release|x64.ActiveCfg = Release|x64
-		{B514436C-B525-48DE-A82C-0110FE55943B}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -645,19 +601,11 @@ Global
 		{05EF7925-0C5D-4BFF-8D2E-341B14ABB9B1} = {994A1883-8211-4E23-AF98-ADB2AC627644}
 		{9677F7AE-0EBC-4BC4-A3FD-B61468FAA860} = {3E03B0F7-25DE-4132-A3CD-765354B26408}
 		{26023EC2-B298-459C-8D05-CB9B185752CB} = {3E03B0F7-25DE-4132-A3CD-765354B26408}
-		{F26935E2-D711-4EB5-8608-4F53E909512F} = {3E03B0F7-25DE-4132-A3CD-765354B26408}
 		{0B4B7EA7-8A50-4946-8C62-45C79D3426FE} = {3E03B0F7-25DE-4132-A3CD-765354B26408}
 		{35E3ACD9-51BD-49DF-99A4-DB745ACB491B} = {3E03B0F7-25DE-4132-A3CD-765354B26408}
 		{97295C91-A455-4B78-89C9-BB6EA1791BBE} = {FF9F4BC0-101E-4DA0-8646-503BD6313DE9}
 		{54C05E77-0E5D-449E-B048-8166D2EE97E7} = {FF9F4BC0-101E-4DA0-8646-503BD6313DE9}
 		{FEE9F556-803D-43D9-BB9F-92D1465D86BE} = {FF9F4BC0-101E-4DA0-8646-503BD6313DE9}
-		{2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347} = {23D01721-DB47-4545-AD6C-B0DF786308C8}
-		{A41A41EE-9D9C-4131-AA27-531660CD85A4} = {2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}
-		{1DF27E91-74C1-43E8-9443-09296169D55F} = {2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}
-		{67489C46-E97E-4C91-9636-79854DC5EAD1} = {2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}
-		{1DC058BF-4C29-46EC-A856-D0707D772445} = {2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}
-		{DCF80A40-6BC2-4629-BF87-11699A465E3D} = {2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}
-		{B514436C-B525-48DE-A82C-0110FE55943B} = {2AAACE0F-C246-4FBE-83D6-9DB1B0D3F347}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {20E1D613-A9A0-4471-B029-8528325AE9EC}

--- a/ROCm-Examples-Portable-VS2019.sln
+++ b/ROCm-Examples-Portable-VS2019.sln
@@ -194,27 +194,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Porting-CUDA-Driver-API", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "load_module_vs2019", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\load_module\load_module_vs2019.vcxproj", "{AC95117E-7C1C-49A3-B64E-7951EC28B699}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "load_module_ex_vs2019", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\load_module_ex\load_module_ex_vs2019.vcxproj", "{EC1461F2-85C9-4654-8A90-7AE8C9E67209}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "address_retrieval_vs2019", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\address_retrieval\address_retrieval_vs2019.vcxproj", "{56A1F433-3AB9-4E64-BF45-0B92C8B6FDB9}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "per_thread_default_stream_vs2019", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\per_thread_default_stream\per_thread_default_stream_vs2019.vcxproj", "{541DD7D0-F1F5-4260-BD35-C8E77632C40E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pointer_memory_type_vs2019", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\pointer_memory_type\pointer_memory_type_vs2019.vcxproj", "{38AD6CC6-867E-44BA-B117-F02686076F9F}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Programming-for-HIP-Runtime-Compiler", "Programming-for-HIP-Runtime-Compiler", "{4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "compilation_apis_vs2019", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\compilation_apis\compilation_apis_vs2019.vcxproj", "{404200F8-EE3E-452B-A17F-B8CE8C142054}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_vs2019", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis\linker_apis_vs2019.vcxproj", "{22858BB2-5E22-4B64-BD1B-6D6E487B401B}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_file_vs2019", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis_file\linker_apis_file_vs2019.vcxproj", "{FEEB5A9A-C243-4B6C-BE76-B1AB417120E1}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_options_vs2019", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis_options\linker_apis_options_vs2019.vcxproj", "{0685653A-110C-4F44-AEF3-6AB0A2A3D4A8}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rtc_error_handling_vs2019", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\rtc_error_handling\rtc_error_handling_vs2019.vcxproj", "{A8A0E921-900B-4126-A9CC-B03A34633E55}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lowered_names_vs2019", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\lowered_names\lowered_names_vs2019.vcxproj", "{1035D3D6-5EAB-48D3-A12B-C4A700ACC145}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -510,10 +494,6 @@ Global
 		{AC95117E-7C1C-49A3-B64E-7951EC28B699}.Debug|x64.Build.0 = Debug|x64
 		{AC95117E-7C1C-49A3-B64E-7951EC28B699}.Release|x64.ActiveCfg = Release|x64
 		{AC95117E-7C1C-49A3-B64E-7951EC28B699}.Release|x64.Build.0 = Release|x64
-		{EC1461F2-85C9-4654-8A90-7AE8C9E67209}.Debug|x64.ActiveCfg = Debug|x64
-		{EC1461F2-85C9-4654-8A90-7AE8C9E67209}.Debug|x64.Build.0 = Debug|x64
-		{EC1461F2-85C9-4654-8A90-7AE8C9E67209}.Release|x64.ActiveCfg = Release|x64
-		{EC1461F2-85C9-4654-8A90-7AE8C9E67209}.Release|x64.Build.0 = Release|x64
 		{56A1F433-3AB9-4E64-BF45-0B92C8B6FDB9}.Debug|x64.ActiveCfg = Debug|x64
 		{56A1F433-3AB9-4E64-BF45-0B92C8B6FDB9}.Debug|x64.Build.0 = Debug|x64
 		{56A1F433-3AB9-4E64-BF45-0B92C8B6FDB9}.Release|x64.ActiveCfg = Release|x64
@@ -526,30 +506,6 @@ Global
 		{38AD6CC6-867E-44BA-B117-F02686076F9F}.Debug|x64.Build.0 = Debug|x64
 		{38AD6CC6-867E-44BA-B117-F02686076F9F}.Release|x64.ActiveCfg = Release|x64
 		{38AD6CC6-867E-44BA-B117-F02686076F9F}.Release|x64.Build.0 = Release|x64
-		{404200F8-EE3E-452B-A17F-B8CE8C142054}.Debug|x64.ActiveCfg = Debug|x64
-		{404200F8-EE3E-452B-A17F-B8CE8C142054}.Debug|x64.Build.0 = Debug|x64
-		{404200F8-EE3E-452B-A17F-B8CE8C142054}.Release|x64.ActiveCfg = Release|x64
-		{404200F8-EE3E-452B-A17F-B8CE8C142054}.Release|x64.Build.0 = Release|x64
-		{22858BB2-5E22-4B64-BD1B-6D6E487B401B}.Debug|x64.ActiveCfg = Debug|x64
-		{22858BB2-5E22-4B64-BD1B-6D6E487B401B}.Debug|x64.Build.0 = Debug|x64
-		{22858BB2-5E22-4B64-BD1B-6D6E487B401B}.Release|x64.ActiveCfg = Release|x64
-		{22858BB2-5E22-4B64-BD1B-6D6E487B401B}.Release|x64.Build.0 = Release|x64
-		{FEEB5A9A-C243-4B6C-BE76-B1AB417120E1}.Debug|x64.ActiveCfg = Debug|x64
-		{FEEB5A9A-C243-4B6C-BE76-B1AB417120E1}.Debug|x64.Build.0 = Debug|x64
-		{FEEB5A9A-C243-4B6C-BE76-B1AB417120E1}.Release|x64.ActiveCfg = Release|x64
-		{FEEB5A9A-C243-4B6C-BE76-B1AB417120E1}.Release|x64.Build.0 = Release|x64
-		{0685653A-110C-4F44-AEF3-6AB0A2A3D4A8}.Debug|x64.ActiveCfg = Debug|x64
-		{0685653A-110C-4F44-AEF3-6AB0A2A3D4A8}.Debug|x64.Build.0 = Debug|x64
-		{0685653A-110C-4F44-AEF3-6AB0A2A3D4A8}.Release|x64.ActiveCfg = Release|x64
-		{0685653A-110C-4F44-AEF3-6AB0A2A3D4A8}.Release|x64.Build.0 = Release|x64
-		{A8A0E921-900B-4126-A9CC-B03A34633E55}.Debug|x64.ActiveCfg = Debug|x64
-		{A8A0E921-900B-4126-A9CC-B03A34633E55}.Debug|x64.Build.0 = Debug|x64
-		{A8A0E921-900B-4126-A9CC-B03A34633E55}.Release|x64.ActiveCfg = Release|x64
-		{A8A0E921-900B-4126-A9CC-B03A34633E55}.Release|x64.Build.0 = Release|x64
-		{1035D3D6-5EAB-48D3-A12B-C4A700ACC145}.Debug|x64.ActiveCfg = Debug|x64
-		{1035D3D6-5EAB-48D3-A12B-C4A700ACC145}.Debug|x64.Build.0 = Debug|x64
-		{1035D3D6-5EAB-48D3-A12B-C4A700ACC145}.Release|x64.ActiveCfg = Release|x64
-		{1035D3D6-5EAB-48D3-A12B-C4A700ACC145}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -647,17 +603,9 @@ Global
 		{4E0E0D97-8EF7-4D8B-BB5A-F5B114AAA801} = {9AE38387-AAF7-491C-93D5-003422E121DF}
 		{D5AFC00B-8B39-470F-BE8A-143ADEA26259} = {7CC0F577-AD85-4051-B589-5C837C2E155D}
 		{AC95117E-7C1C-49A3-B64E-7951EC28B699} = {D5AFC00B-8B39-470F-BE8A-143ADEA26259}
-		{EC1461F2-85C9-4654-8A90-7AE8C9E67209} = {D5AFC00B-8B39-470F-BE8A-143ADEA26259}
 		{56A1F433-3AB9-4E64-BF45-0B92C8B6FDB9} = {D5AFC00B-8B39-470F-BE8A-143ADEA26259}
 		{541DD7D0-F1F5-4260-BD35-C8E77632C40E} = {D5AFC00B-8B39-470F-BE8A-143ADEA26259}
 		{38AD6CC6-867E-44BA-B117-F02686076F9F} = {D5AFC00B-8B39-470F-BE8A-143ADEA26259}
-		{4E4BC684-269A-4DB8-A64B-AA7FF3D604C2} = {7CC0F577-AD85-4051-B589-5C837C2E155D}
-		{404200F8-EE3E-452B-A17F-B8CE8C142054} = {4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}
-		{22858BB2-5E22-4B64-BD1B-6D6E487B401B} = {4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}
-		{FEEB5A9A-C243-4B6C-BE76-B1AB417120E1} = {4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}
-		{0685653A-110C-4F44-AEF3-6AB0A2A3D4A8} = {4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}
-		{A8A0E921-900B-4126-A9CC-B03A34633E55} = {4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}
-		{1035D3D6-5EAB-48D3-A12B-C4A700ACC145} = {4E4BC684-269A-4DB8-A64B-AA7FF3D604C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6EBF9134-2D3A-4C31-84F3-BB9A729317C0}

--- a/ROCm-Examples-Portable-VS2022.sln
+++ b/ROCm-Examples-Portable-VS2022.sln
@@ -194,27 +194,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Porting-CUDA-Driver-API", "
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "load_module_vs2022", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\load_module\load_module_vs2022.vcxproj", "{B079D11D-2068-DD93-67EB-48A713E9FB07}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "load_module_ex_vs2022", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\load_module_ex\load_module_ex_vs2022.vcxproj", "{1548044D-8547-9408-09EE-C29DDC19CEA7}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "address_retrieval_vs2022", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\address_retrieval\address_retrieval_vs2022.vcxproj", "{919E29D3-0B7C-AFFF-8E2C-3CD179744131}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "per_thread_default_stream_vs2022", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\per_thread_default_stream\per_thread_default_stream_vs2022.vcxproj", "{2F28FDEC-F73B-C8E7-2166-6F00ED3AF12C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pointer_memory_type_vs2022", "HIP-Doc\Programming-Guide\Porting-CUDA-Driver-API\pointer_memory_type\pointer_memory_type_vs2022.vcxproj", "{7B0E56C2-C6D6-E245-7B21-A64767C87738}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Programming-for-HIP-Runtime-Compiler", "Programming-for-HIP-Runtime-Compiler", "{9836E212-2690-4723-94F2-03C5118AAC14}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "compilation_apis_vs2022", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\compilation_apis\compilation_apis_vs2022.vcxproj", "{17AD5745-81C3-6574-B3A7-BD5E407836CC}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_vs2022", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis\linker_apis_vs2022.vcxproj", "{9CA95495-B513-E12B-C332-BBEE9CF93DAE}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_file_vs2022", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis_file\linker_apis_file_vs2022.vcxproj", "{94982E1C-5992-9AC6-C161-20ABC918AFC1}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "linker_apis_options_vs2022", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\linker_apis_options\linker_apis_options_vs2022.vcxproj", "{D7C61E16-DC76-A0ED-ABBD-1EBD581DBD37}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rtc_error_handling_vs2022", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\rtc_error_handling\rtc_error_handling_vs2022.vcxproj", "{01CF7922-4880-2C13-A711-27CE4C746B04}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lowered_names_vs2022", "HIP-Doc\Programming-Guide\Programming-for-HIP-Runtime-Compiler\lowered_names\lowered_names_vs2022.vcxproj", "{47C2919C-406D-283A-5FB6-B011EB2354FF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -510,10 +494,6 @@ Global
 		{B079D11D-2068-DD93-67EB-48A713E9FB07}.Debug|x64.Build.0 = Debug|x64
 		{B079D11D-2068-DD93-67EB-48A713E9FB07}.Release|x64.ActiveCfg = Release|x64
 		{B079D11D-2068-DD93-67EB-48A713E9FB07}.Release|x64.Build.0 = Release|x64
-		{1548044D-8547-9408-09EE-C29DDC19CEA7}.Debug|x64.ActiveCfg = Debug|x64
-		{1548044D-8547-9408-09EE-C29DDC19CEA7}.Debug|x64.Build.0 = Debug|x64
-		{1548044D-8547-9408-09EE-C29DDC19CEA7}.Release|x64.ActiveCfg = Release|x64
-		{1548044D-8547-9408-09EE-C29DDC19CEA7}.Release|x64.Build.0 = Release|x64
 		{919E29D3-0B7C-AFFF-8E2C-3CD179744131}.Debug|x64.ActiveCfg = Debug|x64
 		{919E29D3-0B7C-AFFF-8E2C-3CD179744131}.Debug|x64.Build.0 = Debug|x64
 		{919E29D3-0B7C-AFFF-8E2C-3CD179744131}.Release|x64.ActiveCfg = Release|x64
@@ -526,30 +506,6 @@ Global
 		{7B0E56C2-C6D6-E245-7B21-A64767C87738}.Debug|x64.Build.0 = Debug|x64
 		{7B0E56C2-C6D6-E245-7B21-A64767C87738}.Release|x64.ActiveCfg = Release|x64
 		{7B0E56C2-C6D6-E245-7B21-A64767C87738}.Release|x64.Build.0 = Release|x64
-		{17AD5745-81C3-6574-B3A7-BD5E407836CC}.Debug|x64.ActiveCfg = Debug|x64
-		{17AD5745-81C3-6574-B3A7-BD5E407836CC}.Debug|x64.Build.0 = Debug|x64
-		{17AD5745-81C3-6574-B3A7-BD5E407836CC}.Release|x64.ActiveCfg = Release|x64
-		{17AD5745-81C3-6574-B3A7-BD5E407836CC}.Release|x64.Build.0 = Release|x64
-		{9CA95495-B513-E12B-C332-BBEE9CF93DAE}.Debug|x64.ActiveCfg = Debug|x64
-		{9CA95495-B513-E12B-C332-BBEE9CF93DAE}.Debug|x64.Build.0 = Debug|x64
-		{9CA95495-B513-E12B-C332-BBEE9CF93DAE}.Release|x64.ActiveCfg = Release|x64
-		{9CA95495-B513-E12B-C332-BBEE9CF93DAE}.Release|x64.Build.0 = Release|x64
-		{94982E1C-5992-9AC6-C161-20ABC918AFC1}.Debug|x64.ActiveCfg = Debug|x64
-		{94982E1C-5992-9AC6-C161-20ABC918AFC1}.Debug|x64.Build.0 = Debug|x64
-		{94982E1C-5992-9AC6-C161-20ABC918AFC1}.Release|x64.ActiveCfg = Release|x64
-		{94982E1C-5992-9AC6-C161-20ABC918AFC1}.Release|x64.Build.0 = Release|x64
-		{D7C61E16-DC76-A0ED-ABBD-1EBD581DBD37}.Debug|x64.ActiveCfg = Debug|x64
-		{D7C61E16-DC76-A0ED-ABBD-1EBD581DBD37}.Debug|x64.Build.0 = Debug|x64
-		{D7C61E16-DC76-A0ED-ABBD-1EBD581DBD37}.Release|x64.ActiveCfg = Release|x64
-		{D7C61E16-DC76-A0ED-ABBD-1EBD581DBD37}.Release|x64.Build.0 = Release|x64
-		{01CF7922-4880-2C13-A711-27CE4C746B04}.Debug|x64.ActiveCfg = Debug|x64
-		{01CF7922-4880-2C13-A711-27CE4C746B04}.Debug|x64.Build.0 = Debug|x64
-		{01CF7922-4880-2C13-A711-27CE4C746B04}.Release|x64.ActiveCfg = Release|x64
-		{01CF7922-4880-2C13-A711-27CE4C746B04}.Release|x64.Build.0 = Release|x64
-		{47C2919C-406D-283A-5FB6-B011EB2354FF}.Debug|x64.ActiveCfg = Debug|x64
-		{47C2919C-406D-283A-5FB6-B011EB2354FF}.Debug|x64.Build.0 = Debug|x64
-		{47C2919C-406D-283A-5FB6-B011EB2354FF}.Release|x64.ActiveCfg = Release|x64
-		{47C2919C-406D-283A-5FB6-B011EB2354FF}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -647,17 +603,9 @@ Global
 		{301FBAD3-7738-8CFD-014B-BE314C8573DD} = {D913551B-498A-4177-A7D6-F2A22A90FC2C}
 		{AB3A4673-90C9-4401-8ACC-85A75018708C} = {4596F2CF-5E1E-4EF7-8339-4934D6BF1F00}
 		{B079D11D-2068-DD93-67EB-48A713E9FB07} = {AB3A4673-90C9-4401-8ACC-85A75018708C}
-		{1548044D-8547-9408-09EE-C29DDC19CEA7} = {AB3A4673-90C9-4401-8ACC-85A75018708C}
 		{919E29D3-0B7C-AFFF-8E2C-3CD179744131} = {AB3A4673-90C9-4401-8ACC-85A75018708C}
 		{2F28FDEC-F73B-C8E7-2166-6F00ED3AF12C} = {AB3A4673-90C9-4401-8ACC-85A75018708C}
 		{7B0E56C2-C6D6-E245-7B21-A64767C87738} = {AB3A4673-90C9-4401-8ACC-85A75018708C}
-		{9836E212-2690-4723-94F2-03C5118AAC14} = {4596F2CF-5E1E-4EF7-8339-4934D6BF1F00}
-		{17AD5745-81C3-6574-B3A7-BD5E407836CC} = {9836E212-2690-4723-94F2-03C5118AAC14}
-		{9CA95495-B513-E12B-C332-BBEE9CF93DAE} = {9836E212-2690-4723-94F2-03C5118AAC14}
-		{94982E1C-5992-9AC6-C161-20ABC918AFC1} = {9836E212-2690-4723-94F2-03C5118AAC14}
-		{D7C61E16-DC76-A0ED-ABBD-1EBD581DBD37} = {9836E212-2690-4723-94F2-03C5118AAC14}
-		{01CF7922-4880-2C13-A711-27CE4C746B04} = {9836E212-2690-4723-94F2-03C5118AAC14}
-		{47C2919C-406D-283A-5FB6-B011EB2354FF} = {9836E212-2690-4723-94F2-03C5118AAC14}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A39869B7-4813-4EE4-B059-C79B5CA433E7}


### PR DESCRIPTION
## Motivation

Some examples have mistakenly landed in the Portable Examples list while they aren't, others are missing compiler/linker flags. Internal tickets: SWDEV-551046, ROCDOC-2021.

## Technical Details

Removed the HIPRTC examples from the Portable Examples list, fixes the compiler / linker errors for the rest.

## Test Plan

-

## Test Result

-

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
