### PR TITLE
Fix paths-filter on push trigger

### DIFF
--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -28,17 +28,36 @@ jobs:
         container:
             image: ubuntu:22.04
         steps:
-          - uses: actions/checkout@v4
           - name: Install dependencies
             run: |
                   apt-get update -qq &&
-                  apt-get install -y build-essential g++ glslang-tools \
+                  apt-get install -y git build-essential g++ glslang-tools \
                     python3 python3-pip libglfw3-dev libvulkan-dev locales wget pkg-config \
                     protobuf-compiler libprotoc-dev libopencv-dev \
                     libavcodec-dev libavformat-dev libavutil-dev
                   python3 -m pip install --upgrade pip
                   python3 -m pip install cmake future==1.0.0 pytz==2022.1 numpy==1.23.0 \
                   google==3.0.0 protobuf==3.12.4
+          # see https://github.com/dorny/paths-filter/issues/212
+          - uses: actions/checkout@v4
+          - name: Trust git directory
+            run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          - uses: dorny/paths-filter@v3
+            id: changes
+            with:
+              filters: |
+                ck:
+                  - 'Libraries/ComposableKernel/**'
+          - name: Set CK build flag
+            run: |
+              # Enable CK for: scheduled runs OR CK files changed
+              if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ steps.changes.outputs.ck }}" == "true" ]; then
+                ENABLE_CK=ON
+              else
+                ENABLE_CK=OFF
+              fi
+              echo "ENABLE_CK=${ENABLE_CK}" >> $GITHUB_ENV
+              echo "ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK}"
           - name: Install ROCm Dev
             run: |
                   wget https://repo.radeon.com/amdgpu-install/${{ env.ROCM_VERSION }}/ubuntu/jammy/amdgpu-install_${{ env.AMDGPU_INSTALLER_VERSION }}_all.deb
@@ -73,22 +92,6 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
-          - uses: dorny/paths-filter@v3
-            id: changes
-            with:
-              filters: |
-                ck:
-                  - 'Libraries/ComposableKernel/**'
-          - name: Set CK build flag
-            run: |
-              # Enable CK for: scheduled runs OR CK files changed
-              if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ steps.changes.outputs.ck }}" == "true" ]; then
-                ENABLE_CK=ON
-              else
-                ENABLE_CK=OFF
-              fi
-              echo "ENABLE_CK=${ENABLE_CK}" >> $GITHUB_ENV
-              echo "ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK}"
           - name: CMake Configure and Build
             shell: bash
             run: |


### PR DESCRIPTION
## Motivation

paths-filter requires specific setup for push-triggered workflows

## Technical Details

The action needs git and the source code being a proper git repository.

- Update git to >= 2.18 before checkout action, then the action will create a proper git repo with `.git` folder
- Mark the repo as safe so subsequent paths-filter action can perform git operations

## Test Plan

Test workflow run on push https://github.com/zichguan-amd/rocm-examples/actions/runs/21686688173/job/62535519865

## Test Result

Works with push trigger

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
