### PR TITLE
Fix rocprofv3 example binary name format in script

### DIFF
--- a/Tools/rocprofv3/rocprofv3-basic.sh
+++ b/Tools/rocprofv3/rocprofv3-basic.sh
@@ -22,7 +22,7 @@
 # SOFTWARE.
 
 EXAMPLE_TOOL="rocprofv3"
-EXAMPLE_BIN="${EXAMPLE_TOOL}_matmul"
+EXAMPLE_BIN="${EXAMPLE_TOOL}-matmul"
 EXAMPLE_WORKLOAD="./$EXAMPLE_BIN"
 
 # Check for existence of tool


### PR DESCRIPTION
## Motivation

Should be `-matmul` not `_matmul`. Fixes ctest failure.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Local test runs successfully.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
