### PR TITLE
Sync rocDecode with upstream for TheRock support

### DIFF
--- a/.github/build_tools/generate_skip_tests.py
+++ b/.github/build_tools/generate_skip_tests.py
@@ -10,8 +10,8 @@ import os
 
 # Tests to skip per GPU target (one list per target that has skips)
 SKIP_TESTS = {
-    # rccl is not supported on gfx1151 yet
     "gfx1151": [
+        # rccl is not supported on gfx1151 yet
         "rccl_allgather",
         "rccl_allreduce",
         "rccl_broadcast",
@@ -21,6 +21,16 @@ SKIP_TESTS = {
         "rccl_reduce",
         "rccl_reducescatter",
         "rccl_send_recv",
+        # rocdecode FFmpeg examples are failing only on gfx1151, rocDecode team is investigating
+        "rocdecode_rocdec_decode",
+        "rocdecode_video_decode-HEVC",
+        "rocdecode_video_decode-AVC",
+        "rocdecode_video_decode-AV1",
+        "rocdecode_video_decode-VP9",
+        "rocdecode_video_decode_mem",
+        "rocdecode_video_decode_perf",
+        "rocdecode_video_decode_rgb",
+        "rocdecode_video_decode_rgb-resize",
     ],
     # Add more targets as needed, e.g.:
     # "gfx1100": [],

--- a/Libraries/rocDecode/CMakeLists.txt
+++ b/Libraries/rocDecode/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
 find_package(rocdecode QUIET)
 if(NOT rocdecode_FOUND)
-    message(STATUS "rocDecode could not be found, not building rocDecode examples")
+    message(WARNING "rocDecode could not be found, not building rocDecode examples")
     return()
 endif()
 

--- a/Libraries/rocDecode/rocdec_decode/CMakeLists.txt
+++ b/Libraries/rocDecode/rocdec_decode/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,8 @@ set(example_name rocdecode_rocdec_decode)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+include("../../../Common/FindFilesystem.cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,25 +50,25 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Try to find the host library directly (handles both naming conventions)
-find_library(ROCDECODE_HOST_LIB
-    NAMES rocdecode-host rocdecodehost
-    PATHS ${ROCM_ROOT}/lib
-    NO_DEFAULT_PATH
-)
+find_package(rocdecode-host 1.0.0 QUIET)
+find_package(FFmpeg QUIET)
 
 add_executable(${example_name} main.cpp)
 
-target_link_libraries(${example_name} PRIVATE rocdecode::rocdecode)
+target_link_libraries(${example_name} PRIVATE hip::host rocdecode::rocdecode ${CXX_FS_LIBRARY})
 
-# Link host library if found
-if(ROCDECODE_HOST_LIB)
-    target_link_libraries(${example_name} PRIVATE ${ROCDECODE_HOST_LIB})
-    target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=1)
-else()
-    target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=0)
+# Link FFmpeg and host library if found
+if(FFMPEG_FOUND)
+    target_include_directories(${example_name} PRIVATE "${FFMPEG_INCLUDE_DIR}")
+    target_link_libraries(${example_name} PRIVATE ${FFMPEG_LIBRARIES})
+endif()
+
+if(rocdecode-host_FOUND)
+    # rocdecode-host
+    target_include_directories(${example_name} PRIVATE "${rocdecode-host_INCLUDE_DIR}")
+    target_link_libraries(${example_name} PRIVATE rocdecode::rocdecode-host)
 endif()
 
 target_include_directories(
@@ -75,5 +77,12 @@ target_include_directories(
 )
 
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+set(ROCDECODE_TEST_FRAMES_DIR "${ROCM_ROOT}/share/rocdecode/frames")
+if(EXISTS "${ROCDECODE_TEST_FRAMES_DIR}")
+    add_test(NAME ${example_name} COMMAND ${example_name} -i "${ROCDECODE_TEST_FRAMES_DIR}")
+else()
+    message(WARNING "rocDecode test frames directory ${ROCDECODE_TEST_FRAMES_DIR} not found, skipping ${example_name} test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/rocdec_decode/Makefile
+++ b/Libraries/rocDecode/rocdec_decode/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
@@ -57,6 +57,13 @@ ifeq ($(GPU_RUNTIME), HIP)
 		CPPFLAGS += -DENABLE_HOST_DECODE=1
 	else
 		CPPFLAGS += -DENABLE_HOST_DECODE=0
+	endif
+
+	# Optional FFmpeg
+	FFMPEG_FOUND := $(shell pkg-config --exists libavcodec libavformat libavutil 2>/dev/null && echo 1)
+	ifeq ($(FFMPEG_FOUND),1)
+		ICPPFLAGS += $(shell pkg-config --cflags libavcodec libavformat libavutil)
+		ILDLIBS   += $(shell pkg-config --libs libavcodec libavformat libavutil)
 	endif
 
 	COMPILER := $(HIPCXX)

--- a/Libraries/rocDecode/rocdec_decode/main.cpp
+++ b/Libraries/rocDecode/rocdec_decode/main.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28,12 +28,22 @@ THE SOFTWARE.
 #include <fstream>
 #include <vector>
 #include <algorithm>
-#include <filesystem>
+
+#if __cplusplus >= 201703L && __has_include(<filesystem>)
+    #include <filesystem>
+    namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#else
+    static_assert(false, "filesystem not available");
+#endif
+
 #include <rocdecode/rocdecode.h>
-#include <rocdecode/rocdecode_host.h>
-
-namespace fs = std::filesystem;
-
+#include <rocdecode/rocparser.h>
+#if ENABLE_HOST_DECODE
+    #include <rocdecode/rocdecode_host.h>
+#endif
 
 __attribute__((visibility("hidden"))) inline bool is_error(rocDecStatus status)
 {
@@ -61,7 +71,7 @@ __attribute__((visibility("hidden"))) inline void report_error(
                 << file_name << ":" << line)
      << ... << std::forward<Args>(args))
         << std::endl;
-    std::abort();
+    std::exit(EXIT_FAILURE);
 }
 
 //hardcoding for this sample
@@ -402,11 +412,12 @@ void create_decoder(decoder_info& dec_info)
     // this will get changed in reconfigure when the sequence header is parsed from the stream to detect the actual video parameters
     create_info.chroma_format = rocDecVideoChromaFormat_420;
     create_info.output_format = rocDecVideoSurfaceFormat_NV12;
-    create_info.bit_depth_minus_8 = 2;
+    create_info.bit_depth_minus_8 = 0;
     create_info.num_output_surfaces = 1;
     CHECK(rocDecCreateDecoder(&dec_info.decoder, &create_info));
 }
 
+#if ENABLE_HOST_DECODE
 int ROCDECAPI handle_video_sequence_host(void* user_data, RocdecVideoFormatHost* format_host)
 {
     decoder_info *p_dec_info = static_cast<decoder_info *>(user_data);
@@ -499,6 +510,7 @@ void create_decoder_host(decoder_info& dec_info)
     CHECK(rocDecCreateDecoderHost(&dec_info.decoder, &create_info));
     dec_info.backend = DECODER_BACKEND_HOST;
 }
+#endif
 
 int ROCDECAPI handle_video_sequence(void* user_data, RocdecVideoFormat* format)
 {
@@ -614,6 +626,7 @@ void decode_frames(decoder_info& dec_info, const std::vector<std::vector<uint8_t
             CHECK(rocDecParseVideoData(dec_info.parser, &packet));
         }
     }
+#if ENABLE_HOST_DECODE
     else if (dec_info.backend == DECODER_BACKEND_HOST)
     {
         for (int i=0; i < static_cast<int>(frames.size()); ++i)
@@ -628,18 +641,24 @@ void decode_frames(decoder_info& dec_info, const std::vector<std::vector<uint8_t
             CHECK(rocDecDecodeFrameHost(dec_info.decoder, &pic_params));
         }
     }
+#endif
 }
 
 void destroy_decoder(decoder_info& dec_info)
 {
+    if (dec_info.decoder == nullptr)
+        return;
     if (dec_info.backend == DECODER_BACKEND_DEVICE)
     {
         CHECK(rocDecDestroyDecoder(dec_info.decoder));
     }
+#if ENABLE_HOST_DECODE
     else if (dec_info.backend == DECODER_BACKEND_HOST)
     {
         CHECK(rocDecDestroyDecoderHost(dec_info.decoder));
     }
+#endif
+    dec_info.decoder = nullptr;
 }
 
 void destroy_parser(decoder_info& dec_info)
