### PR TITLE
Fix MIVisionX make build

### DIFF
--- a/Libraries/MIVisionX/mv_objdetect/Makefile
+++ b/Libraries/MIVisionX/mv_objdetect/Makefile
@@ -91,7 +91,7 @@ $(MODEL_FILE): | $(BUILD_DIR)
 # Run mv_compile to generate deployment artifacts
 $(GENERATED_FILES): $(MODEL_FILE)
 	@echo "Compiling YoloV2 model with mv_compile (batch size: $(BATCH_SIZE))..."
-	@cd $(BUILD_DIR) && CC=gcc $(MV_COMPILE) --model yoloV2Tiny20.caffemodel --install_folder . --input_dims $(BATCH_SIZE),3,416,416
+	@cd $(BUILD_DIR) && CC=gcc CXX=g++ $(MV_COMPILE) --model yoloV2Tiny20.caffemodel --install_folder . --input_dims $(BATCH_SIZE),3,416,416
 	@echo "Model compilation complete"
 
 # Build the example


### PR DESCRIPTION
## Motivation

Fixes the make error in MIVisionX. What's odd is that this doesn't occur in the other PRs but in the mainline CI.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] New examples contain proper CMake and Make files.
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [x] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
