### PR TITLE
Fix return statement in hipTensor CMakeLists.txt

### DIFF
--- a/Libraries/hipTensor/CMakeLists.txt
+++ b/Libraries/hipTensor/CMakeLists.txt
@@ -56,7 +56,7 @@ if(NOT hiptensor_FOUND)
         STATUS
         "hipTensor could not be found, not building hipTensor examples"
     )
-    return(1)
+    return()
 endif()
 
 add_subdirectory(contraction)


### PR DESCRIPTION
## Motivation

`return(1)` does not terminate current file execution and still proceed to add hipTensor examples when hipTensor is not found.

## Technical Details

Couldn't find any docs but `return()` seem to work.

## Test Plan

Test with TheRock tarballs which don't have hipTensor.

## Test Result

`return()` correctly exits.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
