### PR TITLE
git: Ignore .cline_storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 [Bb]uild
 *.pdb
 CMakeUserPresets.json
+.cline_storage


### PR DESCRIPTION
## Motivation

The Cline plugin for VS Code creates the `.cline_storage` directory in the top-level project directory when active. This should not be checked into git.

## Technical Details

Adds `.cline_storage` to `.gitignore`.

## Test Plan

Tested locally.

## Test Result

Works as expected.

## Added/Updated documentation?

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
