### PR TITLE
Build CK only on nightly runs or when CK files changed

### DIFF
--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -65,6 +65,7 @@ jobs:
                     rocwmma-dev \
                     migraphx-dev \
                     hipsparselt-dev \
+                    hipsparse-dev \
                     mivisionx-dev \
                     composablekernel-dev
                   rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - 'Libraries/**'
       - '.github/workflows/**'
+  schedule:
+    # Nightly at 2 AM UTC
+    - cron: '0 2 * * *'
 
 env:
     DEBIAN_FRONTEND: noninteractive
@@ -69,18 +72,34 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
+          - uses: dorny/paths-filter@v3
+            id: changes
+            with:
+              filters: |
+                ck:
+                  - 'Libraries/ComposableKernel/**'
+          - name: Set CK build flag
+            run: |
+              # Enable CK for: scheduled runs OR CK files changed
+              if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ steps.changes.outputs.ck }}" == "true" ]; then
+                ENABLE_CK=ON
+              else
+                ENABLE_CK=OFF
+              fi
+              echo "ENABLE_CK=${ENABLE_CK}" >> $GITHUB_ENV
+              echo "ROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }}"
           - name: CMake Configure and Build
             shell: bash
             run: |
               cd Libraries
-              cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=ON -S . -B build
+              cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }} -S . -B build
               cmake --build build --parallel $(nproc)
           - name: Make
             shell: bash
             run: |
               sed -i '/rocCV/d' Libraries/Makefile
               cd Libraries
-              make -j $(nproc) ROCM_EXAMPLES_ENABLE_CK=ON HIP_ARCHITECTURES="${GPU_TARGETS}"
+              make -j $(nproc) ROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }} HIP_ARCHITECTURES="${GPU_TARGETS}"
 
           # Clean the workspace here since other jobs may not have the permissions to do so later
           # (needed for self-hosted runners)

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -88,19 +88,19 @@ jobs:
                 ENABLE_CK=OFF
               fi
               echo "ENABLE_CK=${ENABLE_CK}" >> $GITHUB_ENV
-              echo "ROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }}"
+              echo "ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK}"
           - name: CMake Configure and Build
             shell: bash
             run: |
               cd Libraries
-              cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }} -S . -B build
+              cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} -S . -B build
               cmake --build build --parallel $(nproc)
           - name: Make
             shell: bash
             run: |
               sed -i '/rocCV/d' Libraries/Makefile
               cd Libraries
-              make -j $(nproc) ROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }} HIP_ARCHITECTURES="${GPU_TARGETS}"
+              make -j $(nproc) ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} HIP_ARCHITECTURES="${GPU_TARGETS}"
 
           # Clean the workspace here since other jobs may not have the permissions to do so later
           # (needed for self-hosted runners)


### PR DESCRIPTION
## Motivation

CK build time is too long for regular PR

## Technical Details

- Add cron job to `build_libraries`
- Detect file change with `dorny/paths-filter@v3`
- Set `ENABLE_CK` environment variable only when it's trigger by cron or if changes are detected at `Libraries/ComposableKernel/**`
- `-DROCM_EXAMPLES_ENABLE_CK=${{ env.ENABLE_CK }}`
- Fixe missing hipsparse dependency for 7.2

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
