### PR TITLE
Add hipTensor examples

### DIFF
--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -47,7 +47,8 @@ jobs:
                     rocfft-dev hipfft-dev \
                     rocsparse-dev \
                     rocthrust-dev \
-                    hipblaslt-dev
+                    hipblaslt-dev \
+                    hiptensor-dev
                   rm -rf /var/lib/apt/lists/*
                   echo "/opt/rocm/bin" >> $GITHUB_PATH
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV

--- a/Common/hiptensor_utils.hpp
+++ b/Common/hiptensor_utils.hpp
@@ -1,0 +1,807 @@
+// MIT License
+//
+// Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef COMMON_HIPTENSOR_UTILS_HPP
+#define COMMON_HIPTENSOR_UTILS_HPP
+
+#include "example_utils.hpp"
+
+#include <hiptensor/hiptensor.hpp>
+#include <hiptensor/hiptensor_types.hpp>
+#include <hiptensor/internal/hiptensor_utility.hpp>
+#include <hiptensor/internal/types.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <unordered_map>
+
+/// \brief Converts a \p hiptensorStatus_t variable to its correspondent string.
+inline const char* hiptensor_status_to_string(hiptensorStatus_t status)
+{
+    switch(status)
+    {
+        case HIPTENSOR_STATUS_SUCCESS: return "HIPTENSOR_STATUS_SUCCESS";
+        case HIPTENSOR_STATUS_NOT_INITIALIZED: return "HIPTENSOR_STATUS_NOT_INITIALIZED";
+        case HIPTENSOR_STATUS_ALLOC_FAILED: return "HIPTENSOR_STATUS_ALLOC_FAILED";
+        case HIPTENSOR_STATUS_INVALID_VALUE: return "HIPTENSOR_STATUS_INVALID_VALUE";
+        case HIPTENSOR_STATUS_ARCH_MISMATCH: return "HIPTENSOR_STATUS_ARCH_MISMATCH";
+        case HIPTENSOR_STATUS_EXECUTION_FAILED: return "HIPTENSOR_STATUS_EXECUTION_FAILED";
+        case HIPTENSOR_STATUS_INTERNAL_ERROR: return "HIPTENSOR_STATUS_INTERNAL_ERROR";
+        case HIPTENSOR_STATUS_NOT_SUPPORTED: return "HIPTENSOR_STATUS_NOT_SUPPORTED";
+        case HIPTENSOR_STATUS_CK_ERROR: return "HIPTENSOR_STATUS_CK_ERROR";
+        case HIPTENSOR_STATUS_HIP_ERROR: return "HIPTENSOR_STATUS_HIP_ERROR";
+        case HIPTENSOR_STATUS_INSUFFICIENT_WORKSPACE:
+            return "HIPTENSOR_STATUS_INSUFFICIENT_WORKSPACE";
+        case HIPTENSOR_STATUS_INSUFFICIENT_DRIVER: return "HIPTENSOR_STATUS_INSUFFICIENT_DRIVER";
+        case HIPTENSOR_STATUS_IO_ERROR: return "HIPTENSOR_STATUS_IO_ERROR";
+        // We do use default because we are not in control of these enumeration values.
+        // Ideally this function is something hiptensor would provide
+        default: return "<unknown hiptensorStatus_t value>";
+    }
+}
+
+/// \brief Checks if the provided status code is \p HIPTENSOR_STATUS_SUCCESS and if not,
+/// prints an error message to the standard error output and terminates the program
+/// with an error code.
+#define HIPTENSOR_CHECK(condition)                                                               \
+    {                                                                                            \
+        const hiptensorStatus_t status = (condition);                                            \
+        if(status != HIPTENSOR_STATUS_SUCCESS)                                                   \
+        {                                                                                        \
+            std::cerr << "hipTensor error encountered: \"" << hiptensor_status_to_string(status) \
+                      << "\" at " << __FILE__ << ':' << __LINE__ << std::endl;                   \
+            std::exit(error_exit_code);                                                          \
+        }                                                                                        \
+    }
+
+#define MAX_ELEMENTS_PRINT_COUNT 512
+
+#define HIPTENSOR_FREE_DEVICE(ptr) \
+    if(ptr != nullptr)             \
+    {                              \
+        HIP_CHECK(hipFree(ptr));   \
+    }
+
+#define HIPTENSOR_FREE_HOST(ptr)     \
+    if(ptr != nullptr)               \
+    {                                \
+        HIP_CHECK(hipHostFree(ptr)); \
+    }
+
+inline bool is_f32_supported()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    HIP_CHECK(hipGetDevice(&mHandle));
+    HIP_CHECK(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return (deviceName.find("gfx908") != std::string::npos)
+           || (deviceName.find("gfx90a") != std::string::npos)
+           || (deviceName.find("gfx942") != std::string::npos)
+           || (deviceName.find("gfx950") != std::string::npos);
+}
+
+inline bool is_f64_supported()
+{
+    hipDevice_t     mHandle;
+    hipDeviceProp_t mProps;
+
+    HIP_CHECK(hipGetDevice(&mHandle));
+    HIP_CHECK(hipGetDeviceProperties(&mProps, mHandle));
+
+    std::string deviceName(mProps.gcnArchName);
+
+    return (deviceName.find("gfx90a") != std::string::npos)
+           || (deviceName.find("gfx942") != std::string::npos)
+           || (deviceName.find("gfx950") != std::string::npos);
+}
+
+template<typename T>
+void hiptensor_print_array_elements(std::ostream& stream, T* vec, size_t size)
+{
+    for(size_t index = 0; index < size; ++index)
+    {
+        if constexpr(std::is_same_v<T, float2> || std::is_same_v<T, double2>)
+        {
+            stream << "(" << vec[index].x << ", " << vec[index].y << ")";
+        }
+        else if constexpr(std::is_same_v<T, _Float16>)
+        {
+            stream << static_cast<float>(vec[index]);
+        }
+        else
+        {
+            stream << vec[index];
+        }
+
+        if(index != size - 1)
+        {
+            stream << ", ";
+        }
+    }
+}
+
+template<typename S>
+void hiptensor_print_vector_elements(const std::vector<S>& vec, std::string sep = " ")
+{
+    for(auto& elem : vec)
+    {
+        std::cout << elem;
+        if(&elem != &vec.back())
+        {
+            std::cout << sep;
+        }
+    }
+}
+
+template<typename F>
+void hiptensor_print_elements_to_file(std::ofstream& fs,
+                                      F*             output,
+                                      size_t         size,
+                                      std::string    sep = " ")
+{
+    if(!fs.is_open())
+    {
+        std::cout << "File not found!\n";
+        return;
+    }
+
+    for(size_t i = 0; i < size; i++)
+    {
+        if constexpr(std::is_same_v<F, float2> || std::is_same_v<F, double2>)
+        {
+            fs << "(" << output[i].x << ", " << output[i].y << ")";
+        }
+        else if constexpr(std::is_same_v<F, _Float16>)
+        {
+            fs << static_cast<float>(output[i]);
+        }
+        else
+        {
+            fs << static_cast<F>(output[i]);
+        }
+
+        if(i != size - 1)
+        {
+            fs << sep;
+        }
+    }
+    return;
+}
+
+// Bilinear contraction sample function
+template<typename ADataType,
+         typename BDataType,
+         typename CDataType,
+         hiptensorDataType_t          typeA,
+         hiptensorDataType_t          typeB,
+         hiptensorDataType_t          typeC,
+         hiptensorComputeDescriptor_t typeCompute>
+int bilinear_contraction_sample(void* alpha, void* beta)
+{
+    // Computing: C_{m,n,u,v} = alpha * A_{m,n,h,k} B_{u,v,h,k} + beta * C_{m,n,u,v}
+
+    std::vector<int> mode_c{'m', 'n', 'u', 'v'};
+    std::vector<int> mode_a{'m', 'n', 'h', 'k'};
+    std::vector<int> mode_b{'u', 'v', 'h', 'k'};
+
+    int nmode_a = mode_a.size();
+    int nmode_b = mode_b.size();
+    int nmode_c = mode_c.size();
+
+    std::unordered_map<int, int64_t> extent;
+
+    extent['m'] = 4;
+    extent['n'] = 3;
+    extent['u'] = 4;
+    extent['v'] = 3;
+    extent['h'] = 6;
+    extent['k'] = 5;
+
+    std::vector<int64_t> c_ms_ns_lengths;
+    for(auto mode : mode_c)
+    {
+        c_ms_ns_lengths.push_back(extent[mode]);
+    }
+
+    std::vector<int64_t> a_ms_ks_lengths;
+    for(auto mode : mode_a)
+    {
+        a_ms_ks_lengths.push_back(extent[mode]);
+    }
+
+    std::vector<int64_t> b_ns_ks_lengths;
+    for(auto mode : mode_b)
+    {
+        b_ns_ks_lengths.push_back(extent[mode]);
+    }
+
+    // Allocating data
+    std::cout << "Initializing host data..." << std::endl;
+
+    size_t elements_a = std::accumulate(a_ms_ks_lengths.begin(),
+                                        a_ms_ks_lengths.end(),
+                                        size_t{1},
+                                        std::multiplies<size_t>());
+    size_t elements_b = std::accumulate(b_ns_ks_lengths.begin(),
+                                        b_ns_ks_lengths.end(),
+                                        size_t{1},
+                                        std::multiplies<size_t>());
+    size_t elements_c = std::accumulate(c_ms_ns_lengths.begin(),
+                                        c_ms_ns_lengths.end(),
+                                        size_t{1},
+                                        std::multiplies<size_t>());
+
+    size_t size_a = sizeof(ADataType) * elements_a;
+    size_t size_b = sizeof(BDataType) * elements_b;
+    size_t size_c = sizeof(CDataType) * elements_c;
+
+    ADataType* A = nullptr;
+    BDataType* B = nullptr;
+    CDataType* C = nullptr;
+    HIP_CHECK(hipHostMalloc((void**)&A, size_a));
+    HIP_CHECK(hipHostMalloc((void**)&B, size_b));
+    HIP_CHECK(hipHostMalloc((void**)&C, size_c));
+
+    void *A_d, *B_d, *C_d;
+
+    HIP_CHECK(hipMalloc(static_cast<void**>(&A_d), size_a));
+    HIP_CHECK(hipMalloc(static_cast<void**>(&B_d), size_b));
+    HIP_CHECK(hipMalloc(static_cast<void**>(&C_d), size_c));
+
+    // Initialize data
+    int init_method = 1; // TODO read value from commandline
+    for(size_t i = 0; i < elements_a; i++)
+    {
+        if(init_method == 0)
+        {
+            A[i] = ADataType(float(std::rand()) / float(RAND_MAX) - 0.5) * 100;
+        }
+        else
+        {
+            A[i] = (ADataType)(float(i) / 100);
+        }
+    }
+
+    for(size_t i = 0; i < elements_b; i++)
+    {
+        if(init_method == 0)
+        {
+            B[i] = BDataType(float(std::rand()) / float(RAND_MAX) - 0.5) * 100;
+        }
+        else
+        {
+            B[i] = (BDataType)(float(i) / 100);
+        }
+    }
+
+    for(size_t i = 0; i < elements_c; i++)
+    {
+        if(init_method == 0)
+        {
+            C[i] = CDataType(float(std::rand()) / float(RAND_MAX) - 0.5) * 100;
+        }
+        else
+        {
+            C[i] = (BDataType)(float(i) / 100);
+        }
+    }
+
+    // Transfer the Host Tensor to Device Memory
+    std::cout << "Initializing device data..." << std::endl;
+
+    HIP_CHECK(hipMemcpy(A_d, static_cast<const void*>(A), size_a, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(B_d, static_cast<const void*>(B), size_b, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(C_d, static_cast<const void*>(C), size_c, hipMemcpyHostToDevice));
+
+    // Retrieve the memory alignment for each tensor
+    uint32_t          alignment_requirement = 1;
+    hiptensorHandle_t handle;
+    HIPTENSOR_CHECK(hiptensorCreate(&handle));
+
+    HIPTENSOR_CHECK(hiptensorLoggerSetMask(HIPTENSOR_LOG_LEVEL_PERF_TRACE));
+
+    // Initialize tensors with the input lengths
+    hiptensorTensorDescriptor_t a_ms_ks = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &a_ms_ks,
+                                                    nmode_a,
+                                                    a_ms_ks_lengths.data(),
+                                                    NULL, /*stride*/
+                                                    typeA,
+                                                    alignment_requirement));
+
+    hiptensorTensorDescriptor_t b_ns_ks = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &b_ns_ks,
+                                                    nmode_b,
+                                                    b_ns_ks_lengths.data(),
+                                                    NULL, /*stride*/
+                                                    typeB,
+                                                    alignment_requirement));
+
+    hiptensorTensorDescriptor_t c_ms_ns = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &c_ms_ns,
+                                                    nmode_c,
+                                                    c_ms_ns_lengths.data(),
+                                                    NULL, /*stride*/
+                                                    typeC,
+                                                    alignment_requirement));
+
+    // Create Contraction Descriptor
+    hiptensorOperationDescriptor_t desc;
+    HIPTENSOR_CHECK(hiptensorCreateContraction(handle,
+                                               &desc,
+                                               a_ms_ks,
+                                               mode_a.data(),
+                                               HIPTENSOR_OP_IDENTITY,
+                                               b_ns_ks,
+                                               mode_b.data(),
+                                               HIPTENSOR_OP_IDENTITY,
+                                               c_ms_ns,
+                                               mode_c.data(),
+                                               HIPTENSOR_OP_IDENTITY,
+                                               c_ms_ns,
+                                               mode_c.data(),
+                                               typeCompute));
+
+    // Set the algorithm to use
+    hiptensorPlanPreference_t plan_pref;
+    HIPTENSOR_CHECK(hiptensorCreatePlanPreference(handle,
+                                                  &plan_pref,
+                                                  HIPTENSOR_ALGO_ACTOR_CRITIC,
+                                                  HIPTENSOR_JIT_MODE_NONE));
+
+    // Query workspace
+    uint64_t worksize = 0;
+    HIPTENSOR_CHECK(hiptensorEstimateWorkspaceSize(handle,
+                                                   desc,
+                                                   plan_pref,
+                                                   HIPTENSOR_WORKSPACE_DEFAULT,
+                                                   &worksize));
+
+    // Create Contraction Plan
+    std::cout << "Initializing contraction plan..." << std::endl;
+
+    hiptensorPlan_t plan;
+    HIPTENSOR_CHECK(hiptensorCreatePlan(handle, &plan, desc, plan_pref, worksize));
+
+    // TODO query actually used workspace
+    void* workspace = nullptr;
+
+    if(worksize > 0)
+    {
+        HIP_CHECK(hipMalloc(static_cast<void**>(&workspace), worksize));
+    }
+
+    std::cout << "Launching contraction kernel..." << std::endl;
+
+    HIPTENSOR_CHECK(hiptensorContract(handle,
+                                      plan,
+                                      alpha,
+                                      A_d,
+                                      B_d,
+                                      beta,
+                                      C_d,
+                                      C_d,
+                                      workspace,
+                                      worksize,
+                                      0 /* stream */));
+
+#if !NDEBUG
+    bool print_elements = false;
+    bool store_elements = false;
+
+    if(print_elements)
+    {
+        if(elements_a < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor A elements:\n";
+            hiptensor_print_array_elements(std::cout, A, elements_a);
+            std::cout << std::endl;
+        }
+
+        if(elements_b < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor B elements:\n";
+            hiptensor_print_array_elements(std::cout, B, elements_b);
+            std::cout << std::endl;
+        }
+
+        if(elements_c < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor C elements:\n";
+            hiptensor_print_array_elements(std::cout, C, elements_c);
+            std::cout << std::endl;
+        }
+
+        HIP_CHECK(hipMemcpy(C, C_d, size_c, hipMemcpyDeviceToHost));
+
+        if(elements_c < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor D elements:\n";
+            hiptensor_print_array_elements(std::cout, C, elements_c);
+            std::cout << std::endl;
+        }
+    }
+
+    if(store_elements)
+    {
+        std::ofstream tensor_a, tensor_b, tensor_c;
+        tensor_a.open("tensor_A.txt");
+        hiptensor_print_elements_to_file(tensor_a, A, elements_a, ", ");
+        tensor_a.close();
+
+        tensor_b.open("tensor_B.txt");
+        hiptensor_print_elements_to_file(tensor_b, B, elements_b, ", ");
+        tensor_b.close();
+
+        tensor_c.open("tensor_C.txt");
+        hiptensor_print_elements_to_file(tensor_c, C, elements_c, ", ");
+        tensor_c.close();
+
+        HIP_CHECK(hipMemcpy(C, C_d, size_c, hipMemcpyDeviceToHost));
+
+        tensor_c.open("tensor_C_scale_contraction_results.txt");
+        hiptensor_print_elements_to_file(tensor_c, C, elements_c, ", ");
+        tensor_c.close();
+    }
+#endif
+
+    HIPTENSOR_CHECK(hiptensorDestroy(handle));
+    HIPTENSOR_CHECK(hiptensorDestroyPlanPreference(plan_pref));
+    HIPTENSOR_CHECK(hiptensorDestroyPlan(plan));
+    HIPTENSOR_CHECK(hiptensorDestroyOperationDescriptor(desc));
+    if(a_ms_ks)
+    {
+        hiptensorDestroyTensorDescriptor(a_ms_ks);
+        a_ms_ks = nullptr;
+    }
+    if(b_ns_ks)
+    {
+        hiptensorDestroyTensorDescriptor(b_ns_ks);
+        b_ns_ks = nullptr;
+    }
+    if(c_ms_ns)
+    {
+        hiptensorDestroyTensorDescriptor(c_ms_ns);
+        c_ms_ns = nullptr;
+    }
+
+    HIPTENSOR_FREE_HOST(A);
+    HIPTENSOR_FREE_HOST(B);
+    HIPTENSOR_FREE_HOST(C);
+
+    HIPTENSOR_FREE_DEVICE(A_d);
+    HIPTENSOR_FREE_DEVICE(B_d);
+    HIPTENSOR_FREE_DEVICE(C_d);
+    HIPTENSOR_FREE_DEVICE(workspace);
+
+    std::cout << "Finished!" << std::endl;
+
+    return 0;
+}
+
+// Scale contraction sample function
+template<typename ADataType,
+         typename BDataType,
+         typename DDataType,
+         hiptensorDataType_t          typeA,
+         hiptensorDataType_t          typeB,
+         hiptensorDataType_t          typeD,
+         hiptensorComputeDescriptor_t typeCompute>
+int scale_contraction_sample(void* alpha)
+{
+    // Computing: C_{m,n,u,v} = A_{m,n,h,k} B_{h,k,u,v}
+
+    std::vector<int> mode_d{'m', 'n', 'u', 'v'};
+    std::vector<int> mode_a{'m', 'n', 'h', 'k'};
+    std::vector<int> mode_b{'u', 'v', 'h', 'k'};
+
+    int nmode_a = mode_a.size();
+    int nmode_b = mode_b.size();
+    int nmode_d = mode_d.size();
+
+    std::unordered_map<int, int64_t> extent;
+
+    extent['m'] = 4;
+    extent['n'] = 3;
+    extent['u'] = 4;
+    extent['v'] = 3;
+    extent['h'] = 6;
+    extent['k'] = 5;
+
+    std::vector<int64_t> d_ms_ns_lengths;
+    for(auto mode : mode_d)
+    {
+        d_ms_ns_lengths.push_back(extent[mode]);
+    }
+
+    std::vector<int64_t> a_ms_ks_lengths;
+    for(auto mode : mode_a)
+    {
+        a_ms_ks_lengths.push_back(extent[mode]);
+    }
+
+    std::vector<int64_t> b_ns_ks_lengths;
+    for(auto mode : mode_b)
+    {
+        b_ns_ks_lengths.push_back(extent[mode]);
+    }
+
+    // Allocating data
+    std::cout << "Initializing host data..." << std::endl;
+
+    size_t elements_a = std::accumulate(a_ms_ks_lengths.begin(),
+                                        a_ms_ks_lengths.end(),
+                                        size_t{1},
+                                        std::multiplies<size_t>());
+    size_t elements_b = std::accumulate(b_ns_ks_lengths.begin(),
+                                        b_ns_ks_lengths.end(),
+                                        size_t{1},
+                                        std::multiplies<size_t>());
+    size_t elements_d = std::accumulate(d_ms_ns_lengths.begin(),
+                                        d_ms_ns_lengths.end(),
+                                        size_t{1},
+                                        std::multiplies<size_t>());
+
+    size_t size_a = sizeof(ADataType) * elements_a;
+    size_t size_b = sizeof(BDataType) * elements_b;
+    size_t size_d = sizeof(DDataType) * elements_d;
+
+    ADataType* A = nullptr;
+    BDataType* B = nullptr;
+    DDataType* D = nullptr;
+    HIP_CHECK(hipHostMalloc((void**)&A, size_a));
+    HIP_CHECK(hipHostMalloc((void**)&B, size_b));
+    HIP_CHECK(hipHostMalloc((void**)&D, size_d));
+
+    void *A_d, *B_d, *D_d;
+
+    HIP_CHECK(hipMalloc(static_cast<void**>(&A_d), size_a));
+    HIP_CHECK(hipMalloc(static_cast<void**>(&B_d), size_b));
+    HIP_CHECK(hipMalloc(static_cast<void**>(&D_d), size_d));
+
+    // Initialize data
+    int init_method = 1; // TODO read the value from command line
+    for(size_t i = 0; i < elements_a; i++)
+    {
+        if(init_method == 0)
+        {
+            A[i] = ADataType(float(std::rand()) / float(RAND_MAX) - 0.5) * 100;
+        }
+        else
+        {
+            A[i] = (ADataType)(float(i) / 100);
+        }
+    }
+
+    for(size_t i = 0; i < elements_b; i++)
+    {
+        if(init_method == 0)
+        {
+            B[i] = BDataType(float(std::rand()) / float(RAND_MAX) - 0.5) * 100;
+        }
+        else
+        {
+            B[i] = (BDataType)(float(i) / 100);
+        }
+    }
+
+    for(size_t i = 0; i < elements_d; i++)
+    {
+        D[i] = std::numeric_limits<DDataType>::signaling_NaN();
+    }
+
+    // Transfer the Host Tensor to Device Memory
+    std::cout << "Initializing device data..." << std::endl;
+
+    HIP_CHECK(hipMemcpy(A_d, static_cast<const void*>(A), size_a, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(B_d, static_cast<const void*>(B), size_b, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(D_d, 0, size_d));
+
+    // Retrieve the memory alignment for each tensor
+    uint32_t          alignment_requirement = 1;
+    hiptensorHandle_t handle;
+    HIPTENSOR_CHECK(hiptensorCreate(&handle));
+
+    HIPTENSOR_CHECK(hiptensorLoggerSetMask(HIPTENSOR_LOG_LEVEL_PERF_TRACE));
+
+    // Initialize tensors with the input lengths
+    hiptensorTensorDescriptor_t a_ms_ks;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &a_ms_ks,
+                                                    nmode_a,
+                                                    a_ms_ks_lengths.data(),
+                                                    NULL, /*stride*/
+                                                    typeA,
+                                                    alignment_requirement));
+
+    hiptensorTensorDescriptor_t b_ns_ks;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &b_ns_ks,
+                                                    nmode_b,
+                                                    b_ns_ks_lengths.data(),
+                                                    NULL, /*stride*/
+                                                    typeB,
+                                                    alignment_requirement));
+
+    hiptensorTensorDescriptor_t d_ms_ns;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &d_ms_ns,
+                                                    nmode_d,
+                                                    d_ms_ns_lengths.data(),
+                                                    NULL, /*stride*/
+                                                    typeD,
+                                                    alignment_requirement));
+
+    // Create Contraction Descriptor
+    hiptensorOperationDescriptor_t desc;
+    HIPTENSOR_CHECK(hiptensorCreateContraction(handle,
+                                               &desc,
+                                               a_ms_ks,
+                                               mode_a.data(),
+                                               HIPTENSOR_OP_IDENTITY,
+                                               b_ns_ks,
+                                               mode_b.data(),
+                                               HIPTENSOR_OP_IDENTITY,
+                                               nullptr,
+                                               nullptr,
+                                               HIPTENSOR_OP_IDENTITY,
+                                               d_ms_ns,
+                                               mode_d.data(),
+                                               typeCompute));
+
+    // Set the algorithm to use
+    hiptensorPlanPreference_t plan_pref;
+    HIPTENSOR_CHECK(hiptensorCreatePlanPreference(handle,
+                                                  &plan_pref,
+                                                  HIPTENSOR_ALGO_ACTOR_CRITIC,
+                                                  HIPTENSOR_JIT_MODE_NONE));
+
+    // Query workspace
+    uint64_t worksize = 0;
+    HIPTENSOR_CHECK(hiptensorEstimateWorkspaceSize(handle,
+                                                   desc,
+                                                   plan_pref,
+                                                   HIPTENSOR_WORKSPACE_DEFAULT,
+                                                   &worksize));
+
+    // Create Contraction Plan
+    std::cout << "Initializing contraction plan..." << std::endl;
+
+    hiptensorPlan_t plan;
+    HIPTENSOR_CHECK(hiptensorCreatePlan(handle, &plan, desc, plan_pref, worksize));
+
+    // TODO query actually used workspace
+    void* workspace = nullptr;
+
+    if(worksize > 0)
+    {
+        HIP_CHECK(hipMalloc(static_cast<void**>(&workspace), worksize));
+    }
+
+    std::cout << "Launching contraction kernel..." << std::endl;
+
+    HIPTENSOR_CHECK(hiptensorContract(handle,
+                                      plan,
+                                      alpha,
+                                      A_d,
+                                      B_d,
+                                      nullptr,
+                                      nullptr,
+                                      D_d,
+                                      workspace,
+                                      worksize,
+                                      0 /* stream */));
+
+#if !NDEBUG
+    bool print_elements = false;
+    bool store_elements = false;
+
+    if(print_elements || store_elements)
+    {
+        HIP_CHECK(hipMemcpy(D, D_d, size_d, hipMemcpyDeviceToHost));
+    }
+
+    if(print_elements)
+    {
+        if(elements_a < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor A elements:\n";
+            hiptensor_print_array_elements(std::cout, A, elements_a);
+            std::cout << std::endl;
+        }
+
+        if(elements_b < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor B elements:\n";
+            hiptensor_print_array_elements(std::cout, B, elements_b);
+            std::cout << std::endl;
+        }
+
+        if(elements_d < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor D elements:\n";
+            hiptensor_print_array_elements(std::cout, D, elements_d);
+            std::cout << std::endl;
+        }
+    }
+
+    if(store_elements)
+    {
+        std::ofstream tensor_a, tensor_b, tensor_d;
+        tensor_a.open("tensor_A.txt");
+        hiptensor_print_elements_to_file(tensor_a, A, elements_a, ", ");
+        tensor_a.close();
+
+        tensor_b.open("tensor_B.txt");
+        hiptensor_print_elements_to_file(tensor_b, B, elements_b, ", ");
+        tensor_b.close();
+
+        tensor_d.open("tensor_D_scale_contraction_results.txt");
+        hiptensor_print_elements_to_file(tensor_d, D, elements_d, ", ");
+        tensor_d.close();
+    }
+#endif
+
+    HIPTENSOR_CHECK(hiptensorDestroy(handle));
+    HIPTENSOR_CHECK(hiptensorDestroyPlan(plan));
+    HIPTENSOR_CHECK(hiptensorDestroyOperationDescriptor(desc));
+    if(a_ms_ks)
+    {
+        HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(a_ms_ks));
+        a_ms_ks = nullptr;
+    }
+    if(b_ns_ks)
+    {
+        HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(b_ns_ks));
+        b_ns_ks = nullptr;
+    }
+    if(d_ms_ns)
+    {
+        HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(d_ms_ns));
+        d_ms_ns = nullptr;
+    }
+
+    HIPTENSOR_FREE_HOST(A);
+    HIPTENSOR_FREE_HOST(B);
+    HIPTENSOR_FREE_HOST(D);
+
+    HIPTENSOR_FREE_DEVICE(A_d);
+    HIPTENSOR_FREE_DEVICE(B_d);
+    HIPTENSOR_FREE_DEVICE(D_d);
+    HIPTENSOR_FREE_DEVICE(workspace);
+
+    std::cout << "Finished!" << std::endl;
+
+    return 0;
+}
+
+#endif // COMMON_HIPTENSOR_UTILS_HPP

