### PR TITLE
Update GH actions to 7.1

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -13,8 +13,8 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: '7.0'
-    AMDGPU_INSTALLER_VERSION: 7.0.70000-1
+    ROCM_VERSION: '7.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:

--- a/.github/workflows/build_applications_cuda.yml
+++ b/.github/workflows/build_applications_cuda.yml
@@ -45,25 +45,30 @@ jobs:
               echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
               echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
+          - name: Setup ROCm Libraries monorepo
+            shell: bash
+            run: |
+              git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/ROCm/rocm-libraries.git
+              cd rocm-libraries
+              git sparse-checkout init --cone
+              git sparse-checkout set projects/hipcub projects/hiprand
+              git checkout develop
+
           - name: Build and install hipCUB
             shell: bash
             run: |
-              git clone https://github.com/ROCm/hipCUB.git
-              pushd hipCUB; mkdir build; cd build
+              cd rocm-libraries/projects/hipcub; mkdir build; cd build
               HIP_PLATFORM=nvidia cmake -DCMAKE_CXX_COMPILER=nvcc ..
               make -j
               make install
-              popd && rm -rf hipCUB
 
           - name: Build and install hipRAND
             shell: bash
             run: |
-              git clone https://github.com/ROCm/hipRAND.git
-              pushd hipRAND; mkdir build; cd build
+              cd rocm-libraries/projects/hiprand; mkdir build; cd build
               HIP_PLATFORM=nvidia CXX=g++ cmake -DBUILD_WITH_LIB=CUDA -DHIP_CUDA_lowest_cc=60 ..
               make -j
               make install
-              popd && rm -rf hipRAND
 
           - name: Configure and Build
             shell: bash

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -13,8 +13,8 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: '7.0'
-    AMDGPU_INSTALLER_VERSION: 7.0.70000-1
+    ROCM_VERSION: '7.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:

--- a/.github/workflows/build_hip_documentation.yml
+++ b/.github/workflows/build_hip_documentation.yml
@@ -13,8 +13,8 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: '7.0'
-    AMDGPU_INSTALLER_VERSION: 7.0.70000-1
+    ROCM_VERSION: '7.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -13,8 +13,8 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: '7.0'
-    AMDGPU_INSTALLER_VERSION: 7.0.70000-1
+    ROCM_VERSION: '7.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
 
 jobs:

--- a/.github/workflows/build_libraries_cuda.yml
+++ b/.github/workflows/build_libraries_cuda.yml
@@ -41,15 +41,22 @@ jobs:
           apt-get update -qq &&
           apt-get install -y hip-dev rocm-cmake
 
+      - name: Setup ROCm Libraries monorepo
+        shell: bash
+        run: |
+          git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/ROCm/rocm-libraries.git
+          cd rocm-libraries
+          git sparse-checkout init --cone
+          git sparse-checkout set projects/hipcub projects/hiprand projects/hipfft projects/rocrand
+          git checkout develop
+
       - name: Build and install hipCUB
         shell: bash
         run: |
-          git clone https://github.com/ROCm/hipCUB.git
-          pushd hipCUB; mkdir build; cd build
+          cd rocm-libraries/projects/hipcub; mkdir build; cd build
           HIP_PLATFORM=nvidia cmake -DCMAKE_CXX_COMPILER=nvcc ..
           make -j
           make install
-          popd && rm -rf hipCUB
 
       - name: Build hipCUB example
         shell: bash
@@ -60,12 +67,10 @@ jobs:
       - name: Build and install hipFFT
         shell: bash
         run: |
-          git clone https://github.com/ROCm/hipFFT.git
-          pushd hipFFT; mkdir build; cd build
+          cd rocm-libraries/projects/hipfft; mkdir build; cd build
           HIP_PLATFORM=nvidia ROCM_PATH=/opt/rocm cmake -LH -DBUILD_WITH_LIB=cuda ..
           make -j
           make install
-          popd && rm -rf hipFFT
 
       - name: Build hipFFT example
         shell: bash
@@ -84,16 +89,10 @@ jobs:
           cd Libraries/hipSPARSELt
           make GPU_RUNTIME=CUDA -j
 
-
-      - name: Build and install rocRAND
+      - name: Install rocRAND
         shell: bash
         run: |
-          git clone https://github.com/ROCm/rocRAND.git
-          pushd rocRAND; mkdir build; cd build
-          HIP_PLATFORM=nvidia CXX=g++ cmake -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_PREFIX_PATH=/opt/rocm -DCMAKE_MODULE_PATH=/opt/rocm/hip/cmake -DHIP_CUDA_lowest_cc=60 ..
-          make -j
-          make install
-          popd && rm -rf rocRAND
+          apt-get install -y rocrand-dev
 
       - name: Build rocRAND example
         shell: bash


### PR DESCRIPTION
## Motivation

Update GitHub CI to 7.1. Use rocm-libraries monorepo for CUDA pipelines.

## Technical Details

Keep CUDA workflows at 7.0 due to a bug in ROCm 7.1 CUDA-related headers that should be fixed in 7.2.
Remove building rocRAND as it's having CUDA-related build issues.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
