### PR TITLE
Update error handling for missing rocWMMA headers

### DIFF
--- a/Libraries/rocWMMA/CMakeLists.txt
+++ b/Libraries/rocWMMA/CMakeLists.txt
@@ -65,7 +65,8 @@ if(NOT ROCWMMA_TARGET AND NOT rocwmma_FOUND)
     )
 
     if(NOT ROCWMMA_INCLUDE_DIR)
-        message(FATAL_ERROR "rocWMMA headers not found. Please install rocWMMA or set ROCWMMA_INCLUDE_DIR")
+        message(WARNING "rocWMMA headers not found. Not building rocWMMA examples. Please install rocWMMA or set ROCWMMA_INCLUDE_DIR")
+        return()
     endif()
 
     # Create imported target for header-only library


### PR DESCRIPTION
## Motivation

Skip examples if rocWMMA not found. Fixes build issue with TheRock.

## Technical Details

Change fatal error to warning and return.

## Test Plan

Build with TheRock wheels and rocWMMA examples should be skipped. Build should not fail.

## Test Result

Build succeeds and rocWMMA examples are skipped.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
