### PR TITLE
Disable hipSPARSELt examples on unsupported architectures (#352)

### DIFF
--- a/Libraries/hipSPARSELt/CMakeLists.txt
+++ b/Libraries/hipSPARSELt/CMakeLists.txt
@@ -27,6 +27,16 @@ include(CTest)
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
+# see https://github.com/ROCm/rocm-libraries/blob/40bbc75960836d1b9e0573606df9dd79800e412a/projects/hipsparselt/cmake/hipsparselt_supported_architectures.cmake#L10-L21
+set(HIPSPARSELT_SUPPORTED_ARCH gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPSPARSELT_SUPPORTED_ARCH)
+        message(STATUS "hipSPARSELt does not support architecture: ${ARCH}, not building hipSPARSELt examples")
+        return()
+    endif()
+endforeach()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"

--- a/Libraries/hipSPARSELt/spmm/CMakeLists.txt
+++ b/Libraries/hipSPARSELt/spmm/CMakeLists.txt
@@ -35,6 +35,15 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
+# see https://github.com/ROCm/rocm-libraries/blob/40bbc75960836d1b9e0573606df9dd79800e412a/projects/hipsparselt/cmake/hipsparselt_supported_architectures.cmake#L10-L21
+set(HIPSPARSELT_SUPPORTED_ARCH gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPSPARSELT_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipSPARSELt does not support architecture: ${ARCH}, not building hipSPARSELt examples")
+    endif()
+endforeach()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"

--- a/Libraries/hipSPARSELt/spmm_advanced/CMakeLists.txt
+++ b/Libraries/hipSPARSELt/spmm_advanced/CMakeLists.txt
@@ -35,6 +35,15 @@ select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()
 
+# see https://github.com/ROCm/rocm-libraries/blob/40bbc75960836d1b9e0573606df9dd79800e412a/projects/hipsparselt/cmake/hipsparselt_supported_architectures.cmake#L10-L21
+set(HIPSPARSELT_SUPPORTED_ARCH gfx942 gfx950)
+
+foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
+    if(NOT ARCH IN_LIST HIPSPARSELT_SUPPORTED_ARCH)
+        message(FATAL_ERROR "hipSPARSELt does not support architecture: ${ARCH}, not building hipSPARSELt examples")
+    endif()
+endforeach()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROCM_ROOT
         "$ENV{HIP_PATH}"


### PR DESCRIPTION



## Motivation
Skips hipSPARSELt on unsupported arch.
(cherry picked from commit 9318a0d9137dfdd3140411a8ef6af4475a7d9df9)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
