### PR TITLE
Skip rccl on gfx1151

### DIFF
--- a/.github/build_tools/generate_skip_tests.py
+++ b/.github/build_tools/generate_skip_tests.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate skip_tests.txt for rocm-examples CI.
+
+Output file is used by ctest --exclude-from-file in the workflow.
+Run from repo root or with --output-dir pointing at .github/build_tools.
+"""
+
+import argparse
+import os
+
+# Tests to skip per GPU target (one list per target that has skips)
+SKIP_TESTS = {
+    # rccl is not supported on gfx1151 yet
+    "gfx1151": [
+        "rccl_allgather",
+        "rccl_allreduce",
+        "rccl_broadcast",
+        "rccl_buffer_registration",
+        "rccl_device_api",
+        "rccl_gradient_allreduce",
+        "rccl_reduce",
+        "rccl_reducescatter",
+        "rccl_send_recv",
+    ],
+    # Add more targets as needed, e.g.:
+    # "gfx1100": [],
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate skip_tests.txt for rocm-examples CI."
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=os.path.join(os.path.dirname(__file__)),
+        help="Directory to write skip_tests.txt (default: script dir)",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="GPU target whose skip list to write (e.g. gfx1151)",
+    )
+    args = parser.parse_args()
+
+    lines = SKIP_TESTS.get(args.target, [])
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    path = os.path.join(args.output_dir, "skip_tests.txt")
+    with open(path, "w") as f:
+        if lines:
+            f.write("\n".join(lines))
+            f.write("\n")
+    if not lines:
+        print(f"No tests to skip for {args.target}.")
+    else:
+        print(f"Wrote {path} ({len(lines)} tests for {args.target})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -193,7 +193,21 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          ctest --test-dir build --output-on-failure 2>&1 | tee ctest_output.log
+          python3 .github/build_tools/generate_skip_tests.py --target ${{ matrix.gpu_config.gpu_target }}
+
+          SKIP_FILE="${GITHUB_WORKSPACE}/.github/build_tools/skip_tests.txt"
+          if [ -s "${SKIP_FILE}" ]; then
+            echo "## Skipped tests" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat "${SKIP_FILE}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No tests skipped." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          ctest --test-dir build --output-on-failure --exclude-from-file "${SKIP_FILE}" 2>&1 | tee ctest_output.log
 
       - name: Test summary
         if: ${{ !cancelled() }}
@@ -216,6 +230,13 @@ jobs:
 
           # Show failed tests if any
           if [ "${FAILED}" -gt 0 ]; then
+            echo "## Failed tests" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat build/Testing/Temporary/LastTestsFailed.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
             echo "<details><summary>Failed tests output</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci_therock.yml
+++ b/.github/workflows/ci_therock.yml
@@ -213,7 +213,21 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          ctest --test-dir build --output-on-failure 2>&1 | tee ctest_output.log
+          python3 .github/build_tools/generate_skip_tests.py --target ${{ matrix.gpu_config.gpu_target }}
+
+          SKIP_FILE="${GITHUB_WORKSPACE}/.github/build_tools/skip_tests.txt"
+          if [ -s "${SKIP_FILE}" ]; then
+            echo "## Skipped tests" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat "${SKIP_FILE}" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No tests skipped." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          ctest --test-dir build --output-on-failure --exclude-from-file "${SKIP_FILE}" 2>&1 | tee ctest_output.log
 
       - name: Test summary
         if: ${{ !cancelled() }}
@@ -236,6 +250,13 @@ jobs:
                     
           # Show failed tests if any
           if [ "${FAILED}" -gt 0 ]; then
+            echo "## Failed tests" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat build/Testing/Temporary/LastTestsFailed.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
             echo "<details><summary>Failed tests output</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY

--- a/Dockerfiles/sles-15.7.Dockerfile
+++ b/Dockerfiles/sles-15.7.Dockerfile
@@ -11,9 +11,9 @@ RUN zypper -qni update -y && \
         awk \
         unzip \
         xz \
-        cmake \
         gcc \
         gcc-c++ \
+        make \
         wget \
         git \
         curl \
@@ -27,6 +27,20 @@ RUN zypper -qni update -y && \
         libXinerama-devel \
         libXrandr-devel && \
     zypper clean -a
+
+# ============================================================================
+# Python virtual environment (ready for ROCm wheel or tarball installation)
+# ROCm installation is delegated to the CI workflow to support both methods
+# ============================================================================
+
+# Create virtual environment with base packages
+RUN python3.13 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install pyyaml cmake
+
+# Set up virtual environment in PATH
+ENV PATH="/opt/venv/bin:${PATH}"
+ENV VIRTUAL_ENV="/opt/venv"
 
 # Build GLFW from source (not available in SLES repos)
 WORKDIR /tmp
@@ -52,20 +66,6 @@ ENV VK_ADD_LAYER_PATH="${VULKAN_SDK}/share/vulkan/explicit_layer.d"
 ENV PKG_CONFIG_PATH="${VULKAN_SDK}/share/pkgconfig:${VULKAN_SDK}/lib/pkgconfig"
 
 ENV HIP_PLATFORM=amd
-
-# ============================================================================
-# Python virtual environment (ready for ROCm wheel or tarball installation)
-# ROCm installation is delegated to the CI workflow to support both methods
-# ============================================================================
-
-# Create virtual environment with base packages
-RUN python3.13 -m venv /opt/venv && \
-    /opt/venv/bin/pip install --upgrade pip && \
-    /opt/venv/bin/pip install pyyaml
-
-# Set up virtual environment in PATH
-ENV PATH="/opt/venv/bin:${PATH}"
-ENV VIRTUAL_ENV="/opt/venv"
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Motivation

rccl doesn't support gfx1151 yet

## Technical Details

Skip tests with `--exclude-from-file` ctest option, available since v3.29. https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-exclude-from-file

Update SLES Dockerfile to use cmake from pip so it is >= v3.29.
Add python script to generate a skip_tests.txt file containing the skip tests.

## Test Plan

CI run

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
