### PR TITLE
Add -fpic to glad.cpp for SLES 15.7 gcc compatibility

### DIFF
--- a/Applications/sobel_filter/CMakeLists.txt
+++ b/Applications/sobel_filter/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip ../../External/glad/glad.cpp)
+set_source_files_properties(../../External/glad/glad.cpp PROPERTIES COMPILE_OPTIONS "-fpic")
 
 add_test(NAME ${example_name} COMMAND ${example_name})
 

--- a/HIP-Basic/opengl_interop/CMakeLists.txt
+++ b/HIP-Basic/opengl_interop/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip ../../External/glad/glad.cpp)
+set_source_files_properties(../../External/glad/glad.cpp PROPERTIES COMPILE_OPTIONS "-fpic")
 
 set(include_dirs "../../Common" "../../External")
 if(GPU_RUNTIME STREQUAL "CUDA")


### PR DESCRIPTION
## Motivation

Fixes build error on SLES 15.7

## Technical Details

gcc on SLES 15.7 is built without `--enable-default-pie`, thus need to set `-fpic` explicitly for `glad.cpp` to build with clang which uses pie by default https://github.com/ROCm/llvm-project/blob/1ab860e4a2d43cac1b7e0995809fc24cd750e5ec/utils/bazel/llvm-project-overlay/clang/include/clang/Config/config.h#L26

## Test Plan

Build and test on sles15.7

## Test Result

Build with no error. `sobel_filter` test pass.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
