### PR TITLE
Fix hipTensor return code for unsupported devices

### DIFF
--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f64_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/main.cpp
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f64_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/f16_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/f32_f16/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/f32_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/f64_f32/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f64_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/contraction/scale/f64_f64/main.cpp
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/main.cpp
@@ -28,7 +28,7 @@ int main()
     if(!is_f64_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define data types.

--- a/Libraries/hipTensor/elementwise/binary/main.cpp
+++ b/Libraries/hipTensor/elementwise/binary/main.cpp
@@ -37,7 +37,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define type aliases.

--- a/Libraries/hipTensor/elementwise/permute/main.cpp
+++ b/Libraries/hipTensor/elementwise/permute/main.cpp
@@ -37,7 +37,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define type aliases.

--- a/Libraries/hipTensor/elementwise/trinary/main.cpp
+++ b/Libraries/hipTensor/elementwise/trinary/main.cpp
@@ -37,7 +37,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define type aliases.

--- a/Libraries/hipTensor/reduction/main.cpp
+++ b/Libraries/hipTensor/reduction/main.cpp
@@ -37,7 +37,7 @@ int main()
     if(!is_f32_supported())
     {
         std::cout << "unsupported host device" << std::endl;
-        exit(EXIT_FAILURE);
+        return 0;
     }
 
     // 2. Define type aliases.


### PR DESCRIPTION
## Motivation

hipTensor examples failing CI.

## Technical Details

- Unfortunately the current CMake setup doesn't detect targets to compile against. An overhaul of the setup is not planned at this time
- As a fix, the return code of the checks in each sample is fixed to not return an error code

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
