### PR TITLE
Disable MIVisionX OpenCV example

### DIFF
--- a/Libraries/MIVisionX/CMakeLists.txt
+++ b/Libraries/MIVisionX/CMakeLists.txt
@@ -58,4 +58,8 @@ endif()
 add_subdirectory(canny)
 # Disable this test until Jira ticket ROCM-1771 is resolved
 #add_subdirectory(mv_objdetect)
-add_subdirectory(opencv_orb)
+
+# OpenCV support will be removed in future releases
+# this example will only work on ubuntu 22.04 with MIVisionX built from source with OpenCV support
+# see https://github.com/ROCm/MIVisionX/pull/1575
+# add_subdirectory(opencv_orb)

--- a/Libraries/MIVisionX/Makefile
+++ b/Libraries/MIVisionX/Makefile
@@ -22,8 +22,8 @@
 
 EXAMPLES := \
 	canny \
-	mv_objdetect \
-	opencv_orb
+	mv_objdetect
+# opencv_orb
 
 all: $(EXAMPLES)
 

--- a/Libraries/MIVisionX/opencv_orb/README.md
+++ b/Libraries/MIVisionX/opencv_orb/README.md
@@ -1,5 +1,8 @@
 # MIVisionX ORB Feature Detection
 
+> [!WARNING]
+> This example is deprecated. OpenCV support from MIVisionX will be removed in future releases, this example will only work on Ubuntu 22.04 with MIVisionX built from source with OpenCV support. For more details on how to build MIVisionX, please see https://github.com/ROCm/MIVisionX and https://github.com/ROCm/MIVisionX/pull/1575
+
 ## Description
 
 This example demonstrates ORB (Oriented FAST and Rotated BRIEF) feature detection using OpenVX with OpenCV extensions. The example processes images or live camera feeds to detect and extract keypoint features, which are useful for object recognition, image matching, and tracking applications.


### PR DESCRIPTION
## Motivation

MIVisionX is no longer built with OpenCV support enabled on non-ubuntu distros.

## Technical Details

Disabled `opencv_orb` and update README.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [x] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
