### PR TITLE
Fix test file copy for Programming-Patterns examples

### DIFF
--- a/HIP-Doc/Tutorials/Programming-Patterns/bfs/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/Programming-Patterns/bfs/CMakeLists.txt
@@ -70,12 +70,18 @@ target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda
 add_executable(graphgen graphgen.cpp)
 target_compile_features(graphgen PRIVATE cxx_std_17)
 
-# Make example runnable using ctest
-add_test(NAME ${example_name} COMMAND ${example_name} ${CMAKE_CURRENT_SOURCE_DIR}/graph4096.txt)
+set(example_work_dir $<TARGET_FILE_DIR:${example_name}>)
 
-# Copy test graphs to build directory
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/graph4096.txt ${CMAKE_BINARY_DIR}/graph4096.txt COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/graph65536.txt ${CMAKE_BINARY_DIR}/graph65536.txt COPYONLY)
+# Copy test image to executable output directory
+add_custom_command(TARGET ${example_name} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/graph4096.txt ${example_work_dir}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/graph65536.txt ${example_work_dir}
+    WORKING_DIRECTORY ${example_work_dir}
+    COMMENT "Copying test graphs to ${example_work_dir}"
+)
+
+# Make example runnable using ctest
+add_test(NAME ${example_name} COMMAND ${example_name} graph4096.txt WORKING_DIRECTORY ${example_work_dir})
 
 install(TARGETS ${example_name} graphgen)
 install(FILES graph4096.txt graph65536.txt DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/HIP-Doc/Tutorials/Programming-Patterns/histogram_atomics/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/Programming-Patterns/histogram_atomics/CMakeLists.txt
@@ -52,8 +52,18 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
+
+set(example_work_dir $<TARGET_FILE_DIR:${example_name}>)
+
+# Copy test image to executable output directory
+add_custom_command(TARGET ${example_name} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test_colored.jpg ${example_work_dir}
+    WORKING_DIRECTORY ${example_work_dir}
+    COMMENT "Copying test image to ${example_work_dir}"
+)
+
 # Make example runnable using ctest
-add_test(NAME ${example_name} COMMAND ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name} WORKING_DIRECTORY ${example_work_dir})
 
 set_source_files_properties(main.hip PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
@@ -65,9 +75,6 @@ target_include_directories(${example_name} PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:${ROCM_ROOT}/include>
 )
 target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
-
-# Copy test image to build directory
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_colored.jpg ${CMAKE_BINARY_DIR}/test_colored.jpg COPYONLY)
 
 install(TARGETS ${example_name})
 install(FILES test_colored.jpg DESTINATION ${CMAKE_INSTALL_PREFIX})

--- a/HIP-Doc/Tutorials/Programming-Patterns/image_convolution/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/Programming-Patterns/image_convolution/CMakeLists.txt
@@ -52,8 +52,18 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 add_executable(${example_name} main.hip)
+
+set(example_work_dir $<TARGET_FILE_DIR:${example_name}>)
+
+# Copy test image to executable output directory
+add_custom_command(TARGET ${example_name} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/test.jpg ${example_work_dir}
+    WORKING_DIRECTORY ${example_work_dir}
+    COMMENT "Copying test image to ${example_work_dir}"
+)
+
 # Make example runnable using ctest
-add_test(NAME ${example_name} COMMAND ${example_name})
+add_test(NAME ${example_name} COMMAND ${example_name} WORKING_DIRECTORY ${example_work_dir})
 
 set_source_files_properties(main.hip PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
@@ -65,9 +75,6 @@ target_include_directories(${example_name} PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:${ROCM_ROOT}/include>
 )
 target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
-
-# Copy test image to build directory
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test.jpg ${CMAKE_BINARY_DIR}/test.jpg COPYONLY)
 
 install(TARGETS ${example_name})
 install(FILES test.jpg DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
## Motivation
Fixes ctest failure

## Technical Details

Copy test files to binary output directory

## Test Plan

CI run

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
