### PR TITLE
Fix graph API binary placement

### DIFF
--- a/HIP-Doc/Tutorials/graph_api/src/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/graph_api/src/CMakeLists.txt
@@ -25,6 +25,11 @@ set(example_streams ${PROJECT_NAME}_streams)
 set(example_graph_capture ${PROJECT_NAME}_graph_capture)
 set(example_graph_creation ${PROJECT_NAME}_graph_creation)
 
+file(RELATIVE_PATH folder_bin_long ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+cmake_path(GET folder_bin_long PARENT_PATH folder_bin) # Place the binaries in 'bin', not 'bin/src'
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
+
 include(FetchContent)
 
 find_package(TIFF COMPONENTS CXX)


### PR DESCRIPTION
## Motivation

With the current way, the binaries of the HIP graph API tutorial are placed in `${CMAKE_BINARY_DIR}/bin/src`, unlike all other examples. This PR removes the `src` from the path, placing the binaries in the same directory as the rest of the examples.

## Technical Details

Makes use of `cmake_path`.

## Test Plan

Tested locally.

## Test Result

Works.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
