### PR TITLE
Support experimental filesystem header for GCC versions in [5.3, 8.1) (#307)

### DIFF
--- a/Applications/CMakeLists.txt
+++ b/Applications/CMakeLists.txt
@@ -27,6 +27,7 @@ include(CTest)
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../Common/HipPlatform.cmake")
 select_gpu_language()
 # select_hip_platform requires the language to be enabled

--- a/Common/FindFilesystem.cmake
+++ b/Common/FindFilesystem.cmake
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
+include(CheckCXXSourceCompiles)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+cmake_push_check_state(RESET)
+
+# find available header: filesystem or experimental/filesystem
+check_include_file_cxx("filesystem" CXX_HAVE_FS_HEADER)
+if (CXX_HAVE_FS_HEADER)
+    set(FS_HEADER filesystem)
+    set(FS_NAMESPACE std::filesystem)
+    set(CXX_FS_HEADER_FOUND ON)
+else()
+    check_include_file_cxx("experimental/filesystem" CXX_HAVE_EXPERIMENTAL_FS_HEADER)
+    if(CXX_HAVE_EXPERIMENTAL_FS_HEADER)
+        set(FS_HEADER experimental/filesystem)
+        set(FS_NAMESPACE std::experimental::filesystem)
+        set(CXX_FS_HEADER_FOUND ON)
+    else()
+        set(CXX_FS_HEADER_FOUND OFF)
+        return()
+    endif()
+endif()
+
+string(CONFIGURE
+[[
+    #include <@FS_HEADER@>
+    #include <iostream>
+
+    int main() {
+        std::cout << @FS_NAMESPACE@::current_path() << std::endl;
+        return 0;
+    }
+]] test_code @ONLY)
+
+# Check if filesystem works without additional libraries
+check_cxx_source_compiles("${test_code}" CXX_FS_NO_LINK)
+
+if (NOT CXX_FS_NO_LINK)
+    # Check if we can link stdc++fs
+	set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
+	check_cxx_source_compiles("${test_code}" CXX_FS_CAN_LINK)
+    if (CXX_FS_CAN_LINK)
+        set(CXX_FS_LIBRARY stdc++fs CACHE STRING "Additional library required to use filesystem" FORCE)
+    endif()
+endif()
+
+cmake_pop_check_state()
+
+if(NOT CXX_FS_NO_LINK AND NOT CXX_FS_CAN_LINK)
+    message(FATAL_ERROR "Cannot run simple program using filesystem")
+endif()

--- a/HIP-Basic/CMakeLists.txt
+++ b/HIP-Basic/CMakeLists.txt
@@ -24,6 +24,8 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Basic LANGUAGES CXX)
 include(CTest)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../Common/FindFilesystem.cmake")
+
 # ROCm installation path
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
@@ -93,11 +95,8 @@ if(NOT "${GPU_RUNTIME}" STREQUAL "CUDA")
         endif()
     endif()
 
-    if(
-        CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-        AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.4"
-    )
-        # g++ < 10.4 does not support all required C++17 features
+    if(NOT CXX_FS_HEADER_FOUND)
+        message("filesystem not found, not building module API example")
     else()
         add_subdirectory(module_api)
     endif()

--- a/HIP-Basic/module_api/main.hip
+++ b/HIP-Basic/module_api/main.hip
@@ -24,10 +24,19 @@
 
 #include <hip/hip_runtime.h>
 
-#include <filesystem>
 #include <iostream>
 #include <numeric>
 #include <vector>
+
+#if __has_include(<filesystem>)
+    #include <filesystem>
+    namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#else
+    static_assert(false, "filesystem not available");
+#endif
 
 int main(int, char* argv[])
 {
@@ -65,9 +74,9 @@ int main(int, char* argv[])
     // To do that, find the directory where the example executable is placed in from the 0th argument.
     // Note that this does not always work (the executable may be invoked with a completely different
     // value for argv[0]), but works for the purposes of this example.
-    std::filesystem::path exe_dir
-        = std::filesystem::weakly_canonical(std::filesystem::path(argv[0])).parent_path();
-    std::filesystem::path module_path = exe_dir / module_file_name;
+    fs::path exe_dir
+        = fs::canonical(fs::path(argv[0])).parent_path();
+    fs::path module_path = exe_dir / module_file_name;
 
     // Load the module from the path that we just constructed.
     // If the module does not exist, this function will return an error.

--- a/Tutorials/CMakeLists.txt
+++ b/Tutorials/CMakeLists.txt
@@ -23,15 +23,18 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(Tutorials LANGUAGES CXX)
 include(CTest)
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
 
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
-if(
-    CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.4"
-)
-    # g++ < 10.4 does not support all required C++17 features
-else()
+# skip redution if execution header is not available (for GCC < 10.1)
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_LIBRARIES "tbb")
+check_include_file_cxx(execution CXX_HAVE_EXECUTION_POLICIES)
+cmake_pop_check_state()
+
+if(CXX_HAVE_EXECUTION_POLICIES)
     add_subdirectory(reduction)
 endif()


### PR DESCRIPTION
Use experimental/filesystem for older GCC versions. Skip reduction tutorial by checking for execution header.


(cherry picked from commit d61371871fad30ce9936074271a02403cfca4164)

Removed HIP-Doc and `fdtd` related changes as they are not available in `release/rocm-rel-7.0` branch yet.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