--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -31,6 +31,7 @@ LIBRARIES := \
 
 ifneq ($(GPU_RUNTIME), CUDA)
 LIBRARIES += \
+	hipTensor \
 	rocBLAS \
 	rocFFT \
 	rocPRIM \

--- a/Libraries/hipTensor/CMakeLists.txt
+++ b/Libraries/hipTensor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,29 +21,34 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
+project(hipTensor_examples LANGUAGES CXX)
 include(CTest)
 
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
 endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor)
+if(NOT hiptensor_FOUND)
+    message(
+        STATUS
+        "hipTensor could not be found, not building hipTensor examples"
+    )
+    return(1)
+endif()
+
+add_subdirectory(contraction)
+add_subdirectory(elementwise)
+add_subdirectory(reduction)

--- a/Libraries/hipTensor/Makefile
+++ b/Libraries/hipTensor/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+EXAMPLES := \
+	contraction \
+	elementwise \
+	reduction
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+all: $(EXAMPLES)
 
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+clean: TARGET=clean
+clean: all
+
+$(EXAMPLES):
+	$(MAKE) -C $@ $(TARGET)
+
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipTensor/README.md
+++ b/Libraries/hipTensor/README.md
@@ -1,0 +1,39 @@
+# hipTensor Examples
+
+## Summary
+
+The examples in this subdirectory showcase the functionality of the [hipTensor](https://github.com/ROCm/hipTensor) library. The examples build only on Linux for the ROCm (AMD GPU) backend.
+
+## Prerequisites
+
+### Linux
+
+- [CMake](https://cmake.org/download/) (at least version 3.21).
+- Or GNU Make - available via the distribution's package manager.
+- [ROCm](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html) (at least version 7.x.x).
+- [hipTensor](https://github.com/ROCm/hipTensor): `hiptensor` package available from [repo.radeon.com](https://repo.radeon.com/rocm/). The repository is added during the standard ROCm [install procedure](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html).
+
+### Windows
+
+Support for Windows will be included in the future.
+
+## Building
+
+### Linux
+
+Ensure the dependencies are installed, or use the [provided Dockerfiles](../../Dockerfiles/) to build and run the examples in a containerized environment that has all prerequisites installed.
+
+#### Using CMake
+
+All examples in the `hipTensor` subdirectory can either be built by a single CMake project or be built independently.
+
+- `$ cd Libraries/hipTensor`
+- `$ cmake -S . -B build`
+- `$ cmake --build build`
+
+#### Using Make
+
+All examples can be built by a single invocation to Make or be built independently.
+
+- `$ cd Libraries/hipTensor`
+- `$ make`

--- a/Libraries/hipTensor/contraction/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,29 +21,7 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+project(hipTensor_contraction_examples LANGUAGES CXX)
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
-
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+add_subdirectory(bilinear)
+add_subdirectory(scale)

--- a/Libraries/hipTensor/contraction/Makefile
+++ b/Libraries/hipTensor/contraction/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+EXAMPLES := \
+	bilinear \
+	scale
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+all: $(EXAMPLES)
 
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+clean: TARGET=clean
+clean: all
+
+$(EXAMPLES):
+	$(MAKE) -C $@ $(TARGET)
+
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/bilinear/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,29 +21,13 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+project(hipTensor_contraction_bilinear_examples LANGUAGES CXX)
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
-
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+add_subdirectory(bf16_f32)
+add_subdirectory(cf32_cf32)
+add_subdirectory(f16_f32)
+add_subdirectory(f32_bf16)
+add_subdirectory(f32_f16)
+add_subdirectory(f32_f32)
+add_subdirectory(f64_f32)
+add_subdirectory(f64_f64)

--- a/Libraries/hipTensor/contraction/bilinear/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+EXAMPLES := \
+	bf16_f32 \
+	cf32_cf32 \
+	f16_f32 \
+	f32_bf16 \
+	f32_f16 \
+	f32_f32 \
+	f64_f32 \
+	f64_f64
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+all: $(EXAMPLES)
 
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+clean: TARGET=clean
+clean: all
+
+$(EXAMPLES):
+	$(MAKE) -C $@ $(TARGET)
+
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_bf16_f32

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_bf16_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_bf16_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/README.md
@@ -1,0 +1,104 @@
+# hipTensor BF16 Data with FP32 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with BFloat16 precision for data storage and FP32 for computation.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define BFloat16 data types for tensors and FP32 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_16BF` for BFloat16).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_16BF`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `hip_bfloat16`

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef hip_bfloat16 data_type_a;
+    typedef hip_bfloat16 data_type_b;
+    typedef hip_bfloat16 data_type_c;
+    typedef float        float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_16BF;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_16BF;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_16BF;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_cf32_cf32

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_cf32_cf32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_cf32_cf32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/README.md
@@ -1,0 +1,104 @@
+# hipTensor CF32 Data with CF32 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with single-precision complex floating-point data.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are complex scalars
+- $A$ is a complex tensor of dimensions $m \times n \times h \times k$
+- $B$ is a complex tensor of dimensions $u \times v \times h \times k$
+- $C$ is a complex tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define complex float data types for tensors and computations.
+3. Set up hipTensor data type descriptors.
+4. Set complex scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_C_32F` for complex single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_C32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_C_32F`
+- `HIPTENSOR_COMPUTE_C32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `hipFloatComplex`

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef hipFloatComplex data_type_a;
+    typedef hipFloatComplex data_type_b;
+    typedef hipFloatComplex data_type_c;
+    typedef hipFloatComplex float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_C_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_C_32F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_C_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_C32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f, 1.0f};
+    float_type_compute beta{1.0f, 1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_f16_f32

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_f16_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_f16_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/README.md
@@ -1,0 +1,104 @@
+# hipTensor FP16 Data with FP32 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with FP16 precision for data storage and FP32 for computation.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP16 data types for tensors and FP32 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_16F` for half-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_16F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `_Float16`

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef _Float16 data_type_a;
+    typedef _Float16 data_type_b;
+    typedef _Float16 data_type_c;
+    typedef float    float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_16F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_16F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_16F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_f32_bf16

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_f32_bf16)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_f32_bf16
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/README.md
@@ -1,0 +1,104 @@
+# hipTensor FP32 Data with BF16 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with a mixed precision approach, combining FP32 data and BFloat16 computations.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP32 data types for tensors and BFloat16 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_16BF` for BFloat16).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_16BF`
+- `HIPTENSOR_OP_IDENTITY`
+- `hip_bfloat16`

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef float        data_type_a;
+    typedef float        data_type_b;
+    typedef float        data_type_c;
+    typedef hip_bfloat16 float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_16BF;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_f32_f16

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_f32_f16)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_f32_f16
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/README.md
@@ -1,0 +1,104 @@
+# hipTensor FP32 Data with F16 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with an inverse mixed precision approach, combining FP32 data storage and FP16 computations.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP32 data types for tensors and FP16 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_16F` for half-precision).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_16F`
+- `HIPTENSOR_OP_IDENTITY`
+- `_Float16`

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef float    data_type_a;
+    typedef float    data_type_b;
+    typedef float    data_type_c;
+    typedef _Float16 float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_16F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_f32_f32

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_f32_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_f32_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/README.md
@@ -1,0 +1,103 @@
+# hipTensor FP32 Data with FP32 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with FP32 precision.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP32 data types for all tensors and computations.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef float data_type_a;
+    typedef float data_type_b;
+    typedef float data_type_c;
+    typedef float float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_f64_f32

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_f64_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_f64_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/README.md
@@ -1,0 +1,103 @@
+# hipTensor FP64 Data with FP32 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with a mixed precision approach, combining double-precision data storage and single-precision computations.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F64 operations are supported on the current device.
+2. Define double precision data types for tensors and single precision for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_64F` for double-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_64F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F64 is supported.
+    if(!is_f64_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef double data_type_a;
+    typedef double data_type_b;
+    typedef double data_type_c;
+    typedef float  float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_64F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/.gitignore
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_bilinear_f64_f64

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_bilinear_f64_f64)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_bilinear_f64_f64
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/README.md
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/README.md
@@ -1,0 +1,103 @@
+# hipTensor FP64 Data with FP64 Compute Bilinear Contraction
+
+## Description
+
+This example illustrates how to perform a bilinear tensor contraction operation using the `hipTensor` library with full double-precision floating-point arithmetic.
+
+The operation calculates the following:
+
+$C_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k} + \beta \cdot C_{m,n,u,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $C$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F64 operations are supported on the current device.
+2. Define double precision data types for all tensors and computations.
+3. Set up hipTensor data type descriptors.
+4. Set scalar coefficient values.
+5. Call the `bilinear_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the bilinear contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_64F` for double-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_64F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_64F`
+- `HIPTENSOR_COMPUTE_64F`
+- `HIPTENSOR_OP_IDENTITY`

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/main.cpp
@@ -1,0 +1,58 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F64 is supported.
+    if(!is_f64_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef double data_type_a;
+    typedef double data_type_b;
+    typedef double data_type_c;
+    typedef double float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_c       = HIPTENSOR_R_64F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_64F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha{1.0f};
+    float_type_compute beta{1.0f};
+
+    // 5. Run bilinear contraction sample.
+    return bilinear_contraction_sample<data_type_a,
+                                       data_type_b,
+                                       data_type_c,
+                                       type_a,
+                                       type_b,
+                                       type_c,
+                                       type_compute>(&alpha, &beta);
+}

--- a/Libraries/hipTensor/contraction/scale/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,29 +21,13 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+project(hipTensor_contraction_scale_examples LANGUAGES CXX)
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
-
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+add_subdirectory(bf16_f32)
+add_subdirectory(cf32_cf32)
+add_subdirectory(f16_f32)
+add_subdirectory(f32_bf16)
+add_subdirectory(f32_f16)
+add_subdirectory(f32_f32)
+add_subdirectory(f64_f32)
+add_subdirectory(f64_f64)

--- a/Libraries/hipTensor/contraction/scale/Makefile
+++ b/Libraries/hipTensor/contraction/scale/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+EXAMPLES := \
+	bf16_f32 \
+	cf32_cf32 \
+	f16_f32 \
+	f32_bf16 \
+	f32_f16 \
+	f32_f32 \
+	f64_f32 \
+	f64_f64
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+all: $(EXAMPLES)
 
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+clean: TARGET=clean
+clean: all
+
+$(EXAMPLES):
+	$(MAKE) -C $@ $(TARGET)
+
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_bf16_f32

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_bf16_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_bf16_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/README.md
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/README.md
@@ -1,0 +1,105 @@
+# hipTensor BF16 Data with FP32 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with BFloat16 precision for data storage and FP32 for computation.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define BFloat16 data types for tensors and FP32 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_16BF` for BFloat16).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_16BF`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `hip_bfloat16`

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef hip_bfloat16 data_type_a;
+    typedef hip_bfloat16 data_type_b;
+    typedef hip_bfloat16 data_type_d;
+    typedef float        float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_16BF;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_16BF;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_16BF;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = 1;
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_cf32_cf32

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_cf32_cf32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_cf32_cf32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/README.md
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/README.md
@@ -1,0 +1,105 @@
+# hipTensor CF32 Data with CF32 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with single-precision complex floating-point data.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a complex scalar
+- $A$ is a complex tensor of dimensions $m \times n \times h \times k$
+- $B$ is a complex tensor of dimensions $u \times v \times h \times k$
+- $D$ is a complex tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define complex float data types for tensors and computations.
+3. Set up hipTensor data type descriptors.
+4. Set the complex scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_C_32F` for complex single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_C32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_C_32F`
+- `HIPTENSOR_COMPUTE_C32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `hipFloatComplex`

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef hipFloatComplex data_type_a;
+    typedef hipFloatComplex data_type_b;
+    typedef hipFloatComplex data_type_d;
+    typedef hipFloatComplex float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_C_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_C_32F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_C_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_C32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha(1, 1);
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/f16_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_f16_f32

--- a/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_f16_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/f16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_f16_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/f16_f32/README.md
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/README.md
@@ -1,0 +1,105 @@
+# hipTensor FP16 Data with FP32 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with FP16 precision for data storage and FP32 for computation.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP16 data types for tensors and FP32 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_16F` for half-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_16F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `_Float16`

--- a/Libraries/hipTensor/contraction/scale/f16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef _Float16 data_type_a;
+    typedef _Float16 data_type_b;
+    typedef _Float16 data_type_d;
+    typedef float    float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_16F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_16F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_16F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = 1;
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_f32_bf16

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_f32_bf16)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_f32_bf16
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/README.md
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/README.md
@@ -1,0 +1,105 @@
+# hipTensor FP32 Data with BF16 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with an inverse mixed precision approach, combining FP32 data storage and BFloat16 computations.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP32 data types for tensors and BFloat16 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_16BF` for BFloat16).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_16BF`
+- `HIPTENSOR_OP_IDENTITY`
+- `hip_bfloat16`

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef float        data_type_a;
+    typedef float        data_type_b;
+    typedef float        data_type_d;
+    typedef hip_bfloat16 float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_16BF;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = float_type_compute{1.0f};
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/f32_f16/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_f32_f16

