### PR TITLE
Support experimental filesystem header for GCC versions in [5.3, 8.1)

### DIFF
--- a/Applications/CMakeLists.txt
+++ b/Applications/CMakeLists.txt
@@ -27,6 +27,7 @@ include(CTest)
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../Common/HipPlatform.cmake")
 select_gpu_language()
 # select_hip_platform requires the language to be enabled
@@ -37,13 +38,20 @@ find_package(glfw3)
 
 add_subdirectory(bitonic_sort)
 add_subdirectory(convolution)
-add_subdirectory(fdtd)
 add_subdirectory(floyd_warshall)
 add_subdirectory(histogram)
+add_subdirectory(prefix_sum)
+
+if(NOT CXX_FS_HEADER_FOUND)
+    message("filesystem not found, not building fdtd example")
+else()
+    add_subdirectory(fdtd)
+endif()
+
 if(NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND ROCM_EXAMPLES_HIP_PLATFORM STREQUAL "nvidia"))
     add_subdirectory(monte_carlo_pi)
 endif()
-add_subdirectory(prefix_sum)
+
 if(NOT glfw3_FOUND)
     message("GLFW not found, not building sobel filter example")
 else()

--- a/Applications/fdtd/main.hip
+++ b/Applications/fdtd/main.hip
@@ -30,12 +30,19 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 
-namespace fs = std::filesystem;
+#if __has_include(<filesystem>)
+    #include <filesystem>
+    namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#else
+    static_assert(false, "filesystem not available");
+#endif
 
 // Physical constants.
 __device__ __constant__ constexpr float c0 = 299792458.0f; // Speed of light (m/s).

--- a/Common/FindFilesystem.cmake
+++ b/Common/FindFilesystem.cmake
@@ -23,45 +23,57 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
 include(CheckCXXSourceCompiles)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-cmake_push_check_state()
+cmake_push_check_state(RESET)
 
-set(test_code
+# find available header: filesystem or experimental/filesystem
+check_include_file_cxx("filesystem" CXX_HAVE_FS_HEADER)
+if (CXX_HAVE_FS_HEADER)
+    set(FS_HEADER filesystem)
+    set(FS_NAMESPACE std::filesystem)
+    set(CXX_FS_HEADER_FOUND ON)
+else()
+    check_include_file_cxx("experimental/filesystem" CXX_HAVE_EXPERIMENTAL_FS_HEADER)
+    if(CXX_HAVE_EXPERIMENTAL_FS_HEADER)
+        set(FS_HEADER experimental/filesystem)
+        set(FS_NAMESPACE std::experimental::filesystem)
+        set(CXX_FS_HEADER_FOUND ON)
+    else()
+        set(CXX_FS_HEADER_FOUND OFF)
+        return()
+    endif()
+endif()
+
+string(CONFIGURE
 [[
-#include <filesystem>
-#include <iostream>
+    #include <@FS_HEADER@>
+    #include <iostream>
 
-namespace fs = std::filesystem;
+    int main() {
+        std::cout << @FS_NAMESPACE@::current_path() << std::endl;
+        return 0;
+    }
+]] test_code @ONLY)
 
-int main()
-{
-    std::cout << fs::current_path() << std::endl;
-    return 0;
-}
-]]
-)
-# Check if std::filesystem works without additional libraries
+# Check if filesystem works without additional libraries
 check_cxx_source_compiles("${test_code}" CXX_FS_NO_LINK)
 
-if (CXX_FS_NO_LINK)
-    message(STATUS "No extra linking required to use std::filesystem")
-else()
+if (NOT CXX_FS_NO_LINK)
     # Check if we can link stdc++fs
 	set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
 	check_cxx_source_compiles("${test_code}" CXX_FS_CAN_LINK)
     if (CXX_FS_CAN_LINK)
-        set(CXX_FS_LIBRARY stdc++fs CACHE STRING "Additional library required to use std::filesystem" FORCE)
-        message(STATUS "Need explicite linking to stdc++fs")
+        set(CXX_FS_LIBRARY stdc++fs CACHE STRING "Additional library required to use filesystem" FORCE)
     endif()
 endif()
 
-unset(test_code)
 cmake_pop_check_state()
 
 if(NOT CXX_FS_NO_LINK AND NOT CXX_FS_CAN_LINK)
-    message(FATAL_ERROR "Cannot run simple program using std::filesystem")
+    message(FATAL_ERROR "Cannot run simple program using filesystem")
 endif()

--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -24,6 +24,8 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Basic LANGUAGES CXX)
 include(CTest)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/FindFilesystem.cmake")
