### PR TITLE
Make all Ubuntu GH workflow noninteractive

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.1'
     AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
@@ -34,7 +35,6 @@ jobs:
                   python3 -m pip install cmake
           - name: Install ROCm Dev
             run: |
-                  export DEBIAN_FRONTEND=noninteractive
                   wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
                   apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
                   apt-get update -qq &&

--- a/.github/workflows/build_applications_cuda.yml
+++ b/.github/workflows/build_applications_cuda.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.0'
     AMDGPU_INSTALLER_VERSION: 7.0.70000-1
 
@@ -36,7 +37,6 @@ jobs:
 
           - name: Install Hip for CUDA
             run: |
-              export DEBIAN_FRONTEND=noninteractive
               wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
               apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
               apt-get update -qq &&

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.1'
     AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
@@ -34,7 +35,6 @@ jobs:
                   python3 -m pip install cmake
           - name: Install ROCm Dev
             run: |
-                  export DEBIAN_FRONTEND=noninteractive
                   wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
                   apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
                   apt-get update -qq &&

--- a/.github/workflows/build_hip_basic_cuda.yml
+++ b/.github/workflows/build_hip_basic_cuda.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.0'
     AMDGPU_INSTALLER_VERSION: 7.0.70000-1
 
@@ -36,7 +37,6 @@ jobs:
 
           - name: Install Hip for CUDA
             run: |
-              export DEBIAN_FRONTEND=noninteractive
               wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
               apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
               apt-get update -qq &&

--- a/.github/workflows/build_hip_documentation.yml
+++ b/.github/workflows/build_hip_documentation.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.1'
     AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
@@ -34,7 +35,6 @@ jobs:
                   python3 -m pip install cmake
           - name: Install ROCm Dev
             run: |
-                  export DEBIAN_FRONTEND=noninteractive
                   wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
                   apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
                   apt-get update -qq &&

--- a/.github/workflows/build_hip_documentation_cuda.yml
+++ b/.github/workflows/build_hip_documentation_cuda.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.0'
     AMDGPU_INSTALLER_VERSION: 7.0.70000-1
 
@@ -36,7 +37,6 @@ jobs:
 
           - name: Install Hip for CUDA
             run: |
-              export DEBIAN_FRONTEND=noninteractive
               wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
               apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
               apt-get update -qq &&

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.1'
     AMDGPU_INSTALLER_VERSION: 7.1.70100-1
     GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
@@ -34,7 +35,6 @@ jobs:
                   python3 -m pip install cmake
           - name: Install ROCm Dev
             run: |
-                  export DEBIAN_FRONTEND=noninteractive
                   wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
                   apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
                   apt-get update -qq &&

--- a/.github/workflows/build_libraries_cuda.yml
+++ b/.github/workflows/build_libraries_cuda.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/**'
 
 env:
+    DEBIAN_FRONTEND: noninteractive
     ROCM_VERSION: '7.0'
     AMDGPU_INSTALLER_VERSION: 7.0.70000-1
 
@@ -35,7 +36,6 @@ jobs:
 
       - name: Install Hip for CUDA
         run: |
-          export DEBIAN_FRONTEND=noninteractive
           wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
           apt-get -y install ./amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb &&
           apt-get update -qq &&

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,6 +13,7 @@ on:
       - 'release/rocm-rel*'
 
 env:
+  DEBIAN_FRONTEND: noninteractive
   CLANG_FORMAT: /usr/lib/llvm-18/bin/clang-format
 
 jobs:


### PR DESCRIPTION
## Motivation

Make all Ubuntu jobs noninteractive. Fixes Libraries CI.

## Technical Details

Set `DEBIAN_FRONTEND=noninteractive` as top-level environment variable so every job inherits it.

## Test Plan

GH CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
