### PR TITLE
Fix HIPCXX variable usage in Makefiles

### DIFF
--- a/HIP-Basic/device_query/Makefile
+++ b/HIP-Basic/device_query/Makefile
@@ -41,7 +41,6 @@ ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu
 else ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS  ?= -Wall -Wextra
-  HIPCXX    := $(CXX)
   ICXXFLAGS += -D__HIP_PLATFORM_AMD__
   ILDFLAGS  += -L $(ROCM_INSTALL_DIR)/lib
   ILDLIBS   += -lamdhip64

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/simple_device_query/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/simple_device_query/Makefile
@@ -40,7 +40,6 @@ ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu
 else ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS  ?= -Wall -Wextra
-  HIPCXX    := $(CXX)
   ICXXFLAGS += -D__HIP_PLATFORM_AMD__
   ILDFLAGS  += -L $(ROCM_INSTALL_DIR)/lib
   ILDLIBS   += -lamdhip64

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/explicit_copy/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/explicit_copy/Makefile
@@ -41,7 +41,6 @@ ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu
 else ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS  ?= -Wall -Wextra
-  HIPCXX    := $(CXX)
   ICXXFLAGS += -D__HIP_PLATFORM_AMD__
   ILDFLAGS  += -L $(ROCM_INSTALL_DIR)/lib
   ILDLIBS   += -lamdhip64

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pageable_host_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pageable_host_memory/Makefile
@@ -40,7 +40,6 @@ ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu
 else ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS  ?= -Wall -Wextra
-  HIPCXX    := $(CXX)
   ICXXFLAGS += -D__HIP_PLATFORM_AMD__
   ILDFLAGS  += -L $(ROCM_INSTALL_DIR)/lib
   ILDLIBS   += -lamdhip64

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pinned_host_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pinned_host_memory/Makefile
@@ -40,7 +40,6 @@ ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu
 else ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS  ?= -Wall -Wextra
-  HIPCXX    := $(CXX)
   ICXXFLAGS += -D__HIP_PLATFORM_AMD__
   ILDFLAGS  += -L $(ROCM_INSTALL_DIR)/lib
   ILDLIBS   += -lamdhip64


### PR DESCRIPTION
## Motivation

Some examples' Makefile are overriding `HIPCXX` with `$(CXX)` when they should be using a HIP compiler instead of a generic C++ compiler. This creates confusion and breaks HIP compilation without additional flags.

## Technical Details

Remove `HIPCXX := $(CXX)` in Makefiles. If examples want to use a generic C++ compiler, they should use `$(CXX)` directly.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
