### PR TITLE
Update ROCm to 7.1.1 and remove unsupported gfx archs

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -14,9 +14,9 @@ on:
 
 env:
     DEBIAN_FRONTEND: noninteractive
-    ROCM_VERSION: '7.1'
-    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
-    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
+    ROCM_VERSION: '7.1.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.1.70101-1
+    GPU_TARGETS: gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
 
 jobs:
     build:

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -14,9 +14,9 @@ on:
 
 env:
     DEBIAN_FRONTEND: noninteractive
-    ROCM_VERSION: '7.1'
-    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
-    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
+    ROCM_VERSION: '7.1.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.1.70101-1
+    GPU_TARGETS: gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
 
 jobs:
     build:

--- a/.github/workflows/build_hip_documentation.yml
+++ b/.github/workflows/build_hip_documentation.yml
@@ -14,9 +14,9 @@ on:
 
 env:
     DEBIAN_FRONTEND: noninteractive
-    ROCM_VERSION: '7.1'
-    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
-    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
+    ROCM_VERSION: '7.1.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.1.70101-1
+    GPU_TARGETS: gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
 
 jobs:
     build:

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -14,9 +14,9 @@ on:
 
 env:
     DEBIAN_FRONTEND: noninteractive
-    ROCM_VERSION: '7.1'
-    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
-    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
+    ROCM_VERSION: '7.1.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.1.70101-1
+    GPU_TARGETS: gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
 
 jobs:
     build:

--- a/.github/workflows/build_programming_guide.yml
+++ b/.github/workflows/build_programming_guide.yml
@@ -14,9 +14,9 @@ on:
 
 env:
     DEBIAN_FRONTEND: noninteractive
-    ROCM_VERSION: '7.1'
-    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
-    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
+    ROCM_VERSION: '7.1.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.1.70101-1
+    GPU_TARGETS: gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
 
 jobs:
     build:

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -13,9 +13,9 @@ on:
       - '.github/workflows/**'
 
 env:
-    ROCM_VERSION: '7.1'
-    AMDGPU_INSTALLER_VERSION: 7.1.70100-1
-    GPU_TARGETS: gfx803;gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201
+    ROCM_VERSION: '7.1.1'
+    AMDGPU_INSTALLER_VERSION: 7.1.1.70101-1
+    GPU_TARGETS: gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201
 
 jobs:
     build:


### PR DESCRIPTION
## Motivation

The CK PR builds locally on ROCm 7.1.1 but fails in the CI with ROCm 7.1.0. Time to update.

## Technical Details

Updates the Linux CI runners to ROCm 7.1.1. While we're at it, all unsupported gfx archs are removed as well and new ones added according to [this page](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html).

## Test Plan

n/a

## Test Result

n/a

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
