### PR TITLE
Fix swizzle_tensor segfault

### DIFF
--- a/Libraries/hipBLASLt/gemm_swizzle_a/main.cpp
+++ b/Libraries/hipBLASLt/gemm_swizzle_a/main.cpp
@@ -313,17 +313,13 @@ void gemm(hipblasLtHandle_t  handle,
                                                               HIPBLASLT_MATRIX_LAYOUT_ORDER,
                                                               &orderA,
                                                               sizeof(orderA)));
-            hipblaslt_f8_fnuz* src;
-            hipblaslt_f8_fnuz* dst;
+            std::vector<hipblaslt_f8_fnuz> src(m * k, 0);
+            std::vector<hipblaslt_f8_fnuz> dst(m * k, 0);
             HIP_CHECK(
-                hipMalloc(&src, m * k * sizeof(hipblaslt_f8_fnuz))); // Allocate memory on device
+                hipMemcpy(src.data(), d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
+            swizzle_tensor(dst.data(), src.data(), m, k, true);
             HIP_CHECK(
-                hipMalloc(&dst, m * k * sizeof(hipblaslt_f8_fnuz))); // Allocate memory on device
-            HIP_CHECK(
-                hipMemcpy(src, d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
-            swizzle_tensor(dst, src, m, k, true);
-            HIP_CHECK(
-                hipMemcpy(d_a, dst, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
+                hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
         }
     }
     else


### PR DESCRIPTION
## Motivation

Fixes `gemm_swizzle_a` segfault.

## Technical Details

The swizzle should be done on host, the tensors were allocated on device which gives a segfault when access on the host without dma.

## Test Plan

Local run with the PR

## Test Result

No segfault on gfx1100 (navi doesn't support swizzle yet so there's no solution)
```
./hipblaslt_gemm_swizzle_a 
Best solution time: 280.23 us (swizzle_a == 0)
No valid solution found!
No valid solution found!
F16 Swizzle Validation Error at index: 0, diff: 76
f8 Swizzle Validation Error at index: 0, diff: 76
```

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