--- a/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_f32_f16)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/f32_f16/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_f32_f16
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/f32_f16/README.md
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/README.md
@@ -1,0 +1,105 @@
+# hipTensor FP32 Data with FP16 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with an inverse mixed precision approach, combining FP32 data storage and FP16 computations.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP32 data types for tensors and FP16 for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_16F` for half-precision).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_16F`
+- `HIPTENSOR_OP_IDENTITY`
+- `_Float16`

--- a/Libraries/hipTensor/contraction/scale/f32_f16/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef float    data_type_a;
+    typedef float    data_type_b;
+    typedef float    data_type_d;
+    typedef _Float16 float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_16F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = 1;
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/f32_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_f32_f32

--- a/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_f32_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/f32_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_f32_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/f32_f32/README.md
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/README.md
@@ -1,0 +1,104 @@
+# hipTensor FP32 Data with FP32 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with full single-precision floating-point arithmetic.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define FP32 data types for all tensors and computations.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`

--- a/Libraries/hipTensor/contraction/scale/f32_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef float data_type_a;
+    typedef float data_type_b;
+    typedef float data_type_d;
+    typedef float float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_32F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_32F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = 1;
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/f64_f32/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_f64_f32

--- a/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_f64_f32)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/f64_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_f64_f32
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/f64_f32/README.md
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/README.md
@@ -1,0 +1,104 @@
+# hipTensor FP64 Data with FP32 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with a mixed precision approach, combining double-precision data storage and single-precision computations.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F64 operations are supported on the current device.
+2. Define double precision data types for tensors and single precision for the compute type.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_64F` for double-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_64F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`

