### PR TITLE
Disable hipTensor examples on unsupported architectures

### DIFF
--- a/Libraries/hipTensor/CMakeLists.txt
+++ b/Libraries/hipTensor/CMakeLists.txt
@@ -27,6 +27,16 @@ include(CTest)
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(STATUS "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+        return()
+    endif()
+endforeach()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")
     return()

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_bf16_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_cf32_cf32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_f16_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_f32_bf16)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_f32_f16)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_f32_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_f64_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_bilinear_f64_f64)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_bf16_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_cf32_cf32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_f16_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_f32_bf16)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_f32_f16)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_f32_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_f64_f32)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_contraction_scale_f64_f64)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_elementwise_binary)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_elementwise_permutation)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_elementwise_trinary)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")

--- a/Libraries/hipTensor/reduction/CMakeLists.txt
+++ b/Libraries/hipTensor/reduction/CMakeLists.txt
@@ -25,15 +25,28 @@ set(example_name hiptensor_reduction)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(GPU_RUNTIME STREQUAL "CUDA")
-    message(STATUS "hipTensor examples do not support the CUDA runtime")
-    return()
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    message(FATAL_ERROR "hipTensor examples do not support the CUDA runtime.")
 endif()
 
-enable_language(${GPU_RUNTIME})
-set(CMAKE_${GPU_RUNTIME}_STANDARD 17)
-set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
-set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
+set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    endif()
+endforeach()
+
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
+set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
+select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(STATUS "hipTensor examples are only available on Linux")


### PR DESCRIPTION
## Motivation

hipTensor only support gfx9, see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support.

## Technical Details

Don't build hipTensor examples if `CMAKE_HIP_ARCHITECTURES` contains anything not gfx9.

## Test Plan

Build and run ctest on gfx1100

## Test Result

hipTensor examples are not build by default on gfx1100 and are not built unless `-DCMAKE_HIP_ARCHITECTURES` is set to only contain gfx9 architectures.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
