### PR TITLE
Fix rocProfiler-SDK examples on older GCC versions (>=7.5) (#367)

### DIFF
--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_api_buffered_tracing)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/api_callback_tracing/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/api_callback_tracing/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_api_callback_tracing)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -54,7 +56,9 @@ find_package(rocprofiler-sdk-roctx REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../Common)
 
@@ -63,7 +67,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client rocprofiler-sdk-roctx::rocprofiler-sdk-roctx ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/code_object_isa_decode/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/code_object_isa_decode/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_code_object_isa_decode)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -57,12 +59,13 @@ add_executable(${example_name} main.cpp client.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk libdw::libdw amd_comgr)
+target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk libdw::libdw amd_comgr ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}
     PRIVATE ../../../Common ../../../External
 )
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
+set_source_files_properties(client.cpp PROPERTIES LANGUAGE ${GPU_RUNTIME})
 
 install(TARGETS ${example_name})

--- a/Libraries/rocProfiler-SDK/code_object_isa_decode/Makefile
+++ b/Libraries/rocProfiler-SDK/code_object_isa_decode/Makefile
@@ -38,7 +38,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk -ldw -lamd_comgr
+ILDLIBS   := -lrocprofiler-sdk -ldw -lamd_comgr -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/code_object_tracing/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/code_object_tracing/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_code_object_tracing)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/code_object_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/code_object_tracing/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_counter_collection_buffer)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_counter_collection_buffer_device_serialization)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/callback/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/callback/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_counter_collection_callback)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_counter_collection_device_profiling)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_counter_collection_device_profiling_sync)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_counter_collection_print_functional_counters)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_external_correlation_id_request)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/intercept_table/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/intercept_table/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_intercept_table)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/intercept_table/Makefile
+++ b/Libraries/rocProfiler-SDK/intercept_table/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/openmp_target/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/openmp_target/CMakeLists.txt
@@ -42,6 +42,8 @@ endif()
 
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -81,6 +83,7 @@ add_library(${example_name}_client SHARED client.cpp)
 
 target_link_libraries(${example_name}_client PRIVATE
     rocprofiler-sdk::rocprofiler-sdk
+    ${CXX_FS_LIBRARY}
 )
 
 target_include_directories(${example_name}_client PRIVATE
@@ -98,6 +101,7 @@ target_link_libraries(${example_name} PRIVATE
     Threads::Threads
     rocprofiler-sdk-roctx::rocprofiler-sdk-roctx
     ${example_name}_client
+    ${CXX_FS_LIBRARY}
 )
 
 target_include_directories(${example_name} PRIVATE

--- a/Libraries/rocProfiler-SDK/openmp_target/Makefile
+++ b/Libraries/rocProfiler-SDK/openmp_target/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD) -fopenmp
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx
+ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/pc_sampling/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/pc_sampling/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_pc_sampling)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -53,7 +55,9 @@ find_package(rocprofiler-sdk REQUIRED)
 # Create client library
 add_library(${example_name}_client SHARED client.cpp pcs.cpp)
 
-target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+target_link_libraries(${example_name}_client PRIVATE rocprofiler-sdk::rocprofiler-sdk ${CXX_FS_LIBRARY})
+
+target_compile_features(${example_name}_client PRIVATE cxx_std_17 hip_std_17)
 
 target_include_directories(${example_name}_client PRIVATE ../../../Common)
 
@@ -62,7 +66,7 @@ add_executable(${example_name} main.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE ${example_name}_client)
+target_link_libraries(${example_name} PRIVATE ${example_name}_client ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/pc_sampling/Makefile
+++ b/Libraries/rocProfiler-SDK/pc_sampling/Makefile
@@ -39,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk
+ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/thread_trace/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/thread_trace/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocprofiler-sdk_thread_trace)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FindFilesystem.cmake")
+
 if(GPU_RUNTIME STREQUAL "CUDA")
     message(STATUS "rocProfiler-SDK examples do not support the CUDA runtime")
     return()
@@ -58,7 +60,7 @@ add_executable(${example_name} main.cpp client.cpp)
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to example library
-target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk-roctx::rocprofiler-sdk-roctx libdw::libdw amd_comgr)
+target_link_libraries(${example_name} PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk-roctx::rocprofiler-sdk-roctx libdw::libdw amd_comgr ${CXX_FS_LIBRARY})
 
 target_include_directories(
     ${example_name}

--- a/Libraries/rocProfiler-SDK/thread_trace/Makefile
+++ b/Libraries/rocProfiler-SDK/thread_trace/Makefile
@@ -38,7 +38,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx -ldw -lamd_comgr
+ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx -ldw -lamd_comgr -lstdc++fs
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra


### PR DESCRIPTION


## Motivation
* Fix client CXX std in rocProfiler-SDK examples



* Fix filesystem linking for rocProfiler-SDK examples



---------


(cherry picked from commit 393992dbf1bcbd9087fa5734b0c92438b4317f77)

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