--- a/Libraries/hipTensor/contraction/scale/f64_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F64 is supported.
+    if(!is_f64_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef double data_type_a;
+    typedef double data_type_b;
+    typedef double data_type_d;
+    typedef float  float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_64F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = 1;
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/contraction/scale/f64_f64/.gitignore
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_contraction_scale_f64_f64

--- a/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_contraction_scale_f64_f64)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../../Common" "../../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/contraction/scale/f64_f64/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_contraction_scale_f64_f64
+COMMON_INCLUDE_DIR := ../../../../../Common
+EXTERNAL_DIR := ../../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/contraction/scale/f64_f64/README.md
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/README.md
@@ -1,0 +1,104 @@
+# hipTensor FP64 Data with FP64 Compute Scale Contraction
+
+## Description
+
+This example illustrates how to perform a scale tensor contraction operation using the `hipTensor` library with full double-precision floating-point arithmetic.
+
+The operation calculates the following:
+
+$D_{m,n,u,v} = \alpha \cdot A_{m,n,h,k} \cdot B_{u,v,h,k}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $m \times n \times h \times k$
+- $B$ is a tensor of dimensions $u \times v \times h \times k$
+- $D$ is a tensor of dimensions $m \times n \times u \times v$
+
+## Application flow
+
+1. Check if F64 operations are supported on the current device.
+2. Define double precision data types for all tensors and computations.
+3. Set up hipTensor data type descriptors.
+4. Set the scalar coefficient value.
+5. Call the `scale_contraction_sample` template function.
+6. Inside the template function:
+    - Define tensor modes and extents.
+    - Allocate host and device memory.
+    - Initialize tensor data.
+    - Create a hipTensor handle.
+    - Create tensor descriptors.
+    - Create the contraction operation descriptor.
+    - Create an execution plan.
+    - Execute the scale contraction.
+    - Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Contraction Operation Descriptor**:
+  - `hiptensorCreateContraction()`: Creates a descriptor for the contraction operation, specifying the tensors, their modes, and the computation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the contraction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the contraction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorContract()`: Executes the tensor contraction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_64F` for double-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_64F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorContract`
+- `hiptensorCreate`
+- `hiptensorCreateContraction`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipDeviceSynchronize`
+- `hipFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+- `hipMemset`
+- `hipStreamCreate`
+- `hipStreamDestroy`
+- `hipStreamSynchronize`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `HIPTENSOR_R_64F`
+- `HIPTENSOR_COMPUTE_64F`
+- `HIPTENSOR_OP_IDENTITY`

--- a/Libraries/hipTensor/contraction/scale/f64_f64/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/main.cpp
@@ -1,0 +1,57 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+int main()
+{
+    // 1. Check if F64 is supported.
+    if(!is_f64_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define data types.
+    typedef double data_type_a;
+    typedef double data_type_b;
+    typedef double data_type_d;
+    typedef double float_type_compute;
+
+    // 3. Set up tensor data types.
+    constexpr hiptensorDataType_t          type_a       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_b       = HIPTENSOR_R_64F;
+    constexpr hiptensorDataType_t          type_d       = HIPTENSOR_R_64F;
+    constexpr hiptensorComputeDescriptor_t type_compute = HIPTENSOR_COMPUTE_DESC_64F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = 1;
+
+    // 5. Run scale contraction sample.
+    return scale_contraction_sample<data_type_a,
+                                    data_type_b,
+                                    data_type_d,
+                                    type_a,
+                                    type_b,
+                                    type_d,
+                                    type_compute>(&alpha);
+}

--- a/Libraries/hipTensor/elementwise/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,29 +21,8 @@
 # SOFTWARE.
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+project(hipTensor_elementwise_examples LANGUAGES CXX)
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
-
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+add_subdirectory(binary)
+add_subdirectory(permute)
+add_subdirectory(trinary)

--- a/Libraries/hipTensor/elementwise/Makefile
+++ b/Libraries/hipTensor/elementwise/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,30 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-project(Libraries LANGUAGES CXX)
-include(CTest)
+EXAMPLES := \
+	binary \
+	permute \
+	trinary
 
-file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+all: $(EXAMPLES)
 
-# CMake configuration files for CUDA versions of HIP libraries are not yet
-# included under the HIP SDK for Windows.
-if(
-    NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
-)
-    add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
-    add_subdirectory(hipCUB)
-    add_subdirectory(hipFFT)
-    add_subdirectory(hipRAND)
-    add_subdirectory(hipSOLVER)
-    add_subdirectory(hipTensor)
-    add_subdirectory(rocBLAS)
-    add_subdirectory(rocFFT)
-    add_subdirectory(rocPRIM)
-    add_subdirectory(rocRAND)
-    add_subdirectory(rocSOLVER)
-    add_subdirectory(rocSPARSE)
-    add_subdirectory(rocThrust)
-endif()
+clean: TARGET=clean
+clean: all
+
+$(EXAMPLES):
+	$(MAKE) -C $@ $(TARGET)
+
+.PHONY: all clean $(EXAMPLES)

--- a/Libraries/hipTensor/elementwise/binary/.gitignore
+++ b/Libraries/hipTensor/elementwise/binary/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_elementwise_binary

--- a/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_elementwise_binary)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../Common" "../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/elementwise/binary/Makefile
+++ b/Libraries/hipTensor/elementwise/binary/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_elementwise_binary
+COMMON_INCLUDE_DIR := ../../../../Common
+EXTERNAL_DIR := ../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/elementwise/binary/README.md
+++ b/Libraries/hipTensor/elementwise/binary/README.md
@@ -1,0 +1,98 @@
+# hipTensor Elementwise Binary Operation
+
+## Description
+
+This example illustrates how to perform an elementwise binary operation using the `hipTensor` library.
+
+The operation calculates the following:
+
+$D_{c,w,h} = \alpha \cdot A_{w,h,c} + \gamma \cdot C_{w,h,c}$
+
+where:
+
+- $\alpha$ and $\gamma$ are scalars
+- $A$ is a tensor of dimensions $w \times h \times c$
+- $C$ is a tensor of dimensions $w \times h \times c$
+- $D$ is a tensor of dimensions $c \times w \times h$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define data types and set up tensor data type descriptors.
+3. Set scalar coefficient values.
+4. Define tensor modes and extents.
+5. Allocate host and device memory.
+6. Initialize tensor data.
+7. Create a hipTensor handle.
+8. Create tensor descriptors.
+9. Create the elementwise binary operation descriptor.
+10. Create an execution plan.
+11. Execute the elementwise binary operation.
+12. Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Elementwise Binary Operation Descriptor**:
+  - `hiptensorCreateElementwiseBinary()`: Creates a descriptor for an elementwise binary operation, specifying the tensors, their modes, and the operation type.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the elementwise binary operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorElementwiseBinaryExecute()`: Executes the elementwise binary operation using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY` and `HIPTENSOR_OP_ADD`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorCreate`
+- `hiptensorCreateElementwiseBinary`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorElementwiseBinaryExecute`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipFree`
+- `hipHostFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `hiptensorAlgo_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `HIPTENSOR_OP_ADD`
+- `HIPTENSOR_ALGO_DEFAULT`

