### PR TITLE
Fix Vulkan validation errors

### DIFF
--- a/HIP-Basic/vulkan_interop/main.hip
+++ b/HIP-Basic/vulkan_interop/main.hip
@@ -598,8 +598,6 @@ struct frame
 
     /// The semaphore that guards the use of the swapchain image before it is ready.
     VkSemaphore image_acquired;
-    /// The semaphore that guards the present before the image is rendered.
-    VkSemaphore render_finished;
     /// A fence that allows us to synchronize on CPU until this frame is ready
     /// to be re-rendered again after it has been submitted to the GPU.
     VkFence frame_fence;
@@ -614,7 +612,6 @@ struct frame
     explicit frame(const graphics_context& ctx) : ctx(ctx)
     {
         this->image_acquired  = create_semaphore(ctx);
-        this->render_finished = create_semaphore(ctx);
 
         VkFenceCreateInfo fence_create_info = {};
         fence_create_info.sType             = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
@@ -641,7 +638,6 @@ struct frame
         this->ctx.vkd->destroy_command_pool(this->ctx.dev, this->cmd_pool, nullptr);
         this->ctx.vkd->destroy_fence(this->ctx.dev, this->frame_fence, nullptr);
         this->ctx.vkd->destroy_semaphore(this->ctx.dev, this->image_acquired, nullptr);
-        this->ctx.vkd->destroy_semaphore(this->ctx.dev, this->render_finished, nullptr);
     }
 
     /// \brief Wait until the GPU-work for this frame has been completed, so that we
@@ -703,6 +699,11 @@ struct renderer
     std::vector<frame> frames;
     /// The index of the frame we are currently rendering to.
     uint32_t frame_index = 0;
+
+    /// The semaphore that guards the present before the image is rendered. The required number
+    /// is based on the swapchain image count instead of the frame count because vkQueuePresentKHR
+    /// is given ownership of this until the next vkAcquireNextImageKHR.
+    std::vector<VkSemaphore> render_semaphores;
 
     /// The Vulkan frame buffers to render to - each corresponds to a swapchain
     /// image with the same index in <tt>sc</tt>
@@ -770,6 +771,11 @@ struct renderer
         for(size_t i = 0; i < max_frames_in_flight; ++i)
         {
             this->frames.emplace_back(ctx);
+        }
+
+        for(size_t i = 0; i < this->sc.images.size(); ++i)
+        {
+            this->render_semaphores.emplace_back(create_semaphore(ctx));
         }
 
         this->sc.recreate_framebuffers(this->render_pass, this->framebuffers);
@@ -861,6 +867,11 @@ struct renderer
         this->ctx.vkd->destroy_pipeline_layout(this->ctx.dev, this->pipeline_layout, nullptr);
         this->ctx.vkd->destroy_pipeline(this->ctx.dev, this->pipeline, nullptr);
 
