### PR TITLE
Add default shell to GitHub workflows

### DIFF
--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -28,6 +28,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ubuntu:22.04
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
           - name: Install dependencies
@@ -52,13 +55,11 @@ jobs:
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
           - name: CMake Configure and Build
-            shell: bash
             run: |
               cd Applications
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
           - name: Make
-            shell: bash
             run: |
               cd Applications
               make -j

--- a/.github/workflows/build_applications_cuda.yml
+++ b/.github/workflows/build_applications_cuda.yml
@@ -27,7 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
-
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
 
@@ -50,7 +52,6 @@ jobs:
               echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
           - name: Setup ROCm Libraries monorepo
-            shell: bash
             run: |
               git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/ROCm/rocm-libraries.git
               cd rocm-libraries
@@ -59,7 +60,6 @@ jobs:
               git checkout develop
 
           - name: Build and install hipCUB
-            shell: bash
             run: |
               cd rocm-libraries/projects/hipcub; mkdir build; cd build
               HIP_PLATFORM=nvidia cmake -DCMAKE_CXX_COMPILER=nvcc ..
@@ -67,7 +67,6 @@ jobs:
               make install
 
           - name: Build and install hipRAND
-            shell: bash
             run: |
               cd rocm-libraries/projects/hiprand; mkdir build; cd build
               HIP_PLATFORM=nvidia CXX=g++ cmake -DBUILD_WITH_LIB=CUDA -DHIP_CUDA_lowest_cc=60 ..
@@ -75,7 +74,6 @@ jobs:
               make install
 
           - name: Configure and Build
-            shell: bash
             run: |
               cd Applications && mkdir build && cd build
               cmake -DGPU_RUNTIME=CUDA ..

--- a/.github/workflows/build_applications_vs.yml
+++ b/.github/workflows/build_applications_vs.yml
@@ -31,26 +31,25 @@ jobs:
           matrix:
             config: [Debug, Release]
         runs-on: windows-latest
+        defaults:
+          run:
+            shell: pwsh
         steps:
           - uses: actions/checkout@v4
           - uses: microsoft/setup-msbuild@v2
           - name: Install Python dependencies
-            shell: pwsh
             run: |
                   python3 -m pip install rich
           - name: Check GUID
-            shell: pwsh
             run: |
                   python3 Scripts/VisualStudio/check_vs_files.py
           - name: Install additional dependencies
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading GLFW 3.4"
                   Invoke-WebRequest -Uri https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.bin.WIN64.zip -OutFile glfw-3.4.bin.WIN64.zip
                   Expand-Archive -Path glfw-3.4.bin.WIN64.zip -DestinationPath C:\ -PassThru
           - name: Install HIP SDK
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
@@ -68,7 +67,6 @@ jobs:
                       Exit 1
                   }
           - name: Build ${{ matrix.config }} x64
-            shell: pwsh
             run: |
                   Write-Host "Replace toolset $((Get-ChildItem -Recurse -File | Get-Content | Select-String -Pattern 'HIP clang .\..' | Select-Object -First 1).Matches.Value) with HIP clang ${{ env.PLATFORM_TOOLSET_VERSION }}"
                   Get-ChildItem -Recurse -File | Where-Object { Select-String -Pattern 'HIP clang .\..' -Path $_ } | ForEach-Object {

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -29,6 +29,9 @@ jobs:
     find-dockerfiles:
       name: Find Dockerfiles
       runs-on: ubuntu-latest
+      defaults:
+        run:
+          shell: bash
       outputs:
         files: ${{ steps.find-files.outputs.files }}  
       steps:
@@ -51,6 +54,9 @@ jobs:
       name: Build Docker Images
       runs-on: ubuntu-latest
       needs: find-dockerfiles
+      defaults:
+        run:
+          shell: bash
       strategy:
         fail-fast: false
         matrix: 

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -28,6 +28,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ubuntu:22.04
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
           - name: Install dependencies
@@ -48,13 +51,11 @@ jobs:
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
           - name: CMake Configure and Build
-            shell: bash
             run: |
               cd HIP-Basic
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
           - name: Make
-            shell: bash
             run: |
               cd HIP-Basic
               make -j

--- a/.github/workflows/build_hip_basic_cuda.yml
+++ b/.github/workflows/build_hip_basic_cuda.yml
@@ -27,7 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
-
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
 
@@ -47,7 +49,6 @@ jobs:
               apt-get install -y hip-dev hipify-clang
 
           - name: Configure and Build
-            shell: bash
             run: |
               cd HIP-Basic && mkdir build && cd build
               cmake -DGPU_RUNTIME=CUDA ..

--- a/.github/workflows/build_hip_basic_vs.yml
+++ b/.github/workflows/build_hip_basic_vs.yml
@@ -32,19 +32,19 @@ jobs:
           matrix:
             config: [Debug, Release]
         runs-on: windows-latest
+        defaults:
+          run:
+            shell: pwsh
         steps:
           - uses: actions/checkout@v4
           - uses: microsoft/setup-msbuild@v2
           - name: Install Python dependencies
-            shell: pwsh
             run: |
                   python3 -m pip install rich
           - name: Check GUID
-            shell: pwsh
             run: |
                   python3 Scripts/VisualStudio/check_vs_files.py
           - name: Install additional dependencies
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading GLFW 3.4"
@@ -55,7 +55,6 @@ jobs:
                   Write-Host "Installing Vulkan SDK"
                   Start-Process vulkansdk-windows-X64-1.4.313.2.exe -ArgumentList '--accept-licenses','--default-answer','--confirm-command','install' -NoNewWindow -Wait
           - name: Install HIP SDK
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
@@ -73,14 +72,12 @@ jobs:
                       Exit 1
                   }
           - name: Apply patch
