### PR TITLE
Fix VS sobel_filter input file path

### DIFF
--- a/Applications/sobel_filter/main.hip
+++ b/Applications/sobel_filter/main.hip
@@ -315,20 +315,13 @@ int main(int argc, char* argv[])
 #ifdef _WIN32
     char separator = srcpath.find_last_of('/') == std::string::npos ? '\\' : '/';
 
+    // On MSVS we don't have the full path with HIP clang
+    // input file is copied over to the binary directory
     if(srcpath.find("sobel_filter") == std::string::npos)
     {
-        char fullpath[MAX_PATH];
-        if(GetFullPathNameA(srcpath.c_str(), MAX_PATH, fullpath, nullptr))
-        {
-            srcpath = std::string(fullpath);
-            srcpath = srcpath.substr(0, srcpath.find_last_of(separator)) + separator
-                      + "Applications" + separator + "sobel_filter" + separator + "main.hip";
-        }
-        else
-        {
-            std::cerr << "Failed to find image path." << std::endl;
-            return -1;
-        }
+        char buffer[MAX_PATH];
+        GetModuleFileNameA(NULL, buffer, MAX_PATH);
+        srcpath = std::string(buffer);
     }
 #elif defined(__linux__)
     constexpr char separator = '/';

--- a/Applications/sobel_filter/sobel_filter_vs2017.vcxproj
+++ b/Applications/sobel_filter/sobel_filter_vs2017.vcxproj
@@ -31,6 +31,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="test.pgm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/Applications/sobel_filter/sobel_filter_vs2019.vcxproj
+++ b/Applications/sobel_filter/sobel_filter_vs2019.vcxproj
@@ -31,6 +31,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="test.pgm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/Applications/sobel_filter/sobel_filter_vs2022.vcxproj
+++ b/Applications/sobel_filter/sobel_filter_vs2022.vcxproj
@@ -31,6 +31,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="test.pgm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>


### PR DESCRIPTION
## Motivation

Fix input file path on Windows with Visual Studio.

## Technical Details

There's currently no way to get `__FILE__` to expand to a full path when building with Visual Studio using HIP clang. `GetFullPathNameA` get's the current working directory, so the example depends on where it gets invoked, and will fail if we are not in the root directory of rocm-examples.

Instead, we copy the input file to the output binary directory and build the input file path from the binary directory using `GetModuleFileNameA`.
Ref https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea#parameters.

Building with CMake is not affected and works as expected ( `__FILE__` expands to the absolute full path).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