+
 # ROCm installation path
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
@@ -97,11 +99,8 @@ if(NOT "${GPU_RUNTIME}" STREQUAL "CUDA")
         endif()
     endif()
 
-    if(
-        CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.4"
-    )
-        # g++ < 10.4 does not support all required C++17 features
+    if(NOT CXX_FS_HEADER_FOUND)
+        message("filesystem not found, not building module API example")
     else()
         add_subdirectory(module_api)
     endif()

--- a/HIP-Basic/module_api/main.hip
+++ b/HIP-Basic/module_api/main.hip
@@ -24,10 +24,19 @@
 
 #include <hip/hip_runtime.h>
 
-#include <filesystem>
 #include <iostream>
 #include <numeric>
 #include <vector>
+
+#if __has_include(<filesystem>)
+    #include <filesystem>
+    namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#else
+    static_assert(false, "filesystem not available");
+#endif
 
 int main(int, char* argv[])
 {
@@ -65,9 +74,9 @@ int main(int, char* argv[])
     // To do that, find the directory where the example executable is placed in from the 0th argument.
     // Note that this does not always work (the executable may be invoked with a completely different
     // value for argv[0]), but works for the purposes of this example.
-    std::filesystem::path exe_dir
-        = std::filesystem::weakly_canonical(std::filesystem::path(argv[0])).parent_path();
-    std::filesystem::path module_path = exe_dir / module_file_name;
+    fs::path exe_dir
+        = fs::canonical(fs::path(argv[0])).parent_path();
+    fs::path module_path = exe_dir / module_file_name;
 
     // Load the module from the path that we just constructed.
     // If the module does not exist, this function will return an error.

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/CMakeLists.txt
@@ -23,6 +23,7 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Programming-for-HIP-Runtime-Compiler LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -32,8 +33,13 @@ if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")
     message(STATUS "The HIPRTC linker examples are available only for AMD targets.")
 else()
     add_subdirectory(linker_apis)
-    add_subdirectory(linker_apis_file)
     add_subdirectory(linker_apis_options)
+
+    if(NOT CXX_FS_HEADER_FOUND)
+        message("filesystem not found, not building Linker APIs File example")
+    else()
+        add_subdirectory(linker_apis_file)
+    endif()
 endif()
 
 add_subdirectory(lowered_names)

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/main.cpp
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/main.cpp
@@ -26,12 +26,22 @@
 
 #include <cstddef>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <iostream>
 #include <string>
 #include <vector>
+
+#if __has_include(<filesystem>)
+    #include <filesystem>
+    namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#else
+    static_assert(false, "filesystem not available");
+#endif
+
 
 #define CHECK_RET_CODE(call, ret_code)                                                             \
 {                                                                                                  \
@@ -138,7 +148,7 @@ int main()
                                    nullptr,               // Array of options applied to this input
                                    nullptr));             // Array of option values cast to void*
     // [sphinx-link-add-end]
-    std::filesystem::remove(bc_file_path);
+    fs::remove(bc_file_path);
 
     void* binary = nullptr;
     auto binarySize = std::size_t{};

--- a/Tutorials/CMakeLists.txt
+++ b/Tutorials/CMakeLists.txt
@@ -23,15 +23,18 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(Tutorials LANGUAGES CXX)
 include(CTest)
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
 
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
-if(
-    CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.4"
-)
-    # g++ < 10.4 does not support all required C++17 features
-else()
+# skip redution if execution header is not available (for GCC < 10.1)
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_LIBRARIES "tbb")
+check_include_file_cxx(execution CXX_HAVE_EXECUTION_POLICIES)
+cmake_pop_check_state()
+
+if(CXX_HAVE_EXECUTION_POLICIES)
     add_subdirectory(reduction)
 endif()


### PR DESCRIPTION
## Motivation

Fixes build issue with filesystem library on SLES 15.7 which comes with GCC 7.5 by default.

## Technical Details

Conditionally compile with available filesystem header using `__has_include`.
Skips examples in higher-level CMake if no filesystem header can be found.
Change `weakly_canonical` to `canonical` in `module_api` since `weakly_canonical` is not available in experimental/filesystem. https://en.cppreference.com/w/cpp/filesystem/canonical.html The function will error out if given a non-existing path, this does not change the example's functionality.
Skip reduction based on `execution` header availability instead of GCC version so it gets correctly skipped when using clang with older libstdc++.

## Test Plan

Compiles with GCC up to 5.3 https://godbolt.org/z/q5fofsbPd.
Builds `fdtd`, `linker_apis_file`, and `module_api` with CMake and make correctly on SLES 15.7 with GCC 7.5

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
