### PR TITLE
Switch default backend target for rocAL samples

### DIFF
--- a/Libraries/rocAL/basic/CMakeLists.txt
+++ b/Libraries/rocAL/basic/CMakeLists.txt
@@ -56,12 +56,25 @@ find_library(ROCAL_LIBRARY
 
 find_package(OpenCV REQUIRED)
 
+find_path(TurboJPEG_INCLUDE_DIR turbojpeg.h)
+find_library(TurboJPEG_LIBRARY NAMES turbojpeg)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TurboJPEG
+    REQUIRED_VARS TurboJPEG_INCLUDE_DIR TurboJPEG_LIBRARY
+)
+
+if(TurboJPEG_FOUND)
+    set(TurboJPEG_LIBRARIES ${TurboJPEG_LIBRARY})
+    set(TurboJPEG_INCLUDE_DIRS ${TurboJPEG_INCLUDE_DIR})
+endif()
+
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to rocAL library
-target_link_libraries(${example_name} PRIVATE ${ROCAL_LIBRARY} ${OpenCV_LIBS})
+target_link_libraries(${example_name} PRIVATE ${ROCAL_LIBRARY} ${TurboJPEG_LIBRARY} ${OpenCV_LIBS})
 
 # Include directories
 target_include_directories(

--- a/Libraries/rocAL/basic/Makefile
+++ b/Libraries/rocAL/basic/Makefile
@@ -38,7 +38,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(HIP_INCLUDE_DIR) -isystem $(ROCAL_INCLUDE_DIR) -isystem $(OPENCV_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocal -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui
+ILDLIBS   := -lrocal -lturbojpeg -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocAL/basic/main.cpp
+++ b/Libraries/rocAL/basic/main.cpp
@@ -63,7 +63,7 @@ bool setup_augmentation_pipeline(RocalContext       handle,
         = (use_rgb != 0) ? RocalImageColor::ROCAL_COLOR_RGB24 : RocalImageColor::ROCAL_COLOR_U8;
 
     // Set the rocAL decoder type (OpenCV only for simplicity)
-    RocalDecoderType rocal_decoder_type = RocalDecoderType::ROCAL_DECODER_OPENCV;
+    RocalDecoderType rocal_decoder_type = RocalDecoderType::ROCAL_DECODER_TJPEG;
 
     std::cout << "Loading images from: " << input_path << std::endl;
 

--- a/Libraries/rocAL/dataloader/CMakeLists.txt
+++ b/Libraries/rocAL/dataloader/CMakeLists.txt
@@ -56,12 +56,25 @@ find_library(ROCAL_LIBRARY
 
 find_package(OpenCV REQUIRED)
 
+find_path(TurboJPEG_INCLUDE_DIR turbojpeg.h)
+find_library(TurboJPEG_LIBRARY NAMES turbojpeg)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TurboJPEG
+    REQUIRED_VARS TurboJPEG_INCLUDE_DIR TurboJPEG_LIBRARY
+)
+
+if(TurboJPEG_FOUND)
+    set(TurboJPEG_LIBRARIES ${TurboJPEG_LIBRARY})
+    set(TurboJPEG_INCLUDE_DIRS ${TurboJPEG_INCLUDE_DIR})
+endif()
+
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to rocAL library
-target_link_libraries(${example_name} PRIVATE ${ROCAL_LIBRARY} ${OpenCV_LIBS})
+target_link_libraries(${example_name} PRIVATE ${ROCAL_LIBRARY} ${TurboJPEG_LIBRARY} ${OpenCV_LIBS})
 
 # Include directories
 target_include_directories(

--- a/Libraries/rocAL/dataloader/Makefile
+++ b/Libraries/rocAL/dataloader/Makefile
@@ -38,7 +38,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(HIP_INCLUDE_DIR) -isystem $(ROCAL_INCLUDE_DIR) -isystem $(OPENCV_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocal -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui -lpthread
+ILDLIBS   := -lrocal -lturbojpeg -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui -lpthread
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocAL/dataloader/main.cpp
+++ b/Libraries/rocAL/dataloader/main.cpp
@@ -79,7 +79,7 @@ int thread_func(const char*     path,
 
     color_format              = RocalImageColor::ROCAL_COLOR_RGB24;
     int              gpu_id   = (gpu_mode < 0) ? 0 : gpu_mode;
-    RocalDecoderType dec_type = RocalDecoderType::ROCAL_DECODER_OPENCV;
+    RocalDecoderType dec_type = RocalDecoderType::ROCAL_DECODER_TJPEG;
 
     lck.lock();
     // looks like OpenVX has some issue loading kernels from multiple threads at the same time

--- a/Libraries/rocAL/image_augmentation/CMakeLists.txt
+++ b/Libraries/rocAL/image_augmentation/CMakeLists.txt
@@ -56,12 +56,25 @@ find_library(ROCAL_LIBRARY
 
 find_package(OpenCV REQUIRED)
 
+find_path(TurboJPEG_INCLUDE_DIR turbojpeg.h)
+find_library(TurboJPEG_LIBRARY NAMES turbojpeg)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TurboJPEG
+    REQUIRED_VARS TurboJPEG_INCLUDE_DIR TurboJPEG_LIBRARY
+)
+
+if(TurboJPEG_FOUND)
+    set(TurboJPEG_LIBRARIES ${TurboJPEG_LIBRARY})
+    set(TurboJPEG_INCLUDE_DIRS ${TurboJPEG_INCLUDE_DIR})
+endif()
+
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
 add_test(NAME ${example_name} COMMAND ${example_name})
 
 # Link to rocAL library
-target_link_libraries(${example_name} PRIVATE ${ROCAL_LIBRARY} ${OpenCV_LIBS})
+target_link_libraries(${example_name} PRIVATE ${ROCAL_LIBRARY} ${TurboJPEG_LIBRARY} ${OpenCV_LIBS})
 
 # Include directories
 target_include_directories(

--- a/Libraries/rocAL/image_augmentation/Makefile
+++ b/Libraries/rocAL/image_augmentation/Makefile
@@ -38,7 +38,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(HIP_INCLUDE_DIR) -isystem $(ROCAL_INCLUDE_DIR) -isystem $(OPENCV_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
-ILDLIBS   := -lrocal -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui
+ILDLIBS   := -lrocal -lturbojpeg -lopencv_core -lopencv_imgproc -lopencv_imgcodecs -lopencv_highgui
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocAL/image_augmentation/main.cpp
+++ b/Libraries/rocAL/image_augmentation/main.cpp
@@ -109,7 +109,7 @@ bool setup_augmentation_pipeline(RocalContext       handle,
                                            ROCAL_USE_USER_GIVEN_SIZE_RESTRICTED,
                                            output_width,
                                            output_height,
-                                           RocalDecoderType::ROCAL_DECODER_OPENCV);
+                                           RocalDecoderType::ROCAL_DECODER_TJPEG);
     }
 
     if(rocalGetStatus(handle) != ROCAL_OK)


### PR DESCRIPTION
## Motivation

The rocAL samples used the OpenCV backend as targets - this has been requested to be switched to TurboJPEG. This change does not mean that OpenCV will be removed from the samples (as it's used for verification).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] New examples contain proper CMake and Make files.
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [x] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