@@ -728,14 +747,14 @@ int main(int argc, char** argv)
     }
 
     bool b_sort_filenames = false;
-    if (std::filesystem::is_directory(input_file_path))
+    if (fs::is_directory(input_file_path))
     {
-        for (const auto& entry : std::filesystem::directory_iterator(input_file_path))
+        for (const auto& entry : fs::directory_iterator(input_file_path))
         {
             if (entry.is_directory())
             {
                 std::vector<std::string> file_names_sub_folder;
-                for (const auto& sub_entry : std::filesystem::directory_iterator(entry))
+                for (const auto& sub_entry : fs::directory_iterator(entry))
                 {
                     file_names_sub_folder.push_back(sub_entry.path());
                 }
@@ -775,10 +794,12 @@ int main(int argc, char** argv)
         create_parser(dec_info);
         create_decoder(dec_info);
     }
+#if ENABLE_HOST_DECODE
     else
     {
         create_decoder_host(dec_info);
     }
+#endif
     dec_info.dump_decoded_frames = dump_output_frames;
     auto input_frames = read_frames(input_file_names);
     auto start = std::chrono::high_resolution_clock::now();

--- a/Libraries/rocDecode/video_decode/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name rocdecode_video_decode)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,74 +49,32 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Try to find the host library directly (handles both naming conventions)
-find_library(ROCDECODE_HOST_LIB
-    NAMES rocdecode-host rocdecodehost
-    PATHS ${ROCM_ROOT}/lib
-    NO_DEFAULT_PATH
-)
-
+find_package(rocdecode-host 1.0.0 QUIET)
+find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
+set(SOURCES
+    main.cpp
+    "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp"
 )
 
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
+if(rocdecode-host_FOUND)
+    list(APPEND SOURCES "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp")
 endif()
 
-add_executable(${example_name}
-    main.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
-)
+add_executable(${example_name} ${SOURCES})
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
     rocprofiler-register::rocprofiler-register
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
     Threads::Threads
+    ${FFMPEG_LIBRARIES}
 )
-
-# Link host library if found
-if(ROCDECODE_HOST_LIB)
-    target_link_libraries(${example_name} PRIVATE ${ROCDECODE_HOST_LIB})
-    target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=1)
-else()
-    target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=0)
-endif()
 
 target_include_directories(
     ${example_name}
@@ -125,24 +84,56 @@ target_include_directories(
     ".."
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
+# Add rocdecode host utils if host library found
+if(rocdecode-host_FOUND)
+    target_include_directories(${example_name} PRIVATE "${rocdecode-host_INCLUDE_DIR}" "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode")
+    target_link_libraries(${example_name} PRIVATE rocdecode::rocdecode-host)
+    target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=1)
+else()
+    target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=0)
+endif()
+
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)
 endif()
 
-set_source_files_properties(
-    main.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
-    PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
-)
+set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+set(ROCDECODE_TEST_VIDEO_HEVC "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_HEVC}")
+    if(rocdecode-host_FOUND)
+        add_test(NAME ${example_name}-HEVC-host COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_HEVC}")
+    endif()
+    add_test(NAME ${example_name}-HEVC COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_HEVC}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_HEVC} not found, skipping ${example_name}-HEVC test")
+endif()
+
+set(ROCDECODE_TEST_VIDEO_AVC "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_AVC}")
+    add_test(NAME ${example_name}-AVC COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_AVC}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_AVC} not found, skipping ${example_name}-AVC test")
+endif()
+
+set(ROCDECODE_TEST_VIDEO_AV1 "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_AV1}")
+    add_test(NAME ${example_name}-AV1 COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_AV1}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_AV1} not found, skipping ${example_name}-AV1 test")
+endif()
+
+set(ROCDECODE_TEST_VIDEO_VP9 "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_VP9}")
+    add_test(NAME ${example_name}-VP9 COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_VP9}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_VP9} not found, skipping ${example_name}-VP9 test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode/Makefile
+++ b/Libraries/rocDecode/video_decode/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
@@ -44,7 +44,7 @@ ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_INSTALL_DIR)/lib/librocdecode-host.
 # Common variables and flags
 CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
