### PR TITLE
HIP-Doc CMake improvements

### DIFF
--- a/HIP-Doc/CMakeLists.txt
+++ b/HIP-Doc/CMakeLists.txt
@@ -25,22 +25,15 @@ project(HIP-Doc LANGUAGES CXX)
 
 include(CTest)
 
-add_subdirectory(Programming-Guide)
-add_subdirectory(Reference)
-add_subdirectory(Tutorials)
-
 include("${CMAKE_CURRENT_LIST_DIR}/../Common/HipPlatform.cmake")
 select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
-
-
-
-
-
-
-
-
-
+add_subdirectory(Programming-Guide)
+add_subdirectory(Reference)
+add_subdirectory(Tutorials)

--- a/HIP-Doc/Programming-Guide/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(HIP-C++-Language-Extensions)
 add_subdirectory(HIP-Porting-Guide)
 add_subdirectory(Introduction-to-the-HIP-Programming-Model)

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-HIP-C++-Language-Extensions LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(calling_global_functions)
 add_subdirectory(extern_shared_memory)
 add_subdirectory(launch_bounds)

--- a/HIP-Doc/Programming-Guide/HIP-Porting-Guide/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/HIP-Porting-Guide/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-HIP-Porting-Guide LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(device_code_feature_identification)
 add_subdirectory(host_code_feature_identification)
 add_subdirectory(identifying_compilation_target_platform)

--- a/HIP-Doc/Programming-Guide/Introduction-to-the-HIP-Programming-Model/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Introduction-to-the-HIP-Programming-Model/CMakeLists.txt
@@ -23,4 +23,7 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Introduction-to-the-HIP-Programming-Model LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(add_kernel)

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/CMakeLists.txt
@@ -26,6 +26,9 @@ project(HIP-Doc-Programming-Guide-HIP-Porting-CUDA-Driver-API LANGUAGES CXX)
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(address_retrieval)
 add_subdirectory(load_module)
 add_subdirectory(load_module_ex)

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(NAME ${example_name} COMMAND ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name} WORKING_DIRECTORY $<TARGET_FILE_DIR:${example_name}>)
 
 add_dependencies(${example_name} ${example_module})
 set_target_properties(${example_name} PROPERTIES $<$<COMPILE_LANGUAGE:CUDA>:CUDA_EXTENSIONS OFF>
@@ -85,6 +85,7 @@ endif()
 # Copy object file to executable output directory
 if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "HIP")
     set(example_module_hsaco "$<TARGET_FILE_DIR:${example_name}>/${example_module_suffix}.hsaco")
+    message(STATUS "Target path: ${example_module_hsaco}")
     add_custom_command(TARGET ${example_name} POST_BUILD
                        COMMAND ${CMAKE_COMMAND}
                        ARGS -E copy $<TARGET_OBJECTS:${example_module}> ${example_module_hsaco}

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module/CMakeLists.txt
@@ -85,7 +85,6 @@ endif()
 # Copy object file to executable output directory
 if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "HIP")
     set(example_module_hsaco "$<TARGET_FILE_DIR:${example_name}>/${example_module_suffix}.hsaco")
-    message(STATUS "Target path: ${example_module_hsaco}")
     add_custom_command(TARGET ${example_name} POST_BUILD
                        COMMAND ${CMAKE_COMMAND}
                        ARGS -E copy $<TARGET_OBJECTS:${example_module}> ${example_module_hsaco}

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(NAME ${example_name} COMMAND ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name} WORKING_DIRECTORY $<TARGET_FILE_DIR:${example_name}>)
 
 add_dependencies(${example_name} ${example_module})
 set_target_properties(${example_name} PROPERTIES $<$<COMPILE_LANGUAGE:CUDA>:CUDA_EXTENSIONS OFF>

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex_cuda/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-Driver-API/load_module_ex_cuda/CMakeLists.txt
@@ -36,7 +36,7 @@ set_property(TARGET ${example_module} PROPERTY CUDA_PTX_COMPILATION ON)
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
-add_test(NAME ${example_name} COMMAND ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name} WORKING_DIRECTORY $<TARGET_FILE_DIR:${example_name}>)
 
 add_dependencies(${example_name} ${example_module})
 set_target_properties(${example_name} PROPERTIES CXX_EXTENSIONS OFF)

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/CMakeLists.txt
@@ -27,6 +27,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(compilation_apis)
 
 if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Asynchronous-Concurrent-Execution LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(async_kernel_execution)
 add_subdirectory(event_based_synchronization)
 add_subdirectory(sequential_kernel_execution)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(Asynchronous-Concurrent-Execution)
 add_subdirectory(Call-Stack)
 add_subdirectory(Error-Handling)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/CMakeLists.txt
@@ -23,5 +23,8 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Call-Stack LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(call_stack_management)
 add_subdirectory(device_recursion)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/CMakeLists.txt
