### PR TITLE
Enable virtual memory examples for CUDA

### DIFF
--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/CMakeLists.txt
@@ -29,8 +29,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     message(STATUS "The virtual memory example is available only on Linux.")
-elseif(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
-    message(STATUS "The virtual memory example is currently not supported for CUDA.")
 else()
     add_subdirectory(virtual_memory)
 endif()

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/virtual_memory/CMakeLists.txt
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/virtual_memory/CMakeLists.txt
@@ -31,13 +31,14 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../../Common/HipPlatform.cmake")
 select_gpu_language()
-
-if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
-    message(FATAL_ERROR "This example is currently not supported for CUDA.")
-endif()
-
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
+
+if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
+    # The example calls hipDeviceGetAttribute which internally uses the CUDA
+    # driver API. We must explicitly link the driver library.
+    find_package(CUDAToolkit REQUIRED)
+endif()
 
 set(ROCM_ROOT "/opt/rocm" CACHE PATH "Root directory of the ROCm installation")
 
@@ -53,5 +54,6 @@ set_target_properties(${example_name} PROPERTIES $<$<COMPILE_LANGUAGE:CUDA>:CUDA
                                                  $<$<COMPILE_LANGUAGE:HIP>:HIP_EXTENSIONS OFF>)
 target_compile_features(${example_name} PRIVATE cuda_std_17 hip_std_17)
 target_include_directories(${example_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${ROCM_ROOT}/include>)
+target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
 
 install(TARGETS ${example_name})


### PR DESCRIPTION
## Motivation

Due to a bug in ROCm < 7.1, virtual memory didn't work correctly for CUDA GPUs. Since ROCm 7.1 was released a while ago, we can now enable these examples.

## Technical Details

Removes the guards against CUDA from the virtual memory CMake files.

## Test Plan

Tested locally.

## Test Result

Works.

## Added/Updated documentation?

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