-ICPPFLAGS := -isystem $(ROCDECODE_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -I .. -I $(UTILS_DIR) -I $(UTILS_DIR)/rocvideodecode -I $(UTILS_DIR)/ffmpegvideodecode
+ICPPFLAGS := -isystem $(ROCDECODE_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -I .. -I $(UTILS_DIR) -I $(UTILS_DIR)/rocvideodecode
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
 ILDLIBS   := -lrocdecode -lrocprofiler-register -lavcodec -lavformat -lavutil -lpthread
 
@@ -56,6 +56,7 @@ ifeq ($(GPU_RUNTIME), HIP)
 	ifneq ($(ROCDECODE_HOST_LIB),)
 		ILDLIBS  += -l$(ROCDECODE_HOST_LIB)
 		CPPFLAGS += -DENABLE_HOST_DECODE=1
+		ICPPFLAGS += -I $(UTILS_DIR)/ffmpegvideodecode
 	else
 		CPPFLAGS += -DENABLE_HOST_DECODE=0
 	endif
@@ -85,7 +86,11 @@ ICPPFLAGS += $(CPPFLAGS)
 ILDFLAGS  += $(LDFLAGS)
 ILDLIBS   += $(LDLIBS)
 
-SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp
+SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
+
+ifneq ($(ROCDECODE_HOST_LIB),)
+	SOURCES += $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp
+endif
 
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)

--- a/Libraries/rocDecode/video_decode/main.cpp
+++ b/Libraries/rocDecode/video_decode/main.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2025 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -32,18 +32,15 @@ THE SOFTWARE.
 #include <string>
 #include <sys/stat.h>
 #include <vector>
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-    #include <filesystem>
-#else
-    #include <experimental/filesystem>
-#endif
-
-#include "ffmpeg_video_dec.h"
 #include "rocdecode/roc_bitstream_reader.h"
 #include "roc_video_dec.h"
 #include "video_demuxer.h"
 
 #include "rocdecode_utils.hpp"
+
+#if ENABLE_HOST_DECODE
+    #include "ffmpeg_video_dec.h"
+#endif
 
 //hardcoding for host based decoder creation if demux is not available
 #define DEFAULT_WIDTH 2912
@@ -392,7 +389,7 @@ int main(int argc, char** argv)
             for(int i = 0; i < n_frame_returned; i++)
             {
                 pframe = viddec->GetFrame(&pts);
-                if(b_generate_md5)
+                if(b_generate_md5 && pframe)
                 {
                     md5_generator->UpdateMd5ForFrame(pframe, surf_info);
                 }
@@ -493,6 +490,10 @@ int main(int argc, char** argv)
         else if(bs_reader)
         {
             rocDecDestroyBitstreamReader(bs_reader);
+        }
+        if (viddec) {
+            delete viddec;
+            viddec = nullptr;
         }
     }
     catch(const std::exception& ex)

--- a/Libraries/rocDecode/video_decode/main.cpp
+++ b/Libraries/rocDecode/video_decode/main.cpp
@@ -273,14 +273,14 @@ int main(int argc, char** argv)
 #else
             std::cout << "Error: RocDecode HOST library is not found and backend is not supported!"
                       << std::endl;
-            return 0;
+            return 1;
 #endif
         }
 
         if(!viddec->CodecSupported(device_id, rocdec_codec_id, bit_depth))
         {
             std::cerr << "rocDecode doesn't support codec!" << std::endl;
-            return 0;
+            return 1;
         }
         std::string device_name, gcn_arch_name;
         int         pci_bus_id, pci_domain_id, pci_device_id;