--- a/Libraries/hipTensor/elementwise/binary/main.cpp
+++ b/Libraries/hipTensor/elementwise/binary/main.cpp
@@ -1,0 +1,275 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define type aliases.
+    typedef float float_type_a;
+    typedef float float_type_c;
+    typedef float float_type_d;
+    typedef float float_type_compute;
+
+    // 3. Set up tensor data types.
+    hiptensorDataType_t                type_a       = HIPTENSOR_R_32F;
+    hiptensorDataType_t                type_c       = HIPTENSOR_R_32F;
+    hiptensorDataType_t                type_d       = HIPTENSOR_R_32F;
+    hiptensorComputeDescriptor_t const desc_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = (float_type_compute)1.0f;
+    float_type_compute gamma = (float_type_compute)2.0f;
+
+    // 5. Define tensor operation.
+    // D_{c,w,h} = alpha * A_{w,h,c}  + gamma * C_{w,h,c}
+
+    // 6. Set up tensor modes.
+    std::vector<int> mode_a{'w', 'h', 'c'};
+    std::vector<int> mode_c{'w', 'h', 'c'};
+    std::vector<int> mode_d{'c', 'w', 'h'};
+    int              nmode_a = mode_a.size();
+    int              nmode_c = mode_c.size();
+    int              nmode_d = mode_d.size();
+
+    // 7. Set up tensor extents.
+    std::unordered_map<int, int64_t> extent;
+    extent['h'] = 512;
+    extent['w'] = 512;
+    extent['c'] = 512;
+
+    // 8. Calculate extent vectors.
+    std::vector<int64_t> extent_a;
+    for(auto mode : mode_a)
+    {
+        extent_a.push_back(extent[mode]);
+    }
+    std::vector<int64_t> extent_c;
+    for(auto mode : mode_c)
+    {
+        extent_c.push_back(extent[mode]);
+    }
+    std::vector<int64_t> extent_d;
+    for(auto mode : mode_d)
+    {
+        extent_d.push_back(extent[mode]);
+    }
+
+    // 9. Allocate device memory.
+    size_t elements_a = 1;
+    for(auto mode : mode_a)
+    {
+        elements_a *= extent[mode];
+    }
+    size_t elements_c = 1;
+    for(auto mode : mode_c)
+    {
+        elements_c *= extent[mode];
+    }
+    size_t elements_d = 1;
+    for(auto mode : mode_d)
+    {
+        elements_d *= extent[mode];
+    }
+
+    size_t size_a = sizeof(float_type_a) * elements_a;
+    size_t size_c = sizeof(float_type_c) * elements_c;
+    size_t size_d = sizeof(float_type_d) * elements_d;
+
+    void *a_d, *c_d, *d_d;
+    HIP_CHECK(hipMalloc((void**)&a_d, size_a));
+    HIP_CHECK(hipMalloc((void**)&c_d, size_c));
+    HIP_CHECK(hipMalloc((void**)&d_d, size_d));
+
+    float_type_a* a;
+    float_type_c* c;
+    float_type_d* d;
+    HIP_CHECK(hipHostMalloc((void**)&a, sizeof(float_type_a) * elements_a));
+    HIP_CHECK(hipHostMalloc((void**)&c, sizeof(float_type_c) * elements_c));
+    HIP_CHECK(hipHostMalloc((void**)&d, sizeof(float_type_d) * elements_d));
+
+    // 10. Initialize data.
+    for(size_t i = 0; i < elements_a; i++)
+    {
+        a[i] = (float)i;
+        c[i] = static_cast<float>(i % 41);
+    }
+
+    HIP_CHECK(hipMemcpy(a_d, a, size_a, hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(c_d, c, size_c, hipMemcpyDefault));
+
+    // 11. Initialize hipTensor.
+    hiptensorHandle_t handle;
+    HIPTENSOR_CHECK(hiptensorCreate(&handle));
+    HIPTENSOR_CHECK(hiptensorLoggerSetMask(HIPTENSOR_LOG_LEVEL_PERF_TRACE));
+
+    // 12. Create tensor descriptors.
+    hiptensorTensorDescriptor_t desc_a = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_a,
+                                                    nmode_a,
+                                                    extent_a.data(),
+                                                    nullptr /* stride */,
+                                                    type_a,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_c = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_c,
+                                                    nmode_c,
+                                                    extent_c.data(),
+                                                    nullptr /* stride */,
+                                                    type_c,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_d = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_d,
+                                                    nmode_d,
+                                                    extent_d.data(),
+                                                    nullptr /* stride */,
+                                                    type_d,
+                                                    0));
+
+    // 13. Create elementwise binary descriptor.
+    hiptensorOperationDescriptor_t desc;
+    HIPTENSOR_CHECK(hiptensorCreateElementwiseBinary(handle,
+                                                     &desc,
+                                                     desc_a,
+                                                     mode_a.data(),
+                                                     /* unary operator A  */ HIPTENSOR_OP_IDENTITY,
+                                                     desc_c,
+                                                     mode_c.data(),
+                                                     /* unary operator C  */ HIPTENSOR_OP_IDENTITY,
+                                                     desc_d,
+                                                     mode_d.data(),
+                                                     /* unary operator AC */ HIPTENSOR_OP_ADD,
+                                                     desc_compute));
+
+    // 14. Set algorithm.
+    const hiptensorAlgo_t algo = HIPTENSOR_ALGO_DEFAULT;
+
+    hiptensorPlanPreference_t plan_pref;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlanPreference(handle, &plan_pref, algo, HIPTENSOR_JIT_MODE_NONE));
+
+    // 15. Create plan.
+    hiptensorPlan_t plan;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlan(handle, &plan, desc, plan_pref, 0 /* workspaceSizeLimit */));
+
+    // 16. Run elementwise binary operation.
+    HIPTENSOR_CHECK(hiptensorElementwiseBinaryExecute(handle,
+                                                      plan,
+                                                      (void*)&alpha,
+                                                      a_d,
+                                                      (void*)&gamma,
+                                                      c_d,
+                                                      d_d,
+                                                      nullptr /* stream */));
+
+#if !NDEBUG
+    // 17. Print and store results.
+    bool print_elements = false;
+    bool store_elements = false;
+
+    if(print_elements || store_elements)
+    {
+        HIP_CHECK(hipMemcpy(d, d_d, size_d, hipMemcpyDefault));
+    }
+
+    if(print_elements)
+    {
+        if(elements_a < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor A elements:\n";
+            hiptensor_print_array_elements(std::cout, a, elements_a);
+            std::cout << std::endl;
+        }
+
+        if(elements_c < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor C elements:\n";
+            hiptensor_print_array_elements(std::cout, c, elements_c);
+            std::cout << std::endl;
+        }
+
+        if(elements_d < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor D elements:\n";
+            hiptensor_print_array_elements(std::cout, d, elements_d);
+            std::cout << std::endl;
+        }
+    }
+
+    if(store_elements)
+    {
+        std::ofstream tensor_a, tensor_c, tensor_d;
+        tensor_a.open("tensor_A.txt");
+        hiptensor_print_elements_to_file(tensor_a, a, elements_a, ", ");
+        tensor_a.close();
+
+        tensor_c.open("tensor_C.txt");
+        hiptensor_print_elements_to_file(tensor_c, c, elements_c, ", ");
+        tensor_c.close();
+
+        tensor_d.open("tensor_D_scale_contraction_results.txt");
+        hiptensor_print_elements_to_file(tensor_d, d, elements_d, ", ");
+        tensor_d.close();
+    }
+#endif
+
+    // 18. Cleanup.
+    HIPTENSOR_CHECK(hiptensorDestroy(handle));
+    HIPTENSOR_CHECK(hiptensorDestroyPlan(plan));
+    HIPTENSOR_CHECK(hiptensorDestroyOperationDescriptor(desc));
+    HIPTENSOR_CHECK(hiptensorDestroyPlanPreference(plan_pref));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_a));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_c));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_d));
+
+    HIPTENSOR_FREE_HOST(a);
+    HIPTENSOR_FREE_HOST(c);
+    HIPTENSOR_FREE_HOST(d);
+    HIPTENSOR_FREE_DEVICE(a_d);
+    HIPTENSOR_FREE_DEVICE(c_d);
+    HIPTENSOR_FREE_DEVICE(d_d);
+
+    std::cout << "Finished!" << std::endl;
+    return 0;
+}

--- a/Libraries/hipTensor/elementwise/permute/.gitignore
+++ b/Libraries/hipTensor/elementwise/permute/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_elementwise_permutation

--- a/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_elementwise_permutation)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../Common" "../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/elementwise/permute/Makefile
+++ b/Libraries/hipTensor/elementwise/permute/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_elementwise_permutation
+COMMON_INCLUDE_DIR := ../../../../Common
+EXTERNAL_DIR := ../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/elementwise/permute/README.md
+++ b/Libraries/hipTensor/elementwise/permute/README.md
@@ -1,0 +1,96 @@
+# hipTensor Tensor Permutation
+
+## Description
+
+This example illustrates how to perform a tensor permutation operation using the `hipTensor` library.
+
+The operation calculates the following:
+
+$C_{c,w,h} = \alpha \cdot A_{w,h,c}$
+
+where:
+
+- $\alpha$ is a scalar
+- $A$ is a tensor of dimensions $w \times h \times c$
+- $C$ is a tensor of dimensions $c \times w \times h$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define data types and set up tensor data type descriptors.
+3. Set the scalar coefficient value.
+4. Define tensor modes and extents.
+5. Allocate host and device memory.
+6. Initialize tensor data.
+7. Create a hipTensor handle.
+8. Create tensor descriptors.
+9. Create the permutation operation descriptor.
+10. Create an execution plan.
+11. Execute the permutation operation.
+12. Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Permutation Operation Descriptor**:
+  - `hiptensorCreatePermutation()`: Creates a descriptor for a permutation operation, specifying the input and output tensors and their modes.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the permutation operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorPermute()`: Executes the tensor permutation using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorCreate`
+- `hiptensorCreatePermutation`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorPermute`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipFree`
+- `hipHostFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `hiptensorAlgo_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `HIPTENSOR_ALGO_DEFAULT`