-            shell: pwsh
             run: |
                   Write-Host "Applying patches $(Get-ChildItem -File Scripts\VisualStudio\*.patch)"
                   git apply (Get-ChildItem -File Scripts\VisualStudio\*.patch).FullName
                   Write-Host "Patches applied. Showing diff"
                   git diff
           - name: Build ${{ matrix.config }} x64
-            shell: pwsh
             run: |
                   Write-Host "Replace toolset $((Get-ChildItem -Recurse -File | Get-Content | Select-String -Pattern 'HIP clang .\..' | Select-Object -First 1).Matches.Value) with HIP clang ${{ env.PLATFORM_TOOLSET_VERSION }}"
                   Get-ChildItem -Recurse -File | Where-Object { Select-String -Pattern 'HIP clang .\..' -Path $_ } | ForEach-Object {

--- a/.github/workflows/build_hip_documentation.yml
+++ b/.github/workflows/build_hip_documentation.yml
@@ -28,6 +28,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ubuntu:22.04
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
           - name: Install dependencies
@@ -48,7 +51,6 @@ jobs:
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
           - name: CMake Configure and Build
-            shell: bash
             # The CMAKE_POLICY_VERSION_MINIMUM environment variable can be removed once the CMake updates from ROCm 7.0 are available
             run: |
               cd HIP-Doc
@@ -56,7 +58,6 @@ jobs:
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
           - name: Make
-            shell: bash
             run: |
               cd HIP-Doc
               export HSA_XNACK=1

--- a/.github/workflows/build_hip_documentation_cuda.yml
+++ b/.github/workflows/build_hip_documentation_cuda.yml
@@ -27,7 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
-
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
 
@@ -47,7 +49,6 @@ jobs:
               apt-get install -y hip-dev hipify-clang hipfft-dev
 
           - name: Configure and Build
-            shell: bash
             # The CMAKE_POLICY_VERSION_MINIMUM environment variable can be removed once the CMake updates from ROCm 7.0 are available
             run: |
               cd HIP-Doc && mkdir build && cd build

--- a/.github/workflows/build_hip_documentation_vs.yml
+++ b/.github/workflows/build_hip_documentation_vs.yml
@@ -32,19 +32,19 @@ jobs:
           matrix:
             config: [Debug, Release]
         runs-on: windows-latest
+        defaults:
+          run:
+            shell: pwsh
         steps:
           - uses: actions/checkout@v4
           - uses: microsoft/setup-msbuild@v2
           - name: Install Python dependencies
-            shell: pwsh
             run: |
                   python3 -m pip install rich
           - name: Check GUID
-            shell: pwsh
             run: |
                   python3 Scripts/VisualStudio/check_vs_files.py
           - name: Install additional dependencies
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading GLFW 3.4"
@@ -55,7 +55,6 @@ jobs:
                   Write-Host "Installing Vulkan SDK"
                   Start-Process vulkansdk-windows-X64-1.4.313.2.exe -ArgumentList '--accept-licenses','--default-answer','--confirm-command','install' -NoNewWindow -Wait
           - name: Install HIP SDK
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
@@ -73,7 +72,6 @@ jobs:
                       Exit 1
                   }
           - name: Build ${{ matrix.config }} x64