--- a/Libraries/rocDecode/video_decode_batch/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_batch/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocdecode_video_decode_batch)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+include("../../../Common/FindFilesystem.cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,42 +50,11 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
-
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
-endif()
+find_package(FFmpeg REQUIRED)
 
 add_executable(${example_name}
     main.cpp
@@ -92,13 +63,12 @@ add_executable(${example_name}
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
     rocprofiler-register::rocprofiler-register
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
+    ${FFMPEG_LIBRARIES}
     Threads::Threads
-    stdc++fs
+    ${CXX_FS_LIBRARY}
 )
 
 target_include_directories(
@@ -108,13 +78,11 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)
@@ -125,5 +93,13 @@ set_source_files_properties(
     ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
+
+
+set(ROCDECODE_TEST_VIDEO_DIR "${ROCM_ROOT}/share/rocdecode/video")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_DIR}")
+    add_test(NAME ${example_name} COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_DIR}" -t 2)
+else()
+    message(WARNING "rocDecode test video directory ${ROCDECODE_TEST_VIDEO_DIR} not found, skipping ${example_name} test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode_batch/Makefile
+++ b/Libraries/rocDecode/video_decode_batch/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include

--- a/Libraries/rocDecode/video_decode_mem/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_mem/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name rocdecode_video_decode_mem)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,40 +49,10 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
-endif()
+find_package(rocprofiler-register REQUIRED)
+find_package(FFmpeg REQUIRED)
 
 add_executable(${example_name}
     main.cpp
@@ -90,10 +61,10 @@ add_executable(${example_name}
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    ${FFMPEG_LIBRARIES}
 )
 
 target_include_directories(
@@ -103,13 +74,11 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)
@@ -120,5 +89,12 @@ set_source_files_properties(
     ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
+
+set(ROCDECODE_TEST_VIDEO "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")
+if(EXISTS "${ROCDECODE_TEST_VIDEO}")
+    add_test(NAME ${example_name} COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO} not found, skipping ${example_name} test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode_mem/Makefile
+++ b/Libraries/rocDecode/video_decode_mem/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include

--- a/Libraries/rocDecode/video_decode_mem/main.cpp
+++ b/Libraries/rocDecode/video_decode_mem/main.cpp
@@ -182,7 +182,7 @@ int main(int argc, char** argv)
         if(!viddec.CodecSupported(device_id, rocdec_codec_id, demuxer.GetBitDepth()))
         {
             std::cerr << "GPU doesn't support codec!" << std::endl;
-            return 0;
+            return 1;
         }
 
         std::string device_name, gcn_arch_name;
@@ -318,7 +318,7 @@ int main(int argc, char** argv)
     catch(const std::exception& ex)
     {
         std::cout << ex.what() << std::endl;
-        exit(1);
+        return 1;
     }
 
     return 0;

--- a/Libraries/rocDecode/video_decode_mem/main.cpp
+++ b/Libraries/rocDecode/video_decode_mem/main.cpp
@@ -30,11 +30,6 @@ THE SOFTWARE.
 #include <string>
 #include <sys/stat.h>
 #include <vector>
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-    #include <filesystem>
-#else
-    #include <experimental/filesystem>
-#endif
 #include "roc_video_dec.h"
 #include "video_demuxer.h"
 

--- a/Libraries/rocDecode/video_decode_multi_files/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_multi_files/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name rocdecode_video_decode_multi_files)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,40 +49,10 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
-endif()
+find_package(rocprofiler-register REQUIRED)
+find_package(FFmpeg REQUIRED)
 
 add_executable(${example_name}
     main.cpp
@@ -90,10 +61,10 @@ add_executable(${example_name}
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    ${FFMPEG_LIBRARIES}
 )
 
 target_include_directories(
@@ -103,13 +74,11 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)

--- a/Libraries/rocDecode/video_decode_multi_files/Makefile
+++ b/Libraries/rocDecode/video_decode_multi_files/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include

--- a/Libraries/rocDecode/video_decode_multi_files/main.cpp
+++ b/Libraries/rocDecode/video_decode_multi_files/main.cpp
@@ -323,7 +323,7 @@ int main(int argc, char** argv)
     catch(const std::exception& ex)
     {
         std::cout << ex.what() << std::endl;
-        exit(1);
+        return 1;
     }
 
     return 0;

--- a/Libraries/rocDecode/video_decode_multi_files/main.cpp
+++ b/Libraries/rocDecode/video_decode_multi_files/main.cpp
@@ -32,11 +32,6 @@ THE SOFTWARE.
 #include <string>
 #include <sys/stat.h>
 #include <vector>
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-    #include <filesystem>
-#else
-    #include <experimental/filesystem>
-#endif
 #include "roc_video_dec.h"
 #include "video_demuxer.h"
 

--- a/Libraries/rocDecode/video_decode_perf/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_perf/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name rocdecode_video_decode_perf)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,65 +49,37 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
+find_package(rocdecode-host 1.0.0 QUIET)
+find_package(FFmpeg REQUIRED)
+find_package(rocprofiler-register REQUIRED)
+find_package(Threads REQUIRED)
 
-# Try to find the host library directly (handles both naming conventions)
-find_library(ROCDECODE_HOST_LIB
-    NAMES rocdecode-host rocdecodehost
-    PATHS ${ROCM_ROOT}/lib
-    NO_DEFAULT_PATH
+set(SOURCES
+    main.cpp
+    "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp"
 )
 
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
+if(rocdecode-host_FOUND)
+    list(APPEND SOURCES "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp")
 endif()
 
-add_executable(${example_name}
-    main.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
-)
+add_executable(${example_name} ${SOURCES})
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    ${FFMPEG_LIBRARIES}
+    Threads::Threads
 )
 
-# Link host library if found
-if(ROCDECODE_HOST_LIB)
-    target_link_libraries(${example_name} PRIVATE ${ROCDECODE_HOST_LIB})
+# Add rocdecode host utils if host library found
+if(rocdecode-host_FOUND)
+    target_include_directories(${example_name} PRIVATE "${rocdecode-host_INCLUDE_DIR}" "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode")
+    target_link_libraries(${example_name} PRIVATE rocdecode::rocdecode-host)
     target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=1)
 else()
     target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=0)
@@ -119,24 +92,23 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)
 endif()
 
-set_source_files_properties(
-    main.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
-    PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
-)
+set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
+
+set(ROCDECODE_TEST_VIDEO_HEVC "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_HEVC}")
+    add_test(NAME ${example_name} COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_HEVC}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_HEVC} not found, skipping ${example_name} test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode_perf/Makefile
+++ b/Libraries/rocDecode/video_decode_perf/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
@@ -44,7 +44,7 @@ ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_INSTALL_DIR)/lib/librocdecode-host.
 # Common variables and flags
 CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
-ICPPFLAGS := -isystem $(ROCDECODE_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -I $(UTILS_DIR) -I $(UTILS_DIR)/rocvideodecode -I $(UTILS_DIR)/ffmpegvideodecode
+ICPPFLAGS := -isystem $(ROCDECODE_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -I $(UTILS_DIR) -I $(UTILS_DIR)/rocvideodecode
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
 ILDLIBS   := -lrocdecode -lavcodec -lavformat -lavutil
 
@@ -54,8 +54,9 @@ ifeq ($(GPU_RUNTIME), HIP)
 
 	# Add host decode library and flag if available
 	ifneq ($(ROCDECODE_HOST_LIB),)
-		ILDLIBS  += -l$(ROCDECODE_HOST_LIB)
-		CPPFLAGS += -DENABLE_HOST_DECODE=1
+		ILDLIBS   += -l$(ROCDECODE_HOST_LIB)
+		CPPFLAGS  += -DENABLE_HOST_DECODE=1
+		ICPPFLAGS += -I $(UTILS_DIR)/ffmpegvideodecode
 	else
 		CPPFLAGS += -DENABLE_HOST_DECODE=0
 	endif
@@ -85,7 +86,11 @@ ICPPFLAGS += $(CPPFLAGS)
 ILDFLAGS  += $(LDFLAGS)
 ILDLIBS   += $(LDLIBS)
 
-SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp
+SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
+
+ifneq ($(ROCDECODE_HOST_LIB),)
+	SOURCES += $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp
+endif
 
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)

--- a/Libraries/rocDecode/video_decode_perf/main.cpp
+++ b/Libraries/rocDecode/video_decode_perf/main.cpp
@@ -243,7 +243,7 @@ int main(int argc, char** argv)
                 std::cout
                     << "Error: RocDecode HOST library is not found and backend is not supported!"
                     << std::endl;
-                return 0;
+                return 1;
 #endif
             }
 
@@ -324,7 +324,7 @@ int main(int argc, char** argv)
     catch(const std::exception& ex)
     {
         std::cout << ex.what() << std::endl;
-        exit(1);
+        return 1;
     }
 
     return 0;

--- a/Libraries/rocDecode/video_decode_perf/main.cpp
+++ b/Libraries/rocDecode/video_decode_perf/main.cpp
@@ -30,12 +30,9 @@ THE SOFTWARE.
 #include <sys/stat.h>
 #include <thread>
 #include <vector>
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-    #include <filesystem>
-#else
-    #include <experimental/filesystem>
+#if ENABLE_HOST_DECODE
+    #include "ffmpeg_video_dec.h"
 #endif
