### PR TITLE
Disable one hipblaslt example

### DIFF
--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -22,7 +22,6 @@
 
 LIBRARIES := \
 	hipBLAS \
-	hipBLASLt \
 	hipCUB \
 	hipFFT \
 	hipSOLVER \
@@ -31,6 +30,7 @@ LIBRARIES := \
 
 ifneq ($(GPU_RUNTIME), CUDA)
 LIBRARIES += \
+	hipBLASLt \
 	hipTensor \
 	rocBLAS \
 	rocFFT \

--- a/Libraries/hipBLASLt/CMakeLists.txt
+++ b/Libraries/hipBLASLt/CMakeLists.txt
@@ -85,5 +85,6 @@ add_subdirectory(gemm_with_scale_a_b_vector)
 add_subdirectory(gemm_with_TF32)
 add_subdirectory(groupedgemm_ext)
 add_subdirectory(groupedgemm_fixed_mk_ext)
-add_subdirectory(groupedgemm_get_all_algos_ext)
+# Disabled until fix is upstreamed in later ROCm version
+# add_subdirectory(groupedgemm_get_all_algos_ext)
 add_subdirectory(weight_swizzle_padding)

--- a/Libraries/hipBLASLt/Makefile
+++ b/Libraries/hipBLASLt/Makefile
@@ -61,7 +61,6 @@ EXAMPLES := \
 	gemm_with_TF32 \
 	groupedgemm_ext \
 	groupedgemm_fixed_mk_ext \
-	groupedgemm_get_all_algos_ext \
 	weight_swizzle_padding
 
 


### PR DESCRIPTION
## Motivation

Disable hipBLASLt example `groupedgemm_get_all_algos_ext`

## Technical Details

- Currently fails in some CI
- It's been verified that this example fails in 7.0, and a fix for it will be released in a future ROCm release

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