--- a/Libraries/hipTensor/elementwise/permute/main.cpp
+++ b/Libraries/hipTensor/elementwise/permute/main.cpp
@@ -1,0 +1,219 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define type aliases.
+    typedef float float_type_a;
+    typedef float float_type_c;
+    typedef float float_type_compute;
+
+    // 3. Set up tensor data types.
+    hiptensorDataType_t                type_a       = HIPTENSOR_R_32F;
+    hiptensorDataType_t                type_c       = HIPTENSOR_R_32F;
+    hiptensorComputeDescriptor_t const desc_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = (float_type_compute)1.0f;
+
+    // 5. Define tensor operation.
+    // B_{w, h, c, n} = 1.0 * IDENTITY(A_{c, n, h, w})
+
+    // 6. Set up tensor modes.
+    std::vector<int> mode_a{'w', 'h', 'c'};
+    std::vector<int> mode_c{'c', 'w', 'h'};
+    int              nmode_a = mode_a.size();
+    int              nmode_c = mode_c.size();
+
+    // 7. Set up tensor extents.
+    std::unordered_map<int, int64_t> extent;
+    extent['h'] = 512;
+    extent['w'] = 512;
+    extent['c'] = 512;
+
+    // 8. Calculate extent vectors.
+    std::vector<int64_t> extent_a;
+    for(auto mode : mode_a)
+    {
+        extent_a.push_back(extent[mode]);
+    }
+    std::vector<int64_t> extent_c;
+    for(auto mode : mode_c)
+    {
+        extent_c.push_back(extent[mode]);
+    }
+
+    // 9. Allocate device memory.
+    size_t elements_a = 1;
+    for(auto mode : mode_a)
+    {
+        elements_a *= extent[mode];
+    }
+    size_t elements_c = 1;
+    for(auto mode : mode_c)
+    {
+        elements_c *= extent[mode];
+    }
+
+    size_t size_a = sizeof(float_type_a) * elements_a;
+    size_t size_c = sizeof(float_type_c) * elements_c;
+
+    void *a_d, *c_d;
+    HIP_CHECK(hipMalloc((void**)&a_d, size_a));
+    HIP_CHECK(hipMalloc((void**)&c_d, size_c));
+
+    float_type_a *a, *c;
+    HIP_CHECK(hipHostMalloc((void**)&a, sizeof(float_type_a) * elements_a));
+    HIP_CHECK(hipHostMalloc((void**)&c, sizeof(float_type_c) * elements_c));
+
+    // 10. Initialize data.
+    for(size_t i = 0; i < elements_a; i++)
+    {
+        a[i] = (float)i;
+    }
+
+    HIP_CHECK(hipMemcpy(a_d, a, size_a, hipMemcpyDefault));
+
+    // 11. Initialize hipTensor.
+    hiptensorHandle_t handle;
+    HIPTENSOR_CHECK(hiptensorCreate(&handle));
+    HIPTENSOR_CHECK(hiptensorLoggerSetMask(HIPTENSOR_LOG_LEVEL_PERF_TRACE));
+
+    // 12. Create tensor descriptors.
+    hiptensorTensorDescriptor_t desc_a;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_a,
+                                                    nmode_a,
+                                                    extent_a.data(),
+                                                    nullptr /* stride */,
+                                                    type_a,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_c;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_c,
+                                                    nmode_c,
+                                                    extent_c.data(),
+                                                    nullptr /* stride */,
+                                                    type_c,
+                                                    0));
+
+    // 13. Create permutation descriptor.
+    hiptensorOperationDescriptor_t desc;
+    HIPTENSOR_CHECK(hiptensorCreatePermutation(handle,
+                                               &desc,
+                                               desc_a,
+                                               mode_a.data(),
+                                               HIPTENSOR_OP_IDENTITY,
+                                               desc_c,
+                                               mode_c.data(),
+                                               desc_compute));
+
+    // 14. Set algorithm.
+    const hiptensorAlgo_t algo = HIPTENSOR_ALGO_DEFAULT;
+
+    hiptensorPlanPreference_t plan_pref;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlanPreference(handle, &plan_pref, algo, HIPTENSOR_JIT_MODE_NONE));
+
+    // 15. Create plan.
+    hiptensorPlan_t plan;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlan(handle, &plan, desc, plan_pref, 0 /* workspaceSizeLimit */));
+
+    // 16. Run permutation.
+    HIPTENSOR_CHECK(hiptensorPermute(handle, plan, &alpha, a_d, c_d, nullptr /* stream */));
+
+#if !NDEBUG
+    // 17. Print and store results.
+    bool print_elements = false;
+    bool store_elements = false;
+
+    if(print_elements || store_elements)
+    {
+        HIP_CHECK(hipMemcpy(c, c_d, size_c, hipMemcpyDefault));
+    }
+
+    if(print_elements)
+    {
+        if(elements_a < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor A elements:\n";
+            hiptensor_print_array_elements(std::cout, a, elements_a);
+            std::cout << std::endl;
+        }
+
+        if(elements_c < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor C elements:\n";
+            hiptensor_print_array_elements(std::cout, c, elements_c);
+            std::cout << std::endl;
+        }
+    }
+
+    if(store_elements)
+    {
+        std::ofstream tensor_a, tensor_b, tensor_c;
+        tensor_a.open("tensor_A.txt");
+        hiptensor_print_elements_to_file(tensor_a, a, elements_a, ", ");
+        tensor_a.close();
+
+        tensor_c.open("tensor_C_scale_contraction_results.txt");
+        hiptensor_print_elements_to_file(tensor_c, c, elements_c, ", ");
+        tensor_c.close();
+    }
+#endif
+
+    // 18. Cleanup.
+    HIPTENSOR_CHECK(hiptensorDestroy(handle));
+    HIPTENSOR_CHECK(hiptensorDestroyPlan(plan));
+    HIPTENSOR_CHECK(hiptensorDestroyOperationDescriptor(desc));
+    HIPTENSOR_CHECK(hiptensorDestroyPlanPreference(plan_pref));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_a));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_c));
+
+    HIPTENSOR_FREE_HOST(a);
+    HIPTENSOR_FREE_HOST(c);
+    HIPTENSOR_FREE_DEVICE(a_d);
+    HIPTENSOR_FREE_DEVICE(c_d);
+
+    std::cout << "Finished!" << std::endl;
+    return 0;
+}

--- a/Libraries/hipTensor/elementwise/trinary/.gitignore
+++ b/Libraries/hipTensor/elementwise/trinary/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_elementwise_trinary

--- a/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_elementwise_trinary)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../../Common" "../../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/elementwise/trinary/Makefile
+++ b/Libraries/hipTensor/elementwise/trinary/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_elementwise_trinary
+COMMON_INCLUDE_DIR := ../../../../Common
+EXTERNAL_DIR := ../../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/elementwise/trinary/README.md
+++ b/Libraries/hipTensor/elementwise/trinary/README.md
@@ -1,0 +1,97 @@
+# hipTensor Elementwise Trinary Operation
+
+## Description
+
+This example illustrates how to perform an elementwise trinary operation using the `hipTensor` library.
+
+The operation calculates the following:
+
+$D_{c,w,h} = \gamma \cdot C_{w,h,c} + (\alpha \cdot A_{w,h,c} + \beta \cdot B_{w,h,c})$
+
+where:
+
+- $\alpha$, $\beta$, and $\gamma$ are scalars
+- $A$, $B$, and $C$ are tensors of dimensions $w \times h \times c$
+- $D$ is a tensor of dimensions $c \times w \times h$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define data types and set up tensor data type descriptors.
+3. Set scalar coefficient values.
+4. Define tensor modes and extents.
+5. Allocate host and device memory.
+6. Initialize tensor data.
+7. Create a hipTensor handle.
+8. Create tensor descriptors.
+9. Create the elementwise trinary operation descriptor.
+10. Create an execution plan.
+11. Execute the elementwise trinary operation.
+12. Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Elementwise Trinary Operation Descriptor**:
+  - `hiptensorCreateElementwiseTrinary()`: Creates a descriptor for an elementwise trinary operation, specifying the tensors, their modes, and the operation types.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the elementwise trinary operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorElementwiseTrinaryExecute()`: Executes the elementwise trinary operation using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY` and `HIPTENSOR_OP_ADD`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorCreate`
+- `hiptensorCreateElementwiseTrinary`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorElementwiseTrinaryExecute`
+- `hiptensorLoggerSetMask`
+
+### HIP runtime
+
+- `hipFree`
+- `hipHostFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `hiptensorAlgo_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `HIPTENSOR_OP_ADD`
+- `HIPTENSOR_ALGO_DEFAULT`