-#include "ffmpeg_video_dec.h"
 #include "roc_video_dec.h"
 #include "video_demuxer.h"
 

--- a/Libraries/rocDecode/video_decode_pic_files/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_pic_files/CMakeLists.txt
@@ -25,6 +25,7 @@ set(example_name rocdecode_video_decode_pic_files)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,65 +49,37 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
+find_package(rocdecode-host 1.0.0 QUIET)
+find_package(FFmpeg REQUIRED)
+find_package(rocprofiler-register REQUIRED)
+find_package(Threads REQUIRED)
 
-# Try to find the host library directly (handles both naming conventions)
-find_library(ROCDECODE_HOST_LIB
-    NAMES rocdecode-host rocdecodehost
-    PATHS ${ROCM_ROOT}/lib
-    NO_DEFAULT_PATH
+set(SOURCES
+    main.cpp
+    "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp"
 )
 
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
+if(rocdecode-host_FOUND)
+    list(APPEND SOURCES "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp")
 endif()
 
-add_executable(${example_name}
-    main.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
-)
+add_executable(${example_name} ${SOURCES})
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    ${FFMPEG_LIBRARIES}
+    Threads::Threads
 )
 
-# Link host library if found
-if(ROCDECODE_HOST_LIB)
-    target_link_libraries(${example_name} PRIVATE ${ROCDECODE_HOST_LIB})
+# Add rocdecode host utils if host library found
+if(rocdecode-host_FOUND)
+    target_include_directories(${example_name} PRIVATE "${rocdecode-host_INCLUDE_DIR}" "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode")
+    target_link_libraries(${example_name} PRIVATE rocdecode::rocdecode-host)
     target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=1)
 else()
     target_compile_definitions(${example_name} PRIVATE ENABLE_HOST_DECODE=0)
@@ -119,24 +92,16 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    "${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)
 endif()
 
-set_source_files_properties(
-    main.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
-    ${ROCM_ROOT}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
-    PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
-)
+set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode_pic_files/Makefile
+++ b/Libraries/rocDecode/video_decode_pic_files/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include
@@ -44,7 +44,7 @@ ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_INSTALL_DIR)/lib/librocdecode-host.
 # Common variables and flags
 CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
-ICPPFLAGS := -isystem $(ROCDECODE_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -I $(UTILS_DIR) -I $(UTILS_DIR)/rocvideodecode -I $(UTILS_DIR)/ffmpegvideodecode
+ICPPFLAGS := -isystem $(ROCDECODE_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -I $(UTILS_DIR) -I $(UTILS_DIR)/rocvideodecode
 ILDFLAGS  := -L $(ROCM_INSTALL_DIR)/lib
 ILDLIBS   := -lrocdecode -lavcodec -lavformat -lavutil
 
@@ -54,8 +54,9 @@ ifeq ($(GPU_RUNTIME), HIP)
 
 	# Add host decode library and flag if available
 	ifneq ($(ROCDECODE_HOST_LIB),)
-		ILDLIBS  += -l$(ROCDECODE_HOST_LIB)
-		CPPFLAGS += -DENABLE_HOST_DECODE=1
+		ILDLIBS   += -l$(ROCDECODE_HOST_LIB)
+		CPPFLAGS  += -DENABLE_HOST_DECODE=1
+		ICPPFLAGS += -I $(UTILS_DIR)/ffmpegvideodecode
 	else
 		CPPFLAGS += -DENABLE_HOST_DECODE=0
 	endif
@@ -85,7 +86,11 @@ ICPPFLAGS += $(CPPFLAGS)
 ILDFLAGS  += $(LDFLAGS)
 ILDLIBS   += $(LDLIBS)
 
-SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp
+SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
+
+ifneq ($(ROCDECODE_HOST_LIB),)
+	SOURCES += $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp
+endif
 
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)

--- a/Libraries/rocDecode/video_decode_pic_files/main.cpp
+++ b/Libraries/rocDecode/video_decode_pic_files/main.cpp
@@ -306,7 +306,7 @@ int main(int argc, char** argv)
                 for(int j = 0; j < n_frame_returned; j++)
                 {
                     pframe = viddec->GetFrame(&pts);
-                    if(b_generate_md5)
+                    if(b_generate_md5 && pframe)
                     {
                         md5_generator->UpdateMd5ForFrame(pframe, surf_info);
                     }
@@ -399,8 +399,10 @@ int main(int argc, char** argv)
             }
             delete md5_generator;
         }
-
-        delete viddec;
+        if (viddec) {
+            delete viddec;
+            viddec = nullptr;
+        }
     }
     catch(const std::exception& ex)
     {

--- a/Libraries/rocDecode/video_decode_raw/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_raw/CMakeLists.txt
@@ -48,41 +48,10 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-find_library(SWRESAMPLE_LIBRARY swresample REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
-endif()
+find_package(rocprofiler-register REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(${example_name}
     main.cpp
@@ -91,11 +60,10 @@ add_executable(${example_name}
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
-    ${SWRESAMPLE_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    Threads::Threads
 )
 
 target_include_directories(
@@ -105,22 +73,40 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
 )
-
-# FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
-    target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
-else()
-    target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)
-endif()
 
 set_source_files_properties(
     main.cpp
     ${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
+
+set(ROCDECODE_TEST_VIDEO_RAW_HEVC "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H265.265")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_RAW_HEVC}")
+    add_test(NAME ${example_name}-HEVC COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_RAW_HEVC}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_RAW_HEVC} not found, skipping ${example_name}-HEVC test")
+endif()
+
+set(ROCDECODE_TEST_VIDEO_RAW_AVC "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H264.264")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_RAW_AVC}")
+    add_test(NAME ${example_name}-AVC COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_RAW_AVC}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_RAW_AVC} not found, skipping ${example_name}-AVC test")
+endif()
+
+set(ROCDECODE_TEST_VIDEO_RAW_AV1 "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_RAW_AV1}")
+    add_test(NAME ${example_name}-AV1 COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_RAW_AV1}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_RAW_AV1} not found, skipping ${example_name}-AV1 test")
+endif()
+
+set(ROCDECODE_TEST_VIDEO_RAW_VP9 "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_RAW_VP9}")
+    add_test(NAME ${example_name}-VP9 COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_RAW_VP9}")
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_RAW_VP9} not found, skipping ${example_name}-VP9 test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode_raw/Makefile
+++ b/Libraries/rocDecode/video_decode_raw/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include

