### PR TITLE
Remove OpenMP::omp imported target from rocwmma

### DIFF
--- a/Libraries/rocWMMA/CMakeLists.txt
+++ b/Libraries/rocWMMA/CMakeLists.txt
@@ -57,6 +57,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
         get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
         if(ROCWMMA_LINK_LIBS)
             list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+            list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
             set_target_properties(roc::rocwmma PROPERTIES
                 INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
             )
@@ -65,6 +66,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
         get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
         if(ROCWMMA_LINK_LIBS)
             list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+            list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
             set_target_properties(rocwmma PROPERTIES
                 INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
             )

--- a/Libraries/rocWMMA/hiprtc_gemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/hiprtc_gemm/CMakeLists.txt
@@ -65,6 +65,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -74,6 +75,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/perf_dgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_dgemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/perf_hgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_hgemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/perf_i8gemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_i8gemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/perf_sgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/perf_sgemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/simple_dgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_dgemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/simple_dgemv/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_dgemv/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/simple_dlrm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_dlrm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/simple_hgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_hgemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/simple_sgemm/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_sgemm/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )

--- a/Libraries/rocWMMA/simple_sgemv/CMakeLists.txt
+++ b/Libraries/rocWMMA/simple_sgemv/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TARGET roc::rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS roc::rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(roc::rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )
@@ -73,6 +74,7 @@ elseif(TARGET rocwmma)
     get_target_property(ROCWMMA_LINK_LIBS rocwmma INTERFACE_LINK_LIBRARIES)
     if(ROCWMMA_LINK_LIBS)
         list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::OpenMP_CXX)
+        list(REMOVE_ITEM ROCWMMA_LINK_LIBS OpenMP::omp)
         set_target_properties(rocwmma PROPERTIES
             INTERFACE_LINK_LIBRARIES "${ROCWMMA_LINK_LIBS}"
         )


### PR DESCRIPTION
Recently rocwmma switched to using the openmp-config in ROCm, which provides the OpenMP::omp target. I see that the OpenMP::OpenMP_CXX target was removed before so we are just adding to that logic. That being said I think removing these targets is hacky and rocwmma should instead use add_dependency in their config to resolve/lookup these targets.