### PR TITLE
Fix Threads linking for rocProfiler-SDK examples

### DIFF
--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/api_callback_tracing/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/api_callback_tracing/CMakeLists.txt
@@ -52,6 +52,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
 find_package(rocprofiler-sdk-roctx REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -67,7 +68,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client rocprofiler-sdk-roctx::rocprofiler-sdk-roctx ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads rocprofiler-sdk-roctx::rocprofiler-sdk-roctx ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/code_object_isa_decode/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/code_object_isa_decode/CMakeLists.txt
@@ -53,13 +53,14 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 find_package(rocprofiler-sdk REQUIRED)
 find_package(libdw REQUIRED)
 find_package(amd_comgr REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(${example_name} main.cpp client.cpp)
 # Make example runnable using ctest
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk libdw::libdw amd_comgr ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk Threads::Threads libdw::libdw amd_comgr ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/code_object_tracing/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/code_object_tracing/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/callback/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/callback/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/intercept_table/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/intercept_table/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/pc_sampling/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/pc_sampling/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocprofiler-sdk REQUIRED)
+find_package(Threads REQUIRED)
 
 # Create client library
 add_library(${example_name}_client SHARED client.cpp pcs.cpp)
@@ -66,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE ${example_name}_client Threads::Threads ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/thread_trace/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/thread_trace/CMakeLists.txt
@@ -54,13 +54,14 @@ find_package(rocprofiler-sdk REQUIRED)
 find_package(rocprofiler-sdk-roctx REQUIRED)
 find_package(libdw REQUIRED)
 find_package(amd_comgr REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(${example_name} main.cpp client.cpp)
 # Make example runnable using ctest
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk-roctx::rocprofiler-sdk-roctx libdw::libdw amd_comgr ${CXX_FS_LIBRARY})
+target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk Threads::Threads rocprofiler-sdk-roctx::rocprofiler-sdk-roctx libdw::libdw amd_comgr ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}


### PR DESCRIPTION
## Motivation

Fixes build failure on RHEL 8.10

## Technical Details

See https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread#
RHEL 8.10 has glibc 2.28 which requires extra linking to pthread

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