--- a/Libraries/rocDecode/video_decode_raw/main.cpp
+++ b/Libraries/rocDecode/video_decode_raw/main.cpp
@@ -30,18 +30,63 @@ THE SOFTWARE.
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-    #include <filesystem>
-#else
-    #include <experimental/filesystem>
-#endif
 
 #include "rocdecode/roc_bitstream_reader.h"
 #include "roc_video_dec.h"
 
 #include "CmdParser/cmdparser.hpp"
 #include "example_utils.hpp"
-#include "rocdecode_utils.hpp"
+
+typedef enum reconfigure_flush_mode_enum {
+    RECONFIG_FLUSH_MODE_NONE = 0x0,                      /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,              /**<  The remaining frames will be dumped to file in this mode */
+} reconfigure_flush_mode;
+
+// This struct is used by sample apps to dump last frames to file
+typedef struct reconfig_dump_file_struct_t {
+    bool b_dump_frames_to_file;
+    std::string output_file_name;
+} reconfig_dump_file_struct;
+
+// Callback function to flush last frames and save it to file when reconfigure happens
+inline int reconfigure_flush_callback(void *p_viddec_obj, uint32_t flush_mode, void *p_user_struct)
+{
+    int n_frames_flushed = 0;
+    if ((p_viddec_obj == nullptr) || (p_user_struct == nullptr))
+    {
+        return n_frames_flushed;
+    }
+
+    RocVideoDecoder *viddec = static_cast<RocVideoDecoder *>(p_viddec_obj);
+    OutputSurfaceInfo *surf_info;
+    if (!viddec->GetOutputSurfaceInfo(&surf_info))
+    {
+        std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
+        return n_frames_flushed;
+    }
+
+    uint8_t *pframe = nullptr;
+    int64_t pts;
+    while ((pframe = viddec->GetFrame(&pts)))
+    {
+        if (flush_mode != RECONFIG_FLUSH_MODE_NONE)
+        {
+            reconfig_dump_file_struct *p_dump_file_struct = static_cast<reconfig_dump_file_struct *>(p_user_struct);
+            if (flush_mode & reconfigure_flush_mode::RECONFIG_FLUSH_MODE_DUMP_TO_FILE)
+            {
+                if (p_dump_file_struct->b_dump_frames_to_file)
+                {
+                    viddec->SaveFrameToFile(p_dump_file_struct->output_file_name, pframe, surf_info);
+                }
+            }
+        }
+        // release and flush frame
+        viddec->ReleaseFrame(pts, true);
+        n_frames_flushed++;
+    }
+
+    return n_frames_flushed;
+}
 
 int main(int argc, char** argv)
 {

--- a/Libraries/rocDecode/video_decode_raw/main.cpp
+++ b/Libraries/rocDecode/video_decode_raw/main.cpp
@@ -213,7 +213,7 @@ int main(int argc, char** argv)
         if(!viddec.CodecSupported(device_id, rocdec_codec_id, bit_depth))
         {
             std::cerr << "GPU doesn't support codec!" << std::endl;
-            return 0;
+            return 1;
         }
         std::string device_name, gcn_arch_name;
         int         pci_bus_id, pci_domain_id, pci_device_id;
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
     catch(const std::exception& ex)
     {
         std::cout << ex.what() << std::endl;
-        exit(1);
+        return 1;
     }
 
     return 0;

--- a/Libraries/rocDecode/video_decode_rgb/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_rgb/CMakeLists.txt
@@ -22,6 +22,7 @@
 
 set(example_name rocdecode_video_decode_rgb)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
@@ -48,41 +49,11 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-find_library(SWRESAMPLE_LIBRARY swresample REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
-endif()
+find_package(FFmpeg REQUIRED)
+find_package(rocprofiler-register REQUIRED)
+find_package(Threads REQUIRED)
 
 add_executable(${example_name}
     main.cpp
@@ -93,11 +64,11 @@ add_executable(${example_name}
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
-    ${SWRESAMPLE_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    Threads::Threads
+    ${FFMPEG_LIBRARIES}
 )
 
 target_include_directories(
@@ -107,9 +78,7 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
@@ -126,5 +95,13 @@ set_source_files_properties(
     ${ROCM_ROOT}/share/rocdecode/utils/resize_kernels.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
+
+set(ROCDECODE_TEST_VIDEO_HEVC "${ROCM_ROOT}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")
+if(EXISTS "${ROCDECODE_TEST_VIDEO_HEVC}")
+    add_test(NAME ${example_name} COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_HEVC}" -of rgb)
+    add_test(NAME ${example_name}-resize COMMAND ${example_name} -i "${ROCDECODE_TEST_VIDEO_HEVC}" -resize 640x360 -of rgb)
+else()
+    message(WARNING "rocDecode test video ${ROCDECODE_TEST_VIDEO_HEVC} not found, skipping ${example_name}-HEVC test")
+endif()
 
 install(TARGETS ${example_name})

--- a/Libraries/rocDecode/video_decode_rgb/Makefile
+++ b/Libraries/rocDecode/video_decode_rgb/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include

--- a/Libraries/rocDecode/video_decode_rgb/main.cpp
+++ b/Libraries/rocDecode/video_decode_rgb/main.cpp
@@ -340,7 +340,7 @@ int main(int argc, char** argv)
         if(!viddec.CodecSupported(device_id, rocdec_codec_id, demuxer.GetBitDepth()))
         {
             std::cerr << "GPU doesn't support codec!" << std::endl;
-            return 0;
+            return 1;
         }
         VideoPostProcess post_process;
         MD5Generator*    md5_generator = nullptr;

--- a/Libraries/rocDecode/video_decode_rgb/main.cpp
+++ b/Libraries/rocDecode/video_decode_rgb/main.cpp
@@ -20,7 +20,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include "md5.h"
 #include "roc_video_dec.h"
 #include "video_demuxer.h"
 #include "video_post_process.h"

--- a/Libraries/rocDecode/video_to_sequence/CMakeLists.txt
+++ b/Libraries/rocDecode/video_to_sequence/CMakeLists.txt
@@ -25,6 +25,8 @@ set(example_name rocdecode_video_to_sequence)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+include("../../../Common/FindFilesystem.cmake")
 include("../../../Common/HipPlatform.cmake")
 select_gpu_language()
 
@@ -48,41 +50,10 @@ endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}")
 
+find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
-
-# Find FFmpeg libraries
-find_library(AVCODEC_LIBRARY avcodec REQUIRED)
-find_library(AVFORMAT_LIBRARY avformat REQUIRED)
-find_library(AVUTIL_LIBRARY avutil REQUIRED)
-find_library(SWRESAMPLE_LIBRARY swresample REQUIRED)
-
-find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h REQUIRED)
-find_path(AVFORMAT_INCLUDE_DIR libavformat/avformat.h REQUIRED)
-find_path(AVUTIL_INCLUDE_DIR libavutil/avutil.h REQUIRED)
-
-# Check FFmpeg version for compatibility using pkg-config (same as Makefile)
-execute_process(
-    COMMAND pkg-config --modversion libavcodec
-    OUTPUT_VARIABLE AVCODEC_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-)
-
-# If pkg-config fails, try to get version from header as fallback
-if(NOT AVCODEC_VERSION AND AVCODEC_INCLUDE_DIR)
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MAJOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MAJOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MINOR_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MINOR")
-    file(STRINGS "${AVCODEC_INCLUDE_DIR}/libavcodec/version.h" AVCODEC_VERSION_MICRO_LINE
-         REGEX "^#define LIBAVCODEC_VERSION_MICRO")
-
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MAJOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MAJOR "${AVCODEC_VERSION_MAJOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MINOR[ \t]+([0-9]+).*$" "\\1" AVCODEC_MINOR "${AVCODEC_VERSION_MINOR_LINE}")
-    string(REGEX REPLACE "^#define LIBAVCODEC_VERSION_MICRO[ \t]+([0-9]+).*$" "\\1" AVCODEC_MICRO "${AVCODEC_VERSION_MICRO_LINE}")
-
-    set(AVCODEC_VERSION "${AVCODEC_MAJOR}.${AVCODEC_MINOR}.${AVCODEC_MICRO}")
-endif()
+find_package(FFmpeg REQUIRED)
+find_package(rocprofiler-register REQUIRED)
 
 add_executable(${example_name}
     main.cpp
@@ -91,11 +62,11 @@ add_executable(${example_name}
 
 target_link_libraries(${example_name}
     PRIVATE
+    hip::host
     rocdecode::rocdecode
-    ${AVCODEC_LIBRARY}
-    ${AVFORMAT_LIBRARY}
-    ${AVUTIL_LIBRARY}
-    ${SWRESAMPLE_LIBRARY}
+    rocprofiler-register::rocprofiler-register
+    ${FFMPEG_LIBRARIES}
+    ${CXX_FS_LIBRARY}
 )
 
 target_include_directories(
@@ -105,13 +76,11 @@ target_include_directories(
     "../../../External"
     "${ROCM_ROOT}/share/rocdecode/utils"
     "${ROCM_ROOT}/share/rocdecode/utils/rocvideodecode"
-    ${AVCODEC_INCLUDE_DIR}
-    ${AVFORMAT_INCLUDE_DIR}
-    ${AVUTIL_INCLUDE_DIR}
+    "${FFMPEG_INCLUDE_DIR}"
 )
 
 # FFMPEG multi-version support
-if(AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
+if(_FFMPEG_AVCODEC_VERSION VERSION_LESS_EQUAL 58.134.100)
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=0)
 else()
     target_compile_definitions(${example_name} PRIVATE USE_AVCODEC_GREATER_THAN_58_134=1)

--- a/Libraries/rocDecode/video_to_sequence/Makefile
+++ b/Libraries/rocDecode/video_to_sequence/Makefile
@@ -26,7 +26,7 @@ EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
 # HIP variables
-ROCM_INSTALL_DIR := /opt/rocm
+ROCM_INSTALL_DIR ?= /opt/rocm
 UTILS_DIR := ${ROCM_INSTALL_DIR}/share/rocdecode/utils
 
 HIP_INCLUDE_DIR       := $(ROCM_INSTALL_DIR)/include

--- a/Libraries/rocDecode/video_to_sequence/main.cpp
+++ b/Libraries/rocDecode/video_to_sequence/main.cpp
@@ -39,8 +39,12 @@ THE SOFTWARE.
 
 #if __cplusplus >= 201703L && __has_include(<filesystem>)
     #include <filesystem>
-#else
+    namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
     #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
+#else
+    static_assert(false, "filesystem not available");
 #endif
 
 #include "roc_video_dec.h"
@@ -287,19 +291,11 @@ int main(int argc, char** argv)
     bool        b_dump_output_frames = false;
     if(!output_folder_path.empty())
     {
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-        if(std::filesystem::is_directory(output_folder_path))
+        if(fs::is_directory(output_folder_path))
         {
-            std::filesystem::remove_all(output_folder_path);
+            fs::remove_all(output_folder_path);
         }
-        std::filesystem::create_directory(output_folder_path);
-#else
-        if(std::experimental::filesystem::is_directory(output_folder_path))
-        {
-            std::experimental::filesystem::remove_all(output_folder_path);
-        }
-        std::experimental::filesystem::create_directory(output_folder_path);
-#endif
+        fs::create_directory(output_folder_path);
         b_dump_output_frames = true;
     }
 
@@ -327,14 +323,8 @@ int main(int argc, char** argv)
 
     try
     {
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-        for(const auto& entry : std::filesystem::directory_iterator(input_folder_path))
+        for(const auto& entry : fs::directory_iterator(input_folder_path))
         {
-#else
-        for(const auto& entry :
-            std::experimental::filesystem::directory_iterator(input_folder_path))
-        {
-#endif
             input_file_names.push_back(entry.path());
             num_files++;
         }

--- a/Libraries/rocDecode/video_to_sequence/main.cpp
+++ b/Libraries/rocDecode/video_to_sequence/main.cpp
@@ -530,7 +530,7 @@ int main(int argc, char** argv)
     catch(const std::exception& ex)
     {
         std::cout << ex.what() << std::endl;
-        exit(1);
+        return 1;
     }
 
     return 0;

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -1,0 +1,157 @@
+################################################################################
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+################################################################################
+# - Try to find ffmpeg libraries (libavcodec, libavformat and libavutil)
+# Once done this will define
+#
+# FFMPEG_FOUND - system has ffmpeg or libav
+# FFMPEG_INCLUDE_DIR - the ffmpeg include directory
+# FFMPEG_LIBRARIES - Link these to use ffmpeg
+################################################################################
+
+set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig")
+include(FindPackageHandleStandardArgs)
+
+if(FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIR)
+  set(FFMPEG_FOUND TRUE)
+else()
+  # use pkg-config to get the directories and then use these values
+  # in the FIND_PATH() and FIND_LIBRARY() calls
+  find_package(PkgConfig)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(_FFMPEG_AVCODEC libavcodec)
+    pkg_check_modules(_FFMPEG_AVFORMAT libavformat)
+    pkg_check_modules(_FFMPEG_AVUTIL libavutil)
+  endif()
+
+  # AVCODEC
+  find_path(AVCODEC_INCLUDE_DIR 
+    NAMES libavcodec/avcodec.h
+    PATHS ${_FFMPEG_AVCODEC_INCLUDE_DIRS}
+      /usr/local/include
+      /usr/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES ffmpeg libav
+  )
+  mark_as_advanced(AVCODEC_INCLUDE_DIR)
+  find_library(AVCODEC_LIBRARY
+    NAMES avcodec
+    PATHS ${_FFMPEG_AVCODEC_LIBRARY_DIRS}
+      /usr/local/lib
+      /usr/lib
+      /opt/local/lib
+      /sw/lib
+  )
+  mark_as_advanced(AVCODEC_LIBRARY)
+
+  # AVFORMAT
+  find_path(AVFORMAT_INCLUDE_DIR 
+    NAMES libavformat/avformat.h
+    PATHS ${_FFMPEG_AVFORMAT_INCLUDE_DIRS}
+      /usr/local/include
+      /usr/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES ffmpeg libav
+  )
+  mark_as_advanced(AVFORMAT_INCLUDE_DIR)
+  find_library(AVFORMAT_LIBRARY
+    NAMES avformat
+    PATHS ${_FFMPEG_AVFORMAT_LIBRARY_DIRS}
+      /usr/local/lib
+      /usr/lib
+      /opt/local/lib
+      /sw/lib
+  )
+  mark_as_advanced(AVFORMAT_LIBRARY)
+
+  # AVUTIL
+  find_path(AVUTIL_INCLUDE_DIR 
+    NAMES libavutil/avutil.h
+    PATHS ${_FFMPEG_AVUTIL_INCLUDE_DIRS}
+      /usr/local/include
+      /usr/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES ffmpeg libav
+  )
+  mark_as_advanced(AVUTIL_INCLUDE_DIR)
+  find_library(AVUTIL_LIBRARY
+    NAMES avutil
+    PATHS ${_FFMPEG_AVUTIL_LIBRARY_DIRS}
+      /usr/local/lib
+      /usr/lib
+      /opt/local/lib
+      /sw/lib
+  )
+  mark_as_advanced(AVUTIL_LIBRARY)
+
+  if(AVCODEC_LIBRARY AND AVFORMAT_LIBRARY)
+    set(FFMPEG_FOUND TRUE)
+  endif()
+  
+  if(_FFMPEG_AVCODEC_VERSION VERSION_LESS 58.18.100 OR _FFMPEG_AVFORMAT_VERSION VERSION_LESS 58.12.100 OR _FFMPEG_AVUTIL_VERSION VERSION_LESS 56.14.100)
+    if(FFMPEG_FOUND)
+      message("-- ${White}FFMPEG   required min version - 4.0.4 Found:${FFMPEG_VERSION}")
+      message("-- ${White}AVCODEC  required min version - 58.18.100 Found:${_FFMPEG_AVCODEC_VERSION}${ColourReset}")
+      message("-- ${White}AVFORMAT required min version - 58.12.100 Found:${_FFMPEG_AVFORMAT_VERSION}${ColourReset}")
+      message("-- ${White}AVUTIL   required min version - 56.14.100 Found:${_FFMPEG_AVUTIL_VERSION}${ColourReset}")
+    endif()
+    set(FFMPEG_FOUND FALSE)
+    message( "-- ${Yellow}NOTE: FindFFmpeg failed to find -- FFMPEG${ColourReset}" )
+  endif()
+  
+  if(FFMPEG_FOUND)
+    set(FFMPEG_INCLUDE_DIR ${AVFORMAT_INCLUDE_DIR} CACHE INTERNAL "")
+    set(FFMPEG_LIBRARIES
+      ${AVCODEC_LIBRARY}
+      ${AVFORMAT_LIBRARY}
+      ${AVUTIL_LIBRARY}
+      CACHE INTERNAL ""
+    )
+  endif()
+
+  if(FFMPEG_FOUND)
+    message("-- ${White}Using FFMPEG -- \n\tLibraries:${FFMPEG_LIBRARIES} \n\tIncludes:${FFMPEG_INCLUDE_DIR}${ColourReset}")
+  else()
+    if(FFmpeg_FIND_REQUIRED)
+      message(FATAL_ERROR "{Red}FindFFmpeg -- libavcodec or libavformat or libavutil NOT FOUND${ColourReset}")
+    endif()
+  endif()
+endif()
+
+find_package_handle_standard_args(
+  FFmpeg
+  FOUND_VAR FFMPEG_FOUND
+  REQUIRED_VARS
+    FFMPEG_LIBRARIES
+    FFMPEG_INCLUDE_DIR
+    AVCODEC_INCLUDE_DIR
+    AVCODEC_LIBRARY
+    AVFORMAT_INCLUDE_DIR
+    AVFORMAT_LIBRARY
+    AVUTIL_INCLUDE_DIR
+    AVUTIL_LIBRARY
+  VERSION_VAR FFMPEG_VERSION
+)


### PR DESCRIPTION
## Motivation

TheRock tarballs introduced rocDecode without host library. Sync with rocDecode upstream to support TheRock tarballs.

## Technical Details

- Updated CMakefiles to find FFmpeg
- Decouple `rocdecode-host` library
- Added CTests
- Removed unnecessary filesystem includes
- Added hip and rocprofiler-register linking to all examples
- Added threads linking
- Removed FFmpeg dependency from `video_decode_raw`

## Test Plan

Locally tested on gfx1100 + ubuntu 22.04

## Test Result

Builds and passes all tests with TheRock tarball `therock-dist-linux-gfx110X-all-7.12.0a20260225.tar.gz`

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