--- a/Libraries/hipTensor/elementwise/trinary/main.cpp
+++ b/Libraries/hipTensor/elementwise/trinary/main.cpp
@@ -1,0 +1,326 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define type aliases.
+    typedef float float_type_a;
+    typedef float float_type_b;
+    typedef float float_type_c;
+    typedef float float_type_d;
+    typedef float float_type_compute;
+
+    // 3. Set up tensor data types.
+    hiptensorDataType_t type_a = HIPTENSOR_R_32F;
+    hiptensorDataType_t type_b = HIPTENSOR_R_32F;
+    hiptensorDataType_t type_c = HIPTENSOR_R_32F;
+    hiptensorDataType_t type_d = HIPTENSOR_R_32F;
+
+    hiptensorComputeDescriptor_t const desc_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = (float_type_compute)1.0f;
+    float_type_compute beta  = (float_type_compute)1.0f;
+    float_type_compute gamma = (float_type_compute)2.0f;
+
+    // 5. Define tensor operation.
+    // D_{\Pi^C(i_0,i_1,...,i_n)} = \Phi_{ABC}(\Phi_{AB}(\alpha \Psi_A(A_{\Pi^A(i_0,i_1,...,i_n)}), \beta \Psi_B(B_{\Pi^B(i_0,i_1,...,i_n)})), \gamma \Psi_C(C_{\Pi^C(i_0,i_1,...,i_n)}))
+
+    // 6. Set up tensor modes.
+    std::vector<int> mode_a{'w', 'h', 'c'};
+    std::vector<int> mode_b{'w', 'h', 'c'};
+    std::vector<int> mode_c{'w', 'h', 'c'};
+    std::vector<int> mode_d{'c', 'w', 'h'};
+    int              nmode_a = mode_a.size();
+    int              nmode_b = mode_b.size();
+    int              nmode_c = mode_c.size();
+    int              nmode_d = mode_d.size();
+
+    // 7. Set up tensor extents.
+    std::unordered_map<int, int64_t> extent;
+    extent['h'] = 512;
+    extent['w'] = 512;
+    extent['c'] = 512;
+
+    // 8. Calculate extent vectors.
+    std::vector<int64_t> extent_a;
+    for(auto mode : mode_a)
+    {
+        extent_a.push_back(extent[mode]);
+    }
+    std::vector<int64_t> extent_b;
+    for(auto mode : mode_b)
+    {
+        extent_b.push_back(extent[mode]);
+    }
+    std::vector<int64_t> extent_c;
+    for(auto mode : mode_c)
+    {
+        extent_c.push_back(extent[mode]);
+    }
+    std::vector<int64_t> extent_d;
+    for(auto mode : mode_d)
+    {
+        extent_d.push_back(extent[mode]);
+    }
+
+    // 9. Allocate device memory.
+    size_t elements_a = 1;
+    for(auto mode : mode_a)
+    {
+        elements_a *= extent[mode];
+    }
+    size_t elements_b = 1;
+    for(auto mode : mode_b)
+    {
+        elements_b *= extent[mode];
+    }
+    size_t elements_c = 1;
+    for(auto mode : mode_c)
+    {
+        elements_c *= extent[mode];
+    }
+    size_t elements_d = 1;
+    for(auto mode : mode_d)
+    {
+        elements_d *= extent[mode];
+    }
+
+    size_t size_a = sizeof(float_type_a) * elements_a;
+    size_t size_b = sizeof(float_type_b) * elements_b;
+    size_t size_c = sizeof(float_type_c) * elements_c;
+    size_t size_d = sizeof(float_type_d) * elements_d;
+
+    void *a_d, *b_d, *c_d, *d_d;
+    HIP_CHECK(hipMalloc((void**)&a_d, size_a));
+    HIP_CHECK(hipMalloc((void**)&b_d, size_b));
+    HIP_CHECK(hipMalloc((void**)&c_d, size_c));
+    HIP_CHECK(hipMalloc((void**)&d_d, size_d));
+
+    float_type_a* a;
+    float_type_b* b;
+    float_type_c* c;
+    float_type_d* d;
+    HIP_CHECK(hipHostMalloc((void**)&a, sizeof(float_type_a) * elements_a));
+    HIP_CHECK(hipHostMalloc((void**)&b, sizeof(float_type_b) * elements_b));
+    HIP_CHECK(hipHostMalloc((void**)&c, sizeof(float_type_c) * elements_c));
+    HIP_CHECK(hipHostMalloc((void**)&d, sizeof(float_type_d) * elements_d));
+
+    // 10. Initialize data.
+    for(size_t i = 0; i < elements_a; i++)
+    {
+        a[i] = static_cast<float>(i);
+        b[i] = static_cast<float>(i % 19);
+        c[i] = static_cast<float>(i % 41);
+    }
+
+    HIP_CHECK(hipMemcpy(a_d, a, size_a, hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(b_d, b, size_b, hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(c_d, c, size_c, hipMemcpyDefault));
+
+    // 11. Initialize hipTensor.
+    hiptensorHandle_t handle;
+    HIPTENSOR_CHECK(hiptensorCreate(&handle));
+    HIPTENSOR_CHECK(hiptensorLoggerSetMask(HIPTENSOR_LOG_LEVEL_PERF_TRACE));
+
+    // 12. Create tensor descriptors.
+    hiptensorTensorDescriptor_t desc_a = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_a,
+                                                    nmode_a,
+                                                    extent_a.data(),
+                                                    nullptr /* stride */,
+                                                    type_a,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_b = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_b,
+                                                    nmode_b,
+                                                    extent_b.data(),
+                                                    nullptr /* stride */,
+                                                    type_b,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_c = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_c,
+                                                    nmode_c,
+                                                    extent_c.data(),
+                                                    nullptr /* stride */,
+                                                    type_c,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_d = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_d,
+                                                    nmode_d,
+                                                    extent_d.data(),
+                                                    nullptr /* stride */,
+                                                    type_d,
+                                                    0));
+
+    // 13. Create elementwise trinary descriptor.
+    hiptensorOperationDescriptor_t desc;
+    HIPTENSOR_CHECK(hiptensorCreateElementwiseTrinary(handle,
+                                                      &desc,
+                                                      desc_a,
+                                                      mode_a.data(),
+                                                      /* unary operator A */ HIPTENSOR_OP_IDENTITY,
+                                                      desc_b,
+                                                      mode_b.data(),
+                                                      /* unary operator B */ HIPTENSOR_OP_IDENTITY,
+                                                      desc_c,
+                                                      mode_c.data(),
+                                                      /* unary operator C */ HIPTENSOR_OP_IDENTITY,
+                                                      desc_d,
+                                                      mode_d.data(),
+                                                      /* binary operator AC  */ HIPTENSOR_OP_ADD,
+                                                      /* binary operator ABC */ HIPTENSOR_OP_ADD,
+                                                      desc_compute));
+
+    // 14. Set algorithm.
+    const hiptensorAlgo_t algo = HIPTENSOR_ALGO_DEFAULT;
+
+    hiptensorPlanPreference_t plan_pref;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlanPreference(handle, &plan_pref, algo, HIPTENSOR_JIT_MODE_NONE));
+
+    // 15. Create plan.
+    hiptensorPlan_t plan;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlan(handle, &plan, desc, plan_pref, 0 /*workspaceSizeEstimate*/));
+
+    // 16. Run elementwise trinary operation.
+    HIPTENSOR_CHECK(hiptensorElementwiseTrinaryExecute(handle,
+                                                       plan,
+                                                       (void*)&alpha,
+                                                       a_d,
+                                                       (void*)&beta,
+                                                       b_d,
+                                                       (void*)&gamma,
+                                                       c_d,
+                                                       d_d,
+                                                       0));
+
+#if !NDEBUG
+    // 17. Print and store results.
+    bool print_elements = false;
+    bool store_elements = false;
+
+    if(print_elements || store_elements)
+    {
+        HIP_CHECK(hipMemcpy(d, d_d, size_d, hipMemcpyDefault));
+    }
+
+    if(print_elements)
+    {
+        if(elements_a < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor A elements:\n";
+            hiptensor_print_array_elements(std::cout, a, elements_a);
+            std::cout << std::endl;
+        }
+
+        if(elements_b < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor B elements:\n";
+            hiptensor_print_array_elements(std::cout, b, elements_b);
+            std::cout << std::endl;
+        }
+
+        if(elements_c < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor C elements:\n";
+            hiptensor_print_array_elements(std::cout, c, elements_c);
+            std::cout << std::endl;
+        }
+
+        if(elements_d < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor D elements:\n";
+            hiptensor_print_array_elements(std::cout, d, elements_d);
+            std::cout << std::endl;
+        }
+    }
+
+    if(store_elements)
+    {
+        std::ofstream tensor_a, tensor_b, tensor_c, tensor_d;
+        tensor_a.open("tensor_A.txt");
+        hiptensor_print_elements_to_file(tensor_a, a, elements_a, ", ");
+        tensor_a.close();
+
+        tensor_b.open("tensor_B.txt");
+        hiptensor_print_elements_to_file(tensor_b, b, elements_b, ", ");
+        tensor_b.close();
+
+        tensor_c.open("tensor_C.txt");
+        hiptensor_print_elements_to_file(tensor_c, c, elements_c, ", ");
+        tensor_c.close();
+
+        tensor_d.open("tensor_D_scale_contraction_results.txt");
+        hiptensor_print_elements_to_file(tensor_d, d, elements_d, ", ");
+        tensor_d.close();
+    }
+#endif
+
+    // 18. Cleanup.
+    HIPTENSOR_CHECK(hiptensorDestroy(handle));
+    HIPTENSOR_CHECK(hiptensorDestroyPlan(plan));
+    HIPTENSOR_CHECK(hiptensorDestroyOperationDescriptor(desc));
+    HIPTENSOR_CHECK(hiptensorDestroyPlanPreference(plan_pref));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_a));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_b));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_c));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_d));
+
+    HIPTENSOR_FREE_HOST(a);
+    HIPTENSOR_FREE_HOST(b);
+    HIPTENSOR_FREE_HOST(c);
+    HIPTENSOR_FREE_HOST(d);
+    HIPTENSOR_FREE_DEVICE(a_d);
+    HIPTENSOR_FREE_DEVICE(b_d);
+    HIPTENSOR_FREE_DEVICE(c_d);
+    HIPTENSOR_FREE_DEVICE(d_d);
+
+    std::cout << "Finished!" << std::endl;
+    return 0;
+}

--- a/Libraries/hipTensor/reduction/.gitignore
+++ b/Libraries/hipTensor/reduction/.gitignore
@@ -1,0 +1,1 @@
+hiptensor_reduction

--- a/Libraries/hipTensor/reduction/CMakeLists.txt
+++ b/Libraries/hipTensor/reduction/CMakeLists.txt
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set(example_name hiptensor_reduction)
+
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(${example_name} LANGUAGES CXX)
+
+if(GPU_RUNTIME STREQUAL "CUDA")
+    message(STATUS "hipTensor examples do not support the CUDA runtime")
+    return()
+endif()
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    message(STATUS "hipTensor examples are only available on Linux")
+    return()
+else()
+    set(ROCM_ROOT
+        "/opt/rocm"
+        CACHE PATH
+        "Root directory of the ROCm installation"
+    )
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
+
+find_package(hiptensor REQUIRED)
+
+add_executable(${example_name} main.cpp)
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name})
+
+# Link to example library
+target_link_libraries(${example_name} PRIVATE hiptensor)
+
+target_include_directories(
+    ${example_name}
+    PRIVATE "../../../Common" "../../../External"
+)
+set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+
+install(TARGETS ${example_name})

