### PR TITLE
Bump hipBLASLt CMake minimum required version to 3.25.2

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,11 @@ if(
     NOT (CMAKE_SYSTEM_NAME MATCHES "Windows" AND "${GPU_RUNTIME}" STREQUAL "CUDA")
 )
     add_subdirectory(hipBLAS)
-    add_subdirectory(hipBLASLt)
+    if(CMAKE_VERSION VERSION_LESS "3.25.2")
+        message(WARNING "CMake version < 3.25.2, not building hipBLASLt examples.")
+    else()
+        add_subdirectory(hipBLASLt)
+    endif()
     add_subdirectory(hipCUB)
     add_subdirectory(hipFFT)
     add_subdirectory(hipRAND)

--- a/Libraries/hipBLASLt/CMakeLists.txt
+++ b/Libraries/hipBLASLt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(hipBLASLt_examples LANGUAGES CXX)
 include(CTest)
 

--- a/Libraries/hipBLASLt/ext_op_amax/CMakeLists.txt
+++ b/Libraries/hipBLASLt/ext_op_amax/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_ext_op_amax)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/ext_op_layernorm/CMakeLists.txt
+++ b/Libraries/hipBLASLt/ext_op_layernorm/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_ext_op_layernorm)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_alphavec_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_alphavec_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_alphavec_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_amax/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_amax/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_amax)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_amax_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_amax_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_amax_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_amax_with_scale/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_amax_with_scale/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_amax_with_scale)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_amax_with_scale_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_amax_with_scale_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_amax_with_scale_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_attr_tciA_tciB/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_attr_tciA_tciB/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_attr_tciA_tciB)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_batched/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_batched/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_batched)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_batched_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_batched_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_batched_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_bgradb/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_bgradb/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_bgradb)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_bias/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_bias/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_bias)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_bias_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_bias_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_bias_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_bias_swizzle_a_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_bias_swizzle_a_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_bias_swizzle_a_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_dgelu_bgradb/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_dgelu_bgradb/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_dgelu_bgradb)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_dgelu_bgradb_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_dgelu_bgradb_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_dgelu_bgradb_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_ext_bgradb/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_ext_bgradb/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_ext_bgradb)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_gelu_aux_bias/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_gelu_aux_bias/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_gelu_aux_bias)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_gelu_aux_bias_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_gelu_aux_bias_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_gelu_aux_bias_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_get_algo_by_index_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_get_algo_by_index_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_get_algo_by_index_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_get_all_algos/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_get_all_algos/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_get_all_algos)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_get_all_algos_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_get_all_algos_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_get_all_algos_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_is_tuned_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_is_tuned_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_is_tuned_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_mix_precision/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_mix_precision/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_mix_precision)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_mix_precision_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_mix_precision_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_mix_precision_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_mix_precision_with_amax_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_mix_precision_with_amax_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_mix_precision_with_amax_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_swish_bias/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_swish_bias/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_swish_bias)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_swizzle_a/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_swizzle_a/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_swizzle_a)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_swizzle_a_scale_a_b_vector/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_swizzle_a_scale_a_b_vector/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_swizzle_a_scale_a_b_vector)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_tuning_splitk_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_tuning_splitk_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_tuning_splitk_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_tuning_wgm_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_tuning_wgm_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_tuning_wgm_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_with_TF32/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_with_TF32/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_with_TF32)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_with_scale_a_b/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_with_scale_a_b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_with_scale_a_b)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_with_scale_a_b_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_with_scale_a_b_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_with_scale_a_b_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/gemm_with_scale_a_b_vector/CMakeLists.txt
+++ b/Libraries/hipBLASLt/gemm_with_scale_a_b_vector/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_gemm_with_scale_a_b_vector)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/groupedgemm_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/groupedgemm_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_groupedgemm_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/groupedgemm_fixed_mk_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/groupedgemm_fixed_mk_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_groupedgemm_fixed_mk_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/groupedgemm_get_all_algos_ext/CMakeLists.txt
+++ b/Libraries/hipBLASLt/groupedgemm_get_all_algos_ext/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_groupedgemm_get_all_algos_ext)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")

--- a/Libraries/hipBLASLt/weight_swizzle_padding/CMakeLists.txt
+++ b/Libraries/hipBLASLt/weight_swizzle_padding/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 set(example_name hipblaslt_weight_swizzle_padding)
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
 if(GPU_RUNTIME STREQUAL "CUDA")


### PR DESCRIPTION
## Motivation

Bump up the CMake version to match hipBLASLt's change in https://github.com/ROCm/rocm-libraries/commit/392aea29d39e1c61ac4ad1572e396c64738e1c95

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
