### PR TITLE
Test p2p support before run example

### DIFF
--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/p2p_memory_access/main.hip
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/p2p_memory_access/main.hip
@@ -42,7 +42,7 @@
 
 __global__ void simpleKernel(double *data, std::size_t elems)
 {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if(idx < elems)
         data[idx] = idx * 2.0;
 }
@@ -64,6 +64,25 @@ int main()
 
     int deviceId0 = 0;
     int deviceId1 = 1;
+
+    // Check whether peer-to-peer access is supported between the two devices.
+    int canAccessPeer01 = 0;
+    int canAccessPeer10 = 0;
+    HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer01, deviceId0, deviceId1));
+    HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer10, deviceId1, deviceId0));
+    if(!canAccessPeer01 || !canAccessPeer10)
+    {
+        hipDeviceProp_t props0{};
+        hipDeviceProp_t props1{};
+        HIP_CHECK(hipGetDeviceProperties(&props0, deviceId0));
+        HIP_CHECK(hipGetDeviceProperties(&props1, deviceId1));
+        std::cout << "Peer-to-peer access is not supported between device " << deviceId0
+                  << " (arch: " << props0.gcnArchName << ")"
+                  << " and device " << deviceId1
+                  << " (arch: " << props1.gcnArchName << ")"
+                  << ". Skipping example." << std::endl;
+        return EXIT_SUCCESS;
+    }
 
     // Enable peer access to the memory (allocated and future) on the peer device.
     // Ensure the device is active before enabling peer access.

--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
@@ -60,7 +60,7 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) -fPIC -shared -o $@ $< $(ILDFLAGS) $(ILDLIBS)
 
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
-	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)

--- a/Libraries/rocProfiler-SDK/api_callback_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/api_callback_tracing/Makefile
@@ -60,7 +60,7 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) -fPIC -shared -o $@ $< $(ILDFLAGS) $(ILDLIBS)
 
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
-	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -lrocprofiler-sdk-roctx -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -lrocprofiler-sdk-roctx -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
@@ -60,7 +60,7 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) -fPIC -shared -o $@ $< $(ILDFLAGS) $(ILDLIBS)
 
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
-	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)

--- a/Libraries/rocProfiler-SDK/intercept_table/Makefile
+++ b/Libraries/rocProfiler-SDK/intercept_table/Makefile
@@ -60,7 +60,7 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) -fPIC -shared -o $@ $< $(ILDFLAGS) $(ILDLIBS)
 
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
-	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)

--- a/Libraries/rocProfiler-SDK/pc_sampling/Makefile
+++ b/Libraries/rocProfiler-SDK/pc_sampling/Makefile
@@ -60,7 +60,7 @@ $(CLIENT_LIB): client.cpp pcs.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) -fPIC -shared -o $@ client.cpp pcs.cpp $(ILDFLAGS) $(ILDLIBS)
 
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
-	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
+	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)


### PR DESCRIPTION
* Fix error at run example if p2p doesn't support:
`HIP error 101: invalid device ordinal at main.hip:71`
* Fix type cast warnings
* Fix Makefile for profiler examples


Ref to internal issue #ROCM-3783

## Motivation

Avoid error during test examples
`HIP error 101: invalid device ordinal at main.hip:71`
and get clear message about results of example run.

## Technical Details

Call `hipDeviceCanAccessPeer` to test support before enabling p2p via `hipDeviceEnablePeerAccess`

## Test Plan

build and run `hip_p2p_memory_access`

## Test Result

For Navi31:
`Peer-to-peer access is not supported between device 0 (arch: gfx1100) and device 1 (arch: gfx1100). Skipping example.`

## Added/Updated documentation?

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
