### PR TITLE
Fix rocDecode find_package check

### DIFF
--- a/Libraries/rocDecode/CMakeLists.txt
+++ b/Libraries/rocDecode/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
-find_package(rocdecode REQUIRED)
+find_package(rocdecode QUIET)
 if(NOT rocdecode_FOUND)
     message(STATUS "rocDecode could not be found, not building rocDecode examples")
     return()


### PR DESCRIPTION
## Motivation

Bug fixes to enable TheRock.


## Technical Details

`REQUIRED` would fail directly, change to `QUIET` to properly check and skip.

## Test Plan

Build and test on TheRock + gfx1100 + Ubuntu24.04

## Test Result

Properly skips rocDecode.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
