### PR TITLE
rocProfiler-SDK: Obtain registered host memory with `hipHostGetDevice…

### DIFF
--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/main.cpp
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/main.cpp
@@ -331,7 +331,11 @@ void run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         itr = init_v;
     }
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
+    auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
+    HIP_CHECK(
+        hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+
+    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
 
     HIP_CHECK(hipStreamSynchronize(stream));
 

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/main.cpp
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/main.cpp
@@ -322,7 +322,11 @@ void run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         itr = init_v;
     }
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
+    auto page_data_dev_ptr = static_cast<data_type*>(nullptr);
+    HIP_CHECK(
+        hipHostGetDevicePointer(reinterpret_cast<void**>(&page_data_dev_ptr), page_data.data(), 0));
+
+    test_page_migrate<<<1, 1024, 0, stream>>>(page_data_dev_ptr, incr_v);
 
     HIP_CHECK(hipStreamSynchronize(stream));
 


### PR DESCRIPTION
…Pointer` (#418)

(cherry picked from commit 48d3cda48fb137d39177e866b728bbfc98e94211)


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
