### PR TITLE
fix the issue of GEMM validation failure

### DIFF
--- a/HIP-Basic/matrix_multiplication/main.hip
+++ b/HIP-Basic/matrix_multiplication/main.hip
@@ -28,7 +28,6 @@
 #include <algorithm>
 #include <iostream>
 #include <vector>
-#include <vector>
 #include <cstdlib>
 #include <cassert>
 #include <cstddef>

--- a/HIP-Basic/matrix_multiplication/main.hip
+++ b/HIP-Basic/matrix_multiplication/main.hip
@@ -28,10 +28,9 @@
 #include <algorithm>
 #include <iostream>
 #include <vector>
-#include <cstdlib>
+
 #include <cassert>
 #include <cstddef>
-#include <memory>
 
 /// \brief Multiplies matrices \p A and \p B and stores the result to \p C.
 /// - The number of rows of the result matrix is equal to the number of rows of matrix A
@@ -214,9 +213,9 @@ int main(int argc, const char* argv[])
     std::vector<float> C(c_cols * c_rows);
 
     // Set matrix elements to random value on the host.
-    for (size_t i = 0; i < A.size(); ++i) A[i] = static_cast<float>(rand() / RAND_MAX );
-    for (size_t i = 0; i < B.size(); ++i) B[i] = static_cast<float>(rand() / RAND_MAX );
-
+    for (size_t i = 0; i < A.size(); ++i) A[i] = static_cast<float>(rand() / (RAND_MAX + 1.0f) );
+    for (size_t i = 0; i < B.size(); ++i) B[i] = static_cast<float>(rand() / (RAND_MAX + 1.0f) );
+    
     const size_t a_bytes = sizeof(float) * A.size();
     const size_t b_bytes = sizeof(float) * B.size();
     const size_t c_bytes = sizeof(float) * C.size();

--- a/HIP-Basic/matrix_multiplication/main.hip
+++ b/HIP-Basic/matrix_multiplication/main.hip
@@ -28,9 +28,11 @@
 #include <algorithm>
 #include <iostream>
 #include <vector>
-
+#include <vector>
+#include <cstdlib>
 #include <cassert>
 #include <cstddef>
+#include <memory>
 
 /// \brief Multiplies matrices \p A and \p B and stores the result to \p C.
 /// - The number of rows of the result matrix is equal to the number of rows of matrix A
@@ -108,6 +110,53 @@ __global__ void matrix_multiplication_kernel(const float*       A,
     // Every thread stores the final result to global memory.
     C[block_offset + b_cols * ty + tx] = thread_result;
 }
+
+bool checkValidity (const float* A, const float* B, const float* C, size_t a_rows,size_t a_cols, size_t b_cols)
+{
+    const float EPSILON = 0.001;
+    const int BLOCK_SIZE = 64;
+
+    std::vector<float> golden_c(b_cols * a_rows);
+
+    for (size_t i_block = 0; i_block < a_rows; i_block += BLOCK_SIZE) {
+        for (size_t j_block = 0; j_block < b_cols; j_block += BLOCK_SIZE) {
+            for (size_t t_block = 0; t_block < a_cols; t_block += BLOCK_SIZE) {
+                int i_end = std::min(i_block + BLOCK_SIZE, a_rows);
+                int j_end = std::min(j_block + BLOCK_SIZE, b_cols);
+                int t_end = std::min(t_block + BLOCK_SIZE, a_cols);
+
+                
+                for (int i = i_block; i < i_end; ++i) {
+                    for (int t = t_block; t < t_end; ++t) {
+                        float a_val = A[i * a_cols + t];
+                        for (int j = j_block; j < j_end; ++j) {
+                             golden_c[i * b_cols + j] += a_val * B[t * b_cols + j];
+                        }
+                    }
+                }
+            }
+        }
+    }
+   
+    for (size_t i = 0; i < a_rows; ++i) 
+    {        
+        for (size_t j = 0; j < b_cols; ++j) 
+        {
+            float absdiff = abs(C[i*b_cols+j] - golden_c[i*b_cols+j]);
+            if(absdiff > EPSILON)
+            {
+                std::cerr << "\nVALIDATION FAILED!!!\n    reference" << "[" << i << ", " << j << "] = "
+                     << golden_c[i*b_cols+j] << ",\n    calculated" << "[" << i << ", " << j << "] = "
+                     << C[i*b_cols+j]
+                     << ",\n    absolute difference" << "[" << i << ", " << j << "] = " << absdiff << "\n"
+                     << "Further validation was stopped\n\n";
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 template<unsigned int BlockSize>
 void configure_parser(cli::Parser& parser)
 {
@@ -165,11 +214,9 @@ int main(int argc, const char* argv[])
     std::vector<float> B(b_cols * b_rows);
     std::vector<float> C(c_cols * c_rows);
 
-    // Set matrix elements to a constant on the host.
-    std::fill(A.begin(), A.end(), 1.F);
-
-    constexpr float b_value = 0.02F;
-    std::fill(B.begin(), B.end(), b_value);
+    // Set matrix elements to random value on the host.
+    for (size_t i = 0; i < A.size(); ++i) A[i] = static_cast<float>(rand() / RAND_MAX );
+    for (size_t i = 0; i < B.size(); ++i) B[i] = static_cast<float>(rand() / RAND_MAX );
 
     const size_t a_bytes = sizeof(float) * A.size();
     const size_t b_bytes = sizeof(float) * B.size();
@@ -203,11 +250,7 @@ int main(int argc, const char* argv[])
     HIP_CHECK(hipFree(d_C));
 
     // Check if the resulting elements match the expectation.
-    constexpr float tolerance         = 0.001F;
-    const bool      validation_passed = std::all_of(
-        C.begin(),
-        C.end(),
-        [=](const float value) { return tolerance > std::abs(value - a_cols * b_value); });
+    bool      validation_passed = checkValidity(A.data(),B.data(),C.data(),a_rows,a_cols,b_cols);
     if(validation_passed)
     {
         std::cout << "Validation passed." << std::endl;


### PR DESCRIPTION
## Motivation

when trying GEMM sample on R9700, if I change A_rows,A_cols,B_cols from default value to be 4096, validation will fail

## Technical Details

1) set the input matrix value to be random, which is the same with other GEMM application
2) develop a GEMM CPU validation function to test the GPU output , in order to speed up GEMM on CPU, I chose the block GEMM on CPU

## Test Plan

1) run the default value: the validation test can pass:
./hip_matrix_multiplication
Matrix multiplication: [2048x1024] * [1024x1024], block size: 16x16
Validation passed.
2) input size to be 4096, it still can pass 
 ./hip_matrix_multiplication --A_rows 4096 --A_cols 4096 --B_cols 4096
Matrix multiplication: [4096x4096] * [4096x4096], block size: 16x16
Validation passed.
3) run other size, and it still can pass
./hip_matrix_multiplication --A_rows 4096 --A_cols 512 --B_cols 2048
Matrix multiplication: [4096x512] * [512x2048], block size: 16x16
Validation passed.

## Test Result
all the test can pass 
<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [* ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ *] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ *] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