-            shell: pwsh
             run: |
                   Write-Host "Replace toolset $((Get-ChildItem -Recurse -File | Get-Content | Select-String -Pattern 'HIP clang .\..' | Select-Object -First 1).Matches.Value) with HIP clang ${{ env.PLATFORM_TOOLSET_VERSION }}"
                   Get-ChildItem -Recurse -File | Where-Object { Select-String -Pattern 'HIP clang .\..' -Path $_ } | ForEach-Object {

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -31,6 +31,9 @@ jobs:
         runs-on: self-hosted
         container:
             image: ubuntu:22.04
+        defaults:
+            run:
+                shell: bash
         steps:
           - name: Install dependencies
             run: |
@@ -97,13 +100,11 @@ jobs:
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
           - name: CMake Configure and Build
-            shell: bash
             run: |
               cd Libraries
               cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} -DROCM_EXAMPLES_ENABLE_OPENMP=ON -S . -B build
               cmake --build build --parallel $(nproc)
           - name: Make
-            shell: bash
             run: |
               sed -i '/rocCV/d' Libraries/Makefile
               cd Libraries

--- a/.github/workflows/build_libraries_cuda.yml
+++ b/.github/workflows/build_libraries_cuda.yml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image:  nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
-
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -46,7 +48,6 @@ jobs:
           apt-get install -y hip-dev rocm-cmake
 
       - name: Setup ROCm Libraries monorepo
-        shell: bash
         run: |
           git clone --no-checkout --depth=1 --filter=tree:0 https://github.com/ROCm/rocm-libraries.git
           cd rocm-libraries
@@ -55,7 +56,6 @@ jobs:
           git checkout develop
 
       - name: Build and install hipCUB
-        shell: bash
         run: |
           cd rocm-libraries/projects/hipcub; mkdir build; cd build
           HIP_PLATFORM=nvidia cmake -DCMAKE_CXX_COMPILER=nvcc ..
@@ -63,13 +63,11 @@ jobs:
           make install
 
       - name: Build hipCUB example
-        shell: bash
         run: |
           cd Libraries/hipCUB
           make GPU_RUNTIME=CUDA -j
 
       - name: Build and install hipFFT
-        shell: bash
         run: |
           cd rocm-libraries/projects/hipfft; mkdir build; cd build
           HIP_PLATFORM=nvidia ROCM_PATH=/opt/rocm cmake -LH -DBUILD_WITH_LIB=cuda ..
@@ -77,29 +75,24 @@ jobs:
           make install
 
       - name: Build hipFFT example
-        shell: bash
         run: |
           cd Libraries/hipFFT
           make GPU_RUNTIME=CUDA -j
 
       - name: Install hipSPARSELt
-        shell: bash
         run: |
           apt-get install -y hipsparselt-dev
 
       - name: Build hipSPARSELt examples
-        shell: bash
         run: |
           cd Libraries/hipSPARSELt
           make GPU_RUNTIME=CUDA -j
 
       - name: Install rocRAND
-        shell: bash
         run: |
           apt-get install -y rocrand-dev
 
       - name: Build rocRAND example
-        shell: bash
         run: |
           cd Libraries/rocRAND
           make GPU_RUNTIME=CUDA -j

--- a/.github/workflows/build_libraries_vs.yml
+++ b/.github/workflows/build_libraries_vs.yml
@@ -31,19 +31,19 @@ jobs:
             config: [Debug, Release]
             vsversion: [2017, 2019, 2022]
         runs-on: windows-latest
+        defaults:
+          run:
+            shell: pwsh
         steps:
           - uses: actions/checkout@v4
           - uses: microsoft/setup-msbuild@v2
           - name: Install Python dependencies
-            shell: pwsh
             run: |
                   python3 -m pip install rich
           - name: Check GUID
-            shell: pwsh
             run: |
                   python3 Scripts/VisualStudio/check_vs_files.py
           - name: Install HIP SDK
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
@@ -61,14 +61,12 @@ jobs:
                       Exit 1
                   }
           - name: Apply patch
