### PR TITLE
Disable failing MIVisionX test

### DIFF
--- a/Libraries/MIVisionX/CMakeLists.txt
+++ b/Libraries/MIVisionX/CMakeLists.txt
@@ -56,5 +56,6 @@ if(NOT OpenVX_LIBRARY)
 endif()
 
 add_subdirectory(canny)
-add_subdirectory(mv_objdetect)
+# Disable this test until Jira ticket ROCM-1771 is resolved
+#add_subdirectory(mv_objdetect)
 add_subdirectory(opencv_orb)


### PR DESCRIPTION
## Motivation

One of the MIVisionX tests is failing because of missing files in the artifact provided to the Azure runners. The issue has been raised on Jira (ROCM-1771). Until it is resolved we should disable it to unblock the other PRs.

## Technical Details

Comments out the offending test.

## Test Plan

n/a

## Test Result

n/a

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