--- a/Libraries/hipTensor/reduction/Makefile
+++ b/Libraries/hipTensor/reduction/Makefile
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+EXAMPLE := hiptensor_reduction
+COMMON_INCLUDE_DIR := ../../../Common
+EXTERNAL_DIR := ../../../External
+GPU_RUNTIME := HIP
+
+# HIP variables
+ROCM_INSTALL_DIR := /opt/rocm
+
+HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
+HIPBLASLT_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Common variables and flags
+CXX_STD   := c++17
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -isystem $(HIPBLASLT_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
+ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
+ILDLIBS   := -lhiptensor
+
+ifeq ($(GPU_RUNTIME), HIP)
+	CXXFLAGS ?= -Wall -Wextra
+	CPPFLAGS += -D__HIP_PLATFORM_AMD__
+	COMPILER := $(HIPCXX)
+else
+	$(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP; CUDA not supported)
+endif
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+$(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+
+clean:
+	$(RM) $(EXAMPLE)
+
+.PHONY: clean

--- a/Libraries/hipTensor/reduction/README.md
+++ b/Libraries/hipTensor/reduction/README.md
@@ -1,0 +1,101 @@
+# hipTensor Tensor Reduction
+
+## Description
+
+This example illustrates how to perform a tensor reduction operation using the `hipTensor` library.
+
+The operation calculates the following:
+
+$C_{k,v} = \alpha \cdot \sum_{m,h} A_{m,h,k,v} + \beta \cdot C_{k,v}$
+
+where:
+
+- $\alpha$ and $\beta$ are scalars
+- $A$ is a tensor of dimensions $m \times h \times k \times v$
+- $C$ is a tensor of dimensions $k \times v$
+
+## Application flow
+
+1. Check if F32 operations are supported on the current device.
+2. Define data types and set up tensor data type descriptors.
+3. Set scalar coefficient values.
+4. Define tensor modes and extents.
+5. Allocate host and device memory.
+6. Initialize tensor data.
+7. Create a hipTensor handle.
+8. Create tensor descriptors.
+9. Create the reduction operation descriptor.
+10. Create an execution plan.
+11. Execute the reduction operation.
+12. Clean up all resources.
+
+## Key APIs and Concepts
+
+- **hipTensor Initialization**: The hipTensor library is initialized by creating a handle with `hiptensorCreate()` and released with `hiptensorDestroy()`.
+
+- **Tensor Descriptors**:
+  - `hiptensorCreateTensorDescriptor()`: Creates a descriptor for a tensor, defining its data type, dimensions, and strides.
+  - `hiptensorDestroyTensorDescriptor()`: Frees the tensor descriptor.
+
+- **Reduction Operation Descriptor**:
+  - `hiptensorCreateReduction()`: Creates a descriptor for a reduction operation, specifying the input and output tensors, their modes, and the reduction operator.
+  - `hiptensorDestroyOperationDescriptor()`: Frees the reduction operation descriptor.
+
+- **Algorithm Selection and Execution Plan**:
+  - `hiptensorCreatePlanPreference()`: Creates a preference object to guide the algorithm selection process.
+  - `hiptensorEstimateWorkspaceSize()`: Queries for the required workspace memory size for the reduction.
+  - `hiptensorCreatePlan()`: Creates an execution plan based on the operation descriptors and preferences.
+  - `hiptensorDestroyPlanPreference()`: Frees the preference object.
+  - `hiptensorDestroyPlan()`: Frees the execution plan.
+
+- **Execution**:
+  - `hiptensorReduce()`: Executes the tensor reduction using the created plan.
+
+- **Key Enumerations**:
+  - `hiptensorDataType_t`: Defines the data type of tensors (e.g., `HIPTENSOR_R_32F` for single-precision).
+  - `hiptensorComputeDescriptor_t`: Sets the precision for the computation (e.g., `HIPTENSOR_COMPUTE_32F`).
+  - `hiptensorOperator_t`: Specifies tensor operations, such as `HIPTENSOR_OP_IDENTITY` and `HIPTENSOR_OP_ADD`.
+
+## Demonstrated API Calls
+
+### hipTensor
+
+- `hiptensorCreate`
+- `hiptensorCreatePlan`
+- `hiptensorCreatePlanPreference`
+- `hiptensorCreateReduction`
+- `hiptensorCreateTensorDescriptor`
+- `hiptensorDestroy`
+- `hiptensorDestroyOperationDescriptor`
+- `hiptensorDestroyPlan`
+- `hiptensorDestroyPlanPreference`
+- `hiptensorDestroyTensorDescriptor`
+- `hiptensorEstimateWorkspaceSize`
+- `hiptensorLoggerSetMask`
+- `hiptensorReduce`
+
+### HIP runtime
+
+- `hipFree`
+- `hipHostFree`
+- `hipHostMalloc`
+- `hipMalloc`
+- `hipMemcpy`
+
+### Data Types and Enums
+
+- `hiptensorHandle_t`
+- `hiptensorTensorDescriptor_t`
+- `hiptensorOperationDescriptor_t`
+- `hiptensorPlan_t`
+- `hiptensorPlanPreference_t`
+- `hiptensorDataType_t`
+- `hiptensorComputeDescriptor_t`
+- `hiptensorAlgo_t`
+- `hiptensorWorksizePreference_t`
+- `HIPTENSOR_R_32F`
+- `HIPTENSOR_COMPUTE_32F`
+- `HIPTENSOR_OP_IDENTITY`
+- `HIPTENSOR_OP_ADD`
+- `HIPTENSOR_ALGO_DEFAULT`
+- `HIPTENSOR_WORKSPACE_DEFAULT`

--- a/Libraries/hipTensor/reduction/main.cpp
+++ b/Libraries/hipTensor/reduction/main.cpp
@@ -1,0 +1,261 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hiptensor_utils.hpp"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+int main()
+{
+    // 1. Check if F32 is supported.
+    if(!is_f32_supported())
+    {
+        std::cout << "unsupported host device" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // 2. Define type aliases.
+    typedef float float_type_a;
+    // typedef float float_type_b;
+    typedef float float_type_c;
+    typedef float float_type_compute;
+
+    // 3. Set up tensor data types.
+    hiptensorDataType_t type_a = HIPTENSOR_R_32F;
+    hiptensorDataType_t type_c = HIPTENSOR_R_32F;
+    // hiptensorComputeDescriptor_t       type_compute = HIPTENSOR_COMPUTE_DESC_32F;
+    const hiptensorComputeDescriptor_t desc_compute = HIPTENSOR_COMPUTE_DESC_32F;
+
+    // 4. Set scalar values.
+    float_type_compute alpha = (float_type_compute)1.1f;
+    float_type_compute beta  = (float_type_compute)0.f;
+
+    // 5. Define tensor operation.
+    // C_{m,v} = alpha * A_{m,h,k,v} + beta * C_{m,v}
+
+    // 6. Set up tensor modes.
+    std::vector<int32_t> mode_a{'m', 'h', 'k', 'v'};
+    std::vector<int32_t> mode_c{'k', 'v'};
+    int32_t              nmode_a = mode_a.size();
+    int32_t              nmode_c = mode_c.size();
+
+    // 7. Set up tensor extents.
+    std::unordered_map<int32_t, int64_t> extent;
+    extent['m'] = 3;
+    extent['v'] = 4;
+    extent['h'] = 5;
+    extent['k'] = 6;
+
+    // 8. Calculate extent vectors.
+    std::vector<int64_t> extent_c;
+    for(auto mode : mode_c)
+    {
+        extent_c.push_back(extent[mode]);
+    }
+
+    std::vector<int64_t> extent_a;
+    for(auto mode : mode_a)
+    {
+        extent_a.push_back(extent[mode]);
+    }
+
+    // 9. Allocate device memory.
+    size_t elements_a = 1;
+    for(auto mode : mode_a)
+    {
+        elements_a *= extent[mode];
+    }
+
+    size_t elements_c = 1;
+    for(auto mode : mode_c)
+    {
+        elements_c *= extent[mode];
+    }
+
+    size_t size_a = sizeof(float_type_a) * elements_a;
+    size_t size_c = sizeof(float_type_c) * elements_c;
+
+    void *a_d, *c_d;
+    HIP_CHECK(hipMalloc((void**)&a_d, size_a));
+    HIP_CHECK(hipMalloc((void**)&c_d, size_c));
+
+    float_type_a *a, *c;
+    HIP_CHECK(hipHostMalloc((void**)&a, sizeof(float_type_a) * elements_a));
+    HIP_CHECK(hipHostMalloc((void**)&c, sizeof(float_type_c) * elements_c));
+
+    // 10. Initialize data.
+    for(size_t i = 0; i < elements_a; i++)
+    {
+        a[i] = (float)i;
+    }
+    for(size_t i = 0; i < elements_c; i++)
+    {
+        c[i] = (float)(i & 1);
+    }
+
+    HIP_CHECK(hipMemcpy(a_d, a, size_a, hipMemcpyDefault));
+    HIP_CHECK(hipMemcpy(c_d, c, size_c, hipMemcpyDefault));
+
+    // 11. Initialize hipTensor.
+    hiptensorHandle_t handle;
+    HIPTENSOR_CHECK(hiptensorCreate(&handle));
+    HIPTENSOR_CHECK(hiptensorLoggerSetMask(HIPTENSOR_LOG_LEVEL_PERF_TRACE));
+
+    // 12. Create tensor descriptors.
+    hiptensorTensorDescriptor_t desc_a = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_a,
+                                                    nmode_a,
+                                                    extent_a.data(),
+                                                    NULL /* stride */,
+                                                    type_a,
+                                                    0));
+
+    hiptensorTensorDescriptor_t desc_c = nullptr;
+    HIPTENSOR_CHECK(hiptensorCreateTensorDescriptor(handle,
+                                                    &desc_c,
+                                                    nmode_c,
+                                                    extent_c.data(),
+                                                    NULL /* stride */,
+                                                    type_c,
+                                                    0));
+
+    // 13. Set up reduction operation.
+    const hiptensorOperator_t op_reduce = HIPTENSOR_OP_ADD;
+
+    // 14. Create reduction descriptor.
+    hiptensorOperationDescriptor_t desc;
+    HIPTENSOR_CHECK(hiptensorCreateReduction(handle,
+                                             &desc,
+                                             desc_a,
+                                             mode_a.data(),
+                                             HIPTENSOR_OP_IDENTITY,
+                                             desc_c,
+                                             mode_c.data(),
+                                             HIPTENSOR_OP_IDENTITY,
+                                             desc_c,
+                                             mode_c.data(),
+                                             op_reduce,
+                                             desc_compute));
+
+    // 15. Set algorithm.
+    const hiptensorAlgo_t algo = HIPTENSOR_ALGO_DEFAULT;
+
+    hiptensorPlanPreference_t plan_pref;
+    HIPTENSOR_CHECK(
+        hiptensorCreatePlanPreference(handle, &plan_pref, algo, HIPTENSOR_JIT_MODE_NONE));
+
+    // 16. Query workspace estimate.
+    uint64_t                            worksize       = 0;
+    const hiptensorWorksizePreference_t workspace_pref = HIPTENSOR_WORKSPACE_DEFAULT;
+    HIPTENSOR_CHECK(
+        hiptensorEstimateWorkspaceSize(handle, desc, plan_pref, workspace_pref, &worksize));
+    void* work = nullptr;
+    if(worksize > 0)
+    {
+        if(hipSuccess != hipMalloc(&work, worksize))
+        {
+            work     = nullptr;
+            worksize = 0;
+        }
+    }
+
+    // 17. Create plan.
+    hiptensorPlan_t plan;
+    HIPTENSOR_CHECK(hiptensorCreatePlan(handle, &plan, desc, plan_pref, worksize));
+
+    // 18. Run reduction.
+    HIPTENSOR_CHECK(hiptensorReduce(handle,
+                                    plan,
+                                    (const void*)&alpha,
+                                    a_d,
+                                    (const void*)&beta,
+                                    c_d,
+                                    c_d,
+                                    work,
+                                    worksize,
+                                    0));
+
+#if !NDEBUG
+    // 19. Print and store results.
+    bool print_elements = true;
+    bool store_elements = false;
+
+    if(print_elements || store_elements)
+    {
+        HIP_CHECK(hipMemcpy(c, c_d, size_c, hipMemcpyDefault));
+    }
+
+    if(print_elements)
+    {
+        if(elements_a < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor A elements:\n";
+            hiptensor_print_array_elements(std::cout, a, elements_a);
+            std::cout << std::endl;
+        }
+
+        if(elements_c < MAX_ELEMENTS_PRINT_COUNT)
+        {
+            std::cout << "Tensor C elements:\n";
+            hiptensor_print_array_elements(std::cout, c, elements_c);
+            std::cout << std::endl;
+        }
+    }
+
+    if(store_elements)
+    {
+        std::ofstream tensor_a, tensor_c;
+        tensor_a.open("tensor_A.txt");
+        hiptensor_print_elements_to_file(tensor_a, a, elements_a, ", ");
+        tensor_a.close();
+
+        tensor_c.open("tensor_C_scale_contraction_results.txt");
+        hiptensor_print_elements_to_file(tensor_c, c, elements_c, ", ");
+        tensor_c.close();
+    }
+#endif
+
+    // 20. Cleanup.
+    HIPTENSOR_CHECK(hiptensorDestroy(handle));
+    HIPTENSOR_CHECK(hiptensorDestroyPlan(plan));
+    HIPTENSOR_CHECK(hiptensorDestroyOperationDescriptor(desc));
+    HIPTENSOR_CHECK(hiptensorDestroyPlanPreference(plan_pref));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_a));
+    HIPTENSOR_CHECK(hiptensorDestroyTensorDescriptor(desc_c));
+
+    HIPTENSOR_FREE_HOST(a);
+    HIPTENSOR_FREE_HOST(c);
+    HIPTENSOR_FREE_DEVICE(a_d);
+    HIPTENSOR_FREE_DEVICE(c_d);
+    HIPTENSOR_FREE_DEVICE(work);
+
+    std::cout << "Finished!" << std::endl;
+    return 0;
+}

--- a/README.md
+++ b/README.md
@@ -332,6 +332,31 @@ The following options are available when building with CMake.
     - [syevj](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipSOLVER/syevj): Calculates the eigenvalues and eigenvectors from a real symmetric matrix using the Jacobi method.
     - [syevj_batched](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipSOLVER/syevj_batched): Showcases how to compute the eigenvalues and eigenvectors (via Jacobi method) of each matrix in a batch of real symmetric matrices.
     - [sygvj](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipSOLVER/sygvj): Calculates the generalized eigenvalues and eigenvectors from a pair of real symmetric matrices using the Jacobi method.
+  - [hipTensor](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/)
+    - [contraction](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction): Tensor contraction operations that compute products over shared dimensions
+      - [bilinear](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear): Bilinear contractions with accumulation support for combining tensor products with existing output data
+        - [bf16_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/bf16_f32): Demonstrates bilinear tensor contraction using BFloat16 data with FP32 computation.
+        - [cf32_cf32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/cf32_cf32): Shows bilinear tensor contraction with single-precision complex floating-point data.
+        - [f16_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/f16_f32): Demonstrates mixed precision bilinear contraction with FP16 data and FP32 computation.
+        - [f32_bf16](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/f32_bf16): Shows inverse mixed precision with FP32 data and BFloat16 computation.
+        - [f32_f16](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/f32_f16): Demonstrates FP32 data storage with FP16 computational precision.
+        - [f32_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/f32_f32): Standard single-precision bilinear tensor contraction implementation.
+        - [f64_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/f64_f32): Shows mixed precision with FP64 data and FP32 computation.
+        - [f64_f64](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/bilinear/f64_f64): Demonstrates maximum precision bilinear contraction using double-precision arithmetic.
+      - [scale](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale): Scale contractions that compute tensor products from scratch without accumulation for cleaner numerical behavior
+        - [bf16_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/bf16_f32): Shows scale tensor contraction using BFloat16 data with FP32 computation.
+        - [cf32_cf32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/cf32_cf32): Demonstrates scale contraction with single-precision complex floating-point data.
+        - [f16_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/f16_f32): Shows mixed precision scale contraction with FP16 data and FP32 computation.
+        - [f32_bf16](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/f32_bf16): Demonstrates inverse mixed precision scale contraction with FP32 data and BFloat16 computation.
+        - [f32_f16](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/f32_f16): Shows FP32 data storage with FP16 computational precision for scale contractions.
+        - [f32_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/f32_f32): Standard single-precision scale tensor contraction implementation.
+        - [f64_f32](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/f64_f32): Demonstrates mixed precision scale contraction with FP64 data and FP32 computation.
+        - [f64_f64](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/contraction/scale/f64_f64): Shows maximum precision scale contraction using double-precision arithmetic.
+    - [elementwise](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/elementwise): Element-by-element tensor operations including arithmetic, permutation, and multi-tensor combinations
+      - [binary](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/elementwise/binary): Program that demonstrates elementwise binary operations with tensor permutation.
+      - [permute](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/elementwise/permute): Shows how to perform tensor dimension reordering operations.
+      - [trinary](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/elementwise/trinary): Shows how to combine three tensors using nested binary operations with permutation.
+    - [reduction](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/hipTensor/reduction): Program that showcases tensor reduction operations using hipTensor.
   - [rocBLAS](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/rocBLAS/)
     - [level_1](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/rocBLAS/level_1/): Operations between vectors and vectors.
       - [axpy](https://github.com/ROCm/rocm-examples/tree/amd-staging/Libraries/rocBLAS/level_1/axpy/): Simple program that showcases the AXPY operation.


### PR DESCRIPTION
## Motivation

Add hipTensor examples to ROCm examples. These examples were taken from the hipTensor repository

## Technical Details

- Only targets ROCm and Linux, Windows and CUDA targets are omitted
- Targets the latest API in hipTensor from develop (which is not available in 6.4.3)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