-            shell: pwsh
             run: |
                   Write-Host "Applying patches $(Get-ChildItem -File Scripts\VisualStudio\0002-Revert-Rename-hipblas-dll-for-HIP-SDK-7.1.patch)"
                   git apply (Get-ChildItem -File Scripts\VisualStudio\0002-Revert-Rename-hipblas-dll-for-HIP-SDK-7.1.patch).FullName
                   Write-Host "Patches applied. Showing diff"
                   git diff
           - name: Build ${{ matrix.config }} x64 ${{ matrix.vsversion }}
-            shell: pwsh
             run: |
                   Write-Host "Replace toolset $((Get-ChildItem -Recurse -File | Get-Content | Select-String -Pattern 'HIP clang .\..' | Select-Object -First 1).Matches.Value) with HIP clang ${{ env.PLATFORM_TOOLSET_VERSION }}"
                   Get-ChildItem -Recurse -File | Where-Object { Select-String -Pattern 'HIP clang .\..' -Path $_ } | ForEach-Object {

--- a/.github/workflows/build_portable_sln.yml
+++ b/.github/workflows/build_portable_sln.yml
@@ -43,19 +43,19 @@ jobs:
           matrix:
             config: [Debug, Release]
         runs-on: windows-2025
+        defaults:
+          run:
+            shell: pwsh
         steps:
           - uses: actions/checkout@v4
           - uses: microsoft/setup-msbuild@v2
           - name: Install Python dependencies
-            shell: pwsh
             run: |
                   python3 -m pip install rich
           - name: Check GUID
-            shell: pwsh
             run: |
                   python3 Scripts/VisualStudio/check_vs_files.py
           - name: Install additional dependencies
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading GLFW 3.4"
@@ -66,7 +66,6 @@ jobs:
                   Write-Host "Installing Vulkan SDK"
                   Start-Process vulkansdk-windows-X64-1.4.313.2.exe -ArgumentList '--accept-licenses','--default-answer','--confirm-command','install' -NoNewWindow -Wait
           - name: Install CUDA Toolkit
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://developer.download.nvidia.com/compute/cuda/${{ env.CUDA_VERSION }}/local_installers/cuda_${{ env.CUDA_VERSION }}_${{ env.CUDA_INSTALLER_VERSION }}_windows.exe"
@@ -82,7 +81,6 @@ jobs:
                       Exit 1
                   }
           - name: Install HIP SDK
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
@@ -100,14 +98,12 @@ jobs:
                       Exit 1
                   }
           - name: Apply patch
-            shell: pwsh
             run: |
                   Write-Host "Applying patches $(Get-ChildItem -File Scripts\VisualStudio\*.patch)"
                   git apply (Get-ChildItem -File Scripts\VisualStudio\*.patch).FullName
                   Write-Host "Patches applied. Showing diff"
                   git diff
           - name: Build HIP nvcc ${{ matrix.config }} x64
-            shell: pwsh
             run: |
                   Write-Host "Replace toolset $((Get-ChildItem -Recurse -File | Get-Content | Select-String -Pattern 'HIP clang .\..' | Select-Object -First 1).Matches.Value) with HIP nvcc ${{ env.PLATFORM_TOOLSET_VERSION }}"
                   Get-ChildItem -Recurse -File | Where-Object { Select-String -Pattern 'HIP clang .\..' -Path $_ } | ForEach-Object {

--- a/.github/workflows/build_programming_guide.yml
+++ b/.github/workflows/build_programming_guide.yml
@@ -28,6 +28,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ubuntu:22.04
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
           - name: Install dependencies
@@ -47,13 +50,11 @@ jobs:
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
           - name: CMake Configure and Build
-            shell: bash
             run: |
               cd Programming-Guide
               cmake -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
           - name: Make
-            shell: bash
             run: |
               cd Programming-Guide
               make -j

--- a/.github/workflows/build_programming_guide_cuda.yml
+++ b/.github/workflows/build_programming_guide_cuda.yml
@@ -27,7 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
-
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
 
@@ -46,7 +48,6 @@ jobs:
               apt-get install -y hip-dev hipify-clang
 
           - name: Configure and Build
-            shell: bash
             run: |
               cd Programming-Guide && mkdir build && cd build
               cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia ..

--- a/.github/workflows/build_programming_guide_vs.yml
+++ b/.github/workflows/build_programming_guide_vs.yml
@@ -32,19 +32,19 @@ jobs:
           matrix:
             config: [Debug, Release]
         runs-on: windows-latest
+        defaults:
+          run:
+            shell: pwsh
         steps:
           - uses: actions/checkout@v4
           - uses: microsoft/setup-msbuild@v2
           - name: Install Python dependencies
-            shell: pwsh
             run: |
                   python3 -m pip install rich
           - name: Check GUID
-            shell: pwsh
             run: |
                   python3 Scripts/VisualStudio/check_vs_files.py
           - name: Install HIP SDK
-            shell: pwsh
             run: |
                   $ProgressPreference = 'SilentlyContinue'
                   Write-Host "Downloading installer https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-${{ env.HIPSDK_INSTALLER_VERSION }}-Win10-Win11-For-HIP.exe"
@@ -62,7 +62,6 @@ jobs:
                       Exit 1
                   }
           - name: Build ${{ matrix.config }} x64
