### PR TITLE
Consult hipTensor to determine if an arch is supported when building their examples

### DIFF
--- a/Libraries/hipTensor/CMakeLists.txt
+++ b/Libraries/hipTensor/CMakeLists.txt
@@ -27,18 +27,19 @@ include(CTest)
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
-        message(STATUS "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
+        message(WARNING "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
         return()
     endif()
 endforeach()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -50,7 +51,6 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
-find_package(hiptensor)
 if(NOT hiptensor_FOUND)
     message(
         STATUS

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest

--- a/Libraries/hipTensor/reduction/CMakeLists.txt
+++ b/Libraries/hipTensor/reduction/CMakeLists.txt
@@ -34,11 +34,12 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
-# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
-set(HIPTENSOR_SUPPORTED_ARCH gfx908 gfx90a gfx942 gfx950)
+find_package(hiptensor REQUIRED)
 
+# see https://rocm.docs.amd.com/projects/hipTensor/en/latest/install/installation.html#gpu-support
 foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST HIPTENSOR_SUPPORTED_ARCH)
+    hiptensor_is_supported_architecture(${ARCH} IS_SUPPORTED)
+    if(NOT IS_SUPPORTED)
         message(FATAL_ERROR "hipTensor does not support architecture: ${ARCH}, not building hipTensor examples")
     endif()
 endforeach()
@@ -49,7 +50,7 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(STATUS "hipTensor examples are only available on Linux")
+    message(WARNING "hipTensor examples are only available on Linux")
     return()
 else()
     set(ROCM_ROOT
@@ -60,8 +61,6 @@ else()
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
-
-find_package(hiptensor REQUIRED)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest


### PR DESCRIPTION
## Motivation

Avoid inconsistency between list of officially supported architectures by hipTensor and the accepted list of architectures when building the examples.

## Technical Details

Use a new cmake function provided by hipTensor instead of verifying the architecture against a locally maintained list of supported architectures.

Depends on https://github.com/ROCm/hipTensor/pull/409

## Test Plan

1. rocm-examples built with `CMAKE_HIP_ARCHITECTURES` including only hipTensor supported architectures.
2. rocm-examples built with `CMAKE_HIP_ARCHITECTURES` including hipTensor non-supported architectures.

## Test Result

1. Build including hipTensor examples, as expected.
2. Build not including hipTensor examples, as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