+        for(const VkSemaphore semaphore : this->render_semaphores)
+        {
+            this->ctx.vkd->destroy_semaphore(this->ctx.dev, semaphore, nullptr);
+        }
+
         for(const VkFramebuffer fb : this->framebuffers)
         {
             this->ctx.vkd->destroy_framebuffer(this->ctx.dev, fb, nullptr);
@@ -878,10 +889,7 @@ struct renderer
     /// \brief Block until all current frames have finished rendering.
     void wait_all_frames()
     {
-        for(const frame& frame : this->frames)
-        {
-            frame.wait();
-        }
+        VK_CHECK(this->ctx.vkd->device_wait_idle(this->ctx.dev));
     }
 
     /// \brief Upload the initial values for each buffer to Vulkan.
@@ -1102,16 +1110,17 @@ struct renderer
             = {VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT};
 
         // The semaphores that need to be signaled after this step is finished:
-        // - The \p render_finished semaphore allows us to guard the time between when the rendering
+        // - The \p render_semaphore allows us to guard the time between when the rendering
         //   commands are finished (and so when the result is on the swapchain image) and when it can
         //   be copied to the GLFW window.
         // - The \p buffer_ready semaphore signals that the rendering process is finished, and that we
         //   can perform the next step of the simulation. This prevents that HIP is already modifying the
         //   buffer while Vulkan has not completely rendered it to the swapchain image.
 #if USE_EXTERNAL_SEMAPHORES == 1
-        VkSemaphore signal_semaphores[] = {frame.render_finished, this->buffer_ready};
+        VkSemaphore signal_semaphores[] = {this->render_semaphores[this->sc.image_index],
+                                           this->buffer_ready};
 #else
-        VkSemaphore signal_semaphores[] = {frame.render_finished};
+        VkSemaphore signal_semaphores[] = {this->render_semaphores[this->sc.image_index]};
 #endif
 
         // Submit the current frame's command buffer to the GPU.
@@ -1131,7 +1140,8 @@ struct renderer
 
         // Then finally ask the swapchain to draw the current image to the GLFW window, when rendering
         // is finished.
-        const swapchain::present_state present_state = this->sc.present(frame.render_finished);
+        const swapchain::present_state present_state
+            = this->sc.present(this->render_semaphores[this->sc.image_index]);
         if(present_state != swapchain::present_state::optimal)
             this->swapchain_out_of_date = true;
 

--- a/HIP-Basic/vulkan_interop/vulkan_utils.hip
+++ b/HIP-Basic/vulkan_interop/vulkan_utils.hip
@@ -138,6 +138,7 @@ device_dispatch::device_dispatch(const instance_dispatch& dispatch, VkDevice dev
     load(this->unmap_memory, "vkUnmapMemory");
     load(this->cmd_bind_vertex_buffers, "vkCmdBindVertexBuffers");
     load(this->cmd_bind_index_buffer, "vkCmdBindIndexBuffer");
+    load(this->device_wait_idle, "vkDeviceWaitIdle");
 #ifdef _WIN64
     load(this->get_memory_win32_handle, "vkGetMemoryWin32HandleKHR");
     load(this->get_semaphore_win32_handle, "vkGetSemaphoreWin32HandleKHR");

--- a/HIP-Basic/vulkan_interop/vulkan_utils.hpp
+++ b/HIP-Basic/vulkan_interop/vulkan_utils.hpp
@@ -170,6 +170,7 @@ struct device_dispatch
     PFN_vkUnmapMemory                 unmap_memory;
     PFN_vkCmdBindVertexBuffers        cmd_bind_vertex_buffers;
     PFN_vkCmdBindIndexBuffer          cmd_bind_index_buffer;
+    PFN_vkDeviceWaitIdle              device_wait_idle;
 #ifdef _WIN64
     PFN_vkGetMemoryWin32HandleKHR    get_memory_win32_handle;
     PFN_vkGetSemaphoreWin32HandleKHR get_semaphore_win32_handle;

--- a/HIP-Basic/vulkan_interop_mipmap/main.hip
+++ b/HIP-Basic/vulkan_interop_mipmap/main.hip
@@ -641,8 +641,6 @@ struct frame
 
     /// The semaphore that guards the use of the swapchain image before it is ready.
     VkSemaphore image_acquired;
-    /// The semaphore that guards the present before the image is rendered.
-    VkSemaphore render_finished;
     /// A fence that allows us to synchronize on CPU until this frame is ready
     /// to be re-rendered again after it has been submitted to the GPU.
     VkFence frame_fence;
@@ -657,7 +655,6 @@ struct frame
     explicit frame(const graphics_context& ctx) : ctx(ctx)
     {
         this->image_acquired  = create_semaphore(ctx);
-        this->render_finished = create_semaphore(ctx);
 
         VkFenceCreateInfo fence_create_info = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
         fence_create_info.flags             = VK_FENCE_CREATE_SIGNALED_BIT;
@@ -682,7 +679,6 @@ struct frame
         this->ctx.vkd->destroy_command_pool(this->ctx.dev, this->cmd_pool, nullptr);
         this->ctx.vkd->destroy_fence(this->ctx.dev, this->frame_fence, nullptr);
         this->ctx.vkd->destroy_semaphore(this->ctx.dev, this->image_acquired, nullptr);
-        this->ctx.vkd->destroy_semaphore(this->ctx.dev, this->render_finished, nullptr);
     }
 
     /// \brief Wait until the GPU-work for this frame has been completed, so that we
@@ -735,6 +731,12 @@ struct renderer
     std::vector<frame> frames;
     /// The index of the frame we are currently rendering to.
     uint32_t frame_index = 0;
+
+    /// The semaphore that guards the present before the image is rendered. The required number
+    /// is based on the swapchain image count instead of the frame count because vkQueuePresentKHR
+    /// is given ownership of this until the next vkAcquireNextImageKHR.
+    std::vector<VkSemaphore> render_semaphores;
+
     /// The Vulkan frame buffers to render to - each corresponds to a swapchain
     /// image with the same index in <tt>sc</tt>
     std::vector<VkFramebuffer> framebuffers;
@@ -825,6 +827,12 @@ struct renderer
         {
             this->frames.emplace_back(ctx);
         }
+
+        for(size_t i = 0; i < this->sc.images.size(); ++i)
+        {
+            this->render_semaphores.emplace_back(create_semaphore(ctx));
+        }
+
         this->sc.recreate_framebuffers(this->render_pass, this->framebuffers);
 
         // Initialize timing information for performance measurement
@@ -899,6 +907,12 @@ struct renderer
             this->ctx.vkd->destroy_pipeline(this->ctx.dev, this->pipeline, nullptr);
         if(this->pipeline_layout)
             this->ctx.vkd->destroy_pipeline_layout(this->ctx.dev, this->pipeline_layout, nullptr);
+
+        // Destroy Vulkan semaphores
+        for(const VkSemaphore semaphore : this->render_semaphores)
+        {
+            this->ctx.vkd->destroy_semaphore(this->ctx.dev, semaphore, nullptr);
+        }
 
         // Destroy framebuffers
         for(const VkFramebuffer fb : this->framebuffers)
@@ -1338,7 +1352,7 @@ struct renderer
 
         // Setup semaphores to signal after rendering
         std::vector<VkSemaphore> signal_semaphores;
-        signal_semaphores.push_back(current_frame.render_finished);
+        signal_semaphores.push_back(this->render_semaphores[this->sc.image_index]);
 #if USE_EXTERNAL_SEMAPHORES == 1
         signal_semaphores.push_back(this->image_ready_for_hip);
 #endif
@@ -1360,7 +1374,7 @@ struct renderer
 
         // Present the rendered image
         const swapchain::present_state present_state
-            = this->sc.present(current_frame.render_finished);
+            = this->sc.present(this->render_semaphores[this->sc.image_index]);
         if(present_state != swapchain::present_state::optimal)
         {
             this->swapchain_out_of_date = true;


### PR DESCRIPTION
## Motivation
These were reported as driver errors, but they're indicative of application issues (minor in this case).

## Technical Details
In vulkan_interop, semaphore destruction was not waiting on the presentation engine to finish, which can be worked around by waiting for device idle instead of just submission fences. Vulkan_interop_mipmap was already doing this.

Both vulkan samples misused the wait semaphore provided to vkQueuePresentKHR by reusing it before the present completed. This solves that by creating enough semaphores to match the swapchain image count instead of matching the lower frame count as described in https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html

## Test Plan
vulkan_interop and vulkan_interop_mipmap were run on Radeon RX 9700 XT on Windows

## Test Result
Runs as before but without "Validation Error" messages.

## Added/Updated documentation?

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
