### PR TITLE
Update rocWMMA CMake target name

### DIFF
--- a/Libraries/rocWMMA/CMakeLists.txt
+++ b/Libraries/rocWMMA/CMakeLists.txt
@@ -44,10 +44,19 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip)
+find_package(OpenMP)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -56,16 +65,13 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     )
 
     if(NOT ROCWMMA_INCLUDE_DIR)
-        message(
-            STATUS
-            "rocWMMA could not be found, not building rocWMMA examples"
-        )
-        return(1)
+        message(FATAL_ERROR "rocWMMA headers not found. Please install rocWMMA or set ROCWMMA_INCLUDE_DIR")
     endif()
 
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_subdirectory(hiprtc_gemm)

--- a/Libraries/rocWMMA/hiprtc_gemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/hiprtc_gemm/CMakeLists.txt
@@ -46,11 +46,20 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
 find_package(hiprtc REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -65,6 +74,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -72,7 +82,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE hiprtc::hiprtc rocwmma)
+target_link_libraries(${example_name} PRIVATE hiprtc::hiprtc ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/perf_dgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_dgemm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/perf_hgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_hgemm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/perf_sgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_sgemm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/simple_dgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_dgemm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/simple_dgemv/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_dgemv/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/simple_dlrm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_dlrm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/simple_hgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_hgemm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/simple_sgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_sgemm/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocWMMA/simple_sgemv/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_sgemv/CMakeLists.txt
@@ -46,10 +46,19 @@ else()
 endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(hip REQUIRED)
+find_package(OpenMP REQUIRED)
 # Try to find rocWMMA as a package first
 find_package(rocwmma QUIET)
 
-if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
+if(TARGET roc::rocwmma)
+    set(ROCWMMA_TARGET roc::rocwmma)
+elseif(TARGET rocwmma)
+    # Fallback for legacy naming
+    set(ROCWMMA_TARGET rocwmma)
+endif()
+
+if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     # If package not found, try to find headers manually
     find_path(ROCWMMA_INCLUDE_DIR
         NAMES rocwmma/rocwmma.hpp
@@ -64,6 +73,7 @@ if(NOT TARGET rocwmma AND NOT rocwmma_FOUND)
     # Create imported target for header-only library
     add_library(rocwmma INTERFACE)
     target_include_directories(rocwmma INTERFACE ${ROCWMMA_INCLUDE_DIR})
+    set(ROCWMMA_TARGET rocwmma)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -71,7 +81,7 @@ add_executable(${example_name} main.hip)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocwmma)
+target_link_libraries(${example_name} PRIVATE ${ROCWMMA_TARGET})
 
 target_include_directories(
     ${example_name}


### PR DESCRIPTION
## Motivation

Fix Azure CI build failures following rocWMMA target name change to `roc::rocwmma` in https://github.com/ROCm/rocm-libraries/commit/8f545778b668a095f8154d69effb225db8962bc3

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

See if it fixes Azure CI, might break GH workflows...

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