@@ -23,4 +23,7 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Error-Handling LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(error_handling)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-HIP-Graphs LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     message(STATUS "The graph API examples are available only on Linux.")
 else()

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/CMakeLists.txt
@@ -23,4 +23,7 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Initialization LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(simple_device_query)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Memory-Management LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(Device-Memory)
 add_subdirectory(Host-Memory)
 add_subdirectory(SOMA)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Memory-Management-Device-Memory LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(constant_memory)
 add_subdirectory(dynamic_shared_memory)
 add_subdirectory(explicit_copy)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/CMakeLists.txt
@@ -23,5 +23,8 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Memory-Management-Host-Memory LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(pageable_host_memory)
 add_subdirectory(pinned_host_memory)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Memory-Management-SOMA LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     message(STATUS "The memory pool examples are available only on Linux.")
 else()

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/CMakeLists.txt
@@ -24,6 +24,9 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Memory-Management-Unified-Memory-Management
         LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(data_prefetching)
 add_subdirectory(dynamic_unified_memory)
 add_subdirectory(explicit_memory)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/CMakeLists.txt
@@ -24,6 +24,9 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Memory-Management-Virtual-Memory-Management
         LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     message(STATUS "The virtual memory example is available only on Linux.")
 elseif(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Programming-Guide-Using-HIP-Runtime-API-Multi-Device-Management LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(device_enumeration)
 add_subdirectory(device_selection)
 add_subdirectory(multi_device_synchronization)

--- a/HIP-Doc/Reference/CMakeLists.txt
+++ b/HIP-Doc/Reference/CMakeLists.txt
@@ -23,6 +23,9 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Reference LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(CUDA-to-HIP-API-Function-Comparison)
 add_subdirectory(HIP-Complex-Math-API)
 add_subdirectory(HIP-Math-API)

--- a/HIP-Doc/Reference/CUDA-to-HIP-API-Function-Comparison/CMakeLists.txt
+++ b/HIP-Doc/Reference/CUDA-to-HIP-API-Function-Comparison/CMakeLists.txt
@@ -26,6 +26,9 @@ project(HIP-Doc-Reference-CUDA-to-HIP-API-Function-Comparison LANGUAGES CXX)
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(NOT ${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")
     message(STATUS "The block reduction example is available only for CUDA.")
 else()

--- a/HIP-Doc/Reference/HIP-Complex-Math-API/CMakeLists.txt
+++ b/HIP-Doc/Reference/HIP-Complex-Math-API/CMakeLists.txt
@@ -23,4 +23,7 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Reference-HIP-Complex-Math-API LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(complex_math)

--- a/HIP-Doc/Reference/HIP-Math-API/CMakeLists.txt
+++ b/HIP-Doc/Reference/HIP-Math-API/CMakeLists.txt
@@ -23,4 +23,7 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(HIP-Doc-Reference-HIP-Math-API LANGUAGES CXX)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(math)

--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/CMakeLists.txt
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/CMakeLists.txt
@@ -26,6 +26,9 @@ project(HIP-Doc-Reference-Low-Precision-Floating-Point-Types LANGUAGES CXX)
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     message(STATUS "Low-precision floating-point examples are available only on Linux.")
 elseif(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")

--- a/HIP-Doc/Tutorials/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/CMakeLists.txt
@@ -25,4 +25,8 @@ project(HIP-Doc-Tutorials LANGUAGES CXX)
 
 include(CTest)
 
+file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 add_subdirectory(graph_api)

--- a/HIP-Doc/Tutorials/graph_api/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/graph_api/CMakeLists.txt
@@ -24,6 +24,28 @@ cmake_minimum_required(VERSION 3.21)
 
 project(hip_graph_api_tutorial LANGUAGES CXX)
 
+# Check for general C++20 support
+list(FIND CMAKE_CXX_COMPILE_FEATURES cxx_std_20 COMPILER_KNOWS_CXX20)
+if(COMPILER_KNOWS_CXX20 EQUAL -1)
+    message(STATUS "The C++ compiler does not support C++20. Not building the HIP Graph API tutorial examples.")
+    return()
+endif()
+
+# Check for C++20 features we use in the tutorial
+include(CheckIncludeFileCXX)
+set(CMAKE_REQUIRED_QUIET TRUE)
+check_include_file_cxx(numbers HAVE_NUMBERS)
+if(NOT HAVE_NUMBERS)
+    message(STATUS "<numbers> not found. Not building the HIP Graph API tutorial examples.")
+    return()
+endif()
+
+check_include_file_cxx(source_location HAVE_SOURCE_LOC)
+if(NOT HAVE_SOURCE_LOC)
+    message(STATUS "<source_location> not found. Not building the HIP Graph API tutorial examples.")
+    return()
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/HipPlatform.cmake")
 select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})


### PR DESCRIPTION
## Motivation

This PR adds two CMake improvements to the `HIP-Doc` directory:

1. The runtime output directories now mirror the approach found in the other directories.
2. The HIP Graph API tutorial now checks for C++20 support and disables itself when the required features are missing.

No. 2 fixes SWDEV-561586 and SWDEV-561973.

## Technical Details

## Test Plan

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