-            shell: pwsh
             run: |
                   Write-Host "Replace toolset $((Get-ChildItem -Recurse -File | Get-Content | Select-String -Pattern 'HIP clang .\..' | Select-Object -First 1).Matches.Value) with HIP clang ${{ env.PLATFORM_TOOLSET_VERSION }}"
                   Get-ChildItem -Recurse -File | Where-Object { Select-String -Pattern 'HIP clang .\..' -Path $_ } | ForEach-Object {

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -27,6 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ubuntu:22.04
+        defaults:
+            run:
+                shell: bash
         steps:
           - uses: actions/checkout@v4
           - name: Install dependencies
@@ -50,13 +53,11 @@ jobs:
           - name: Install rocprof-compute dependencies
             run: python3 -m pip install -r /opt/rocm/libexec/rocprofiler-compute/requirements.txt
           - name: CMake Configure and Build
-            shell: bash
             run: |
               cd Tools
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
           - name: Make
-            shell: bash
             run: |
               cd Tools
               make -j

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -45,6 +45,9 @@ jobs:
   setup:
     name: "Setup CI"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     outputs:
       gpu_configs: ${{ steps.config.outputs.gpu_configs }}
       install_methods: ${{ steps.config.outputs.install_methods }}
@@ -70,6 +73,9 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --security-opt seccomp=unconfined
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +87,6 @@ jobs:
 
       - name: Install TheRock Python wheel
         if: ${{ matrix.install_method == 'wheel' }}
-        shell: bash
         run: |
           pip install --no-cache-dir --index-url https://rocm.nightlies.amd.com/v2/${{ matrix.gpu_config.therock_family }}/ \
             "rocm[libraries,devel]"
@@ -89,7 +94,6 @@ jobs:
       - name: Wheel sanity check
         if: ${{ matrix.install_method == 'wheel' }}
         id: sanity-check
-        shell: bash
         run: |
           ROCM_VERSION=$(rocm-sdk version)
           echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
@@ -100,7 +104,6 @@ jobs:
 
       - name: Setup environment variables (wheel)
         if: ${{ matrix.install_method == 'wheel' }}
-        shell: bash
         run: |
           ROCM_PATH=$(rocm-sdk path --root)
           echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
@@ -113,7 +116,6 @@ jobs:
       - name: Install TheRock tarball
         if: ${{ matrix.install_method == 'tarball' }}
         id: install-tarball
-        shell: bash
         run: |
           LATEST_TARBALL=$(curl -s "https://rocm.nightlies.amd.com/tarball/" \
             | grep -oE "therock-dist-linux-${{ matrix.gpu_config.therock_family }}-[0-9]+\.[0-9]+\.\w+\.tar\.gz" \
@@ -131,7 +133,6 @@ jobs:
 
       - name: Setup environment variables (tarball)
         if: ${{ matrix.install_method == 'tarball' }}
-        shell: bash
         run: |
           ROCM_PATH=/therock-tarball/install
           echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
@@ -142,13 +143,11 @@ jobs:
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
 
       - name: CMake configure
-        shell: bash
         run: |
           cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DROCM_ROOT="$ROCM_PATH" -DCMAKE_BUILD_RPATH="$ROCM_PATH/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -Wno-dev 2> >(tee cmake_error.log >&2)
 
       - name: CMake configure error summary
         if: ${{ !cancelled() }}
-        shell: bash
         run: |
           if [ ! -f cmake_error.log ]; then
             exit 0
@@ -181,7 +180,6 @@ jobs:
           fi
 
       - name: CMake build
-        shell: bash
         run: |
           cmake --build build -j
 
@@ -193,13 +191,11 @@ jobs:
           path: build/
 
       - name: Run tests
-        shell: bash
         run: |
           ctest --test-dir build --output-on-failure 2>&1 | tee ctest_output.log
 
       - name: Test summary
         if: ${{ !cancelled() }}
-        shell: bash
         run: |
           if [ ! -f ctest_output.log ]; then
             exit 0

--- a/.github/workflows/ci_therock.yml
+++ b/.github/workflows/ci_therock.yml
@@ -66,6 +66,9 @@ jobs:
   setup:
     name: "Setup CI"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     outputs:
       gpu_configs: ${{ steps.config.outputs.gpu_configs }}
       install_methods: ${{ steps.config.outputs.install_methods }}
@@ -91,6 +94,9 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --security-opt seccomp=unconfined
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +108,6 @@ jobs:
 
       - name: Install TheRock Python wheel
         if: ${{ matrix.install_method == 'wheel' }}
-        shell: bash
         run: |
           pip install --no-cache-dir --index-url https://rocm.nightlies.amd.com/v2/${{ matrix.gpu_config.therock_family }}/ \
             "rocm[libraries,devel]"
@@ -110,7 +115,6 @@ jobs:
       - name: Wheel sanity check
         if: ${{ matrix.install_method == 'wheel' }}
         id: sanity-check
-        shell: bash
         run: |
           ROCM_VERSION=$(rocm-sdk version)
           echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
@@ -120,7 +124,6 @@ jobs:
 
       - name: Setup environment variables (wheel)
         if: ${{ matrix.install_method == 'wheel' }}
-        shell: bash
         run: |
           ROCM_PATH=$(rocm-sdk path --root)
           echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
@@ -133,7 +136,6 @@ jobs:
       - name: Install TheRock tarball
         if: ${{ matrix.install_method == 'tarball' }}
         id: install-tarball
-        shell: bash
         run: |
           LATEST_TARBALL=$(curl -s https://rocm.nightlies.amd.com/tarball/ \
             | grep -oE "therock-dist-linux-${{ matrix.gpu_config.therock_family }}-[0-9]+\.[0-9]+\.\w+\.tar\.gz" \
@@ -151,7 +153,6 @@ jobs:
 
       - name: Setup environment variables (tarball)
         if: ${{ matrix.install_method == 'tarball' }}
-        shell: bash
         run: |
           ROCM_PATH=/therock-tarball/install
           echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
@@ -162,13 +163,11 @@ jobs:
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
 
       - name: CMake configure
-        shell: bash
         run: |
           cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DROCM_ROOT="${ROCM_PATH}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -Wno-dev 2> >(tee cmake_error.log >&2)
           
       - name: CMake configure error summary
         if: ${{ !cancelled() }}
-        shell: bash
         run: |
           if [ ! -f cmake_error.log ]; then
             exit 0
@@ -201,7 +200,6 @@ jobs:
           fi
 
       - name: CMake build
-        shell: bash
         run: |
           cmake --build build -j
 
@@ -213,13 +211,11 @@ jobs:
           path: build/
 
       - name: Run tests
-        shell: bash
         run: |
           ctest --test-dir build --output-on-failure 2>&1 | tee ctest_output.log
 
       - name: Test summary
         if: ${{ !cancelled() }}
-        shell: bash
         run: |
           if [ ! -f ctest_output.log ]; then
             exit 0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,6 +28,9 @@ jobs:
   cmake-formatting:
     name: CMake File Formatting
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -47,6 +50,9 @@ jobs:
   make-formatting:
     name: Makefile Formatting
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Check indentation
@@ -56,6 +62,9 @@ jobs:
   source-formatting:
     name: Source Code Formatting
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   Promotion:
     runs-on: self-hosted
+    defaults:
+      run:
+        shell: bash
     env:  
       staging_branch: amd-staging
       mainline_branch: amd-mainline


### PR DESCRIPTION
## Motivation

Set default shell in workflows to set expected shell script syntax. Avoid using bash syntax in sh shell like the scheduled run https://github.com/ROCm/rocm-examples/actions/runs/22124896638/job/63952689431.

## Technical Details

Set bash as default shell for Linux and pwsh for Windows

## Test Plan

CI run

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
