### PR TITLE
Fix test summary output and upload test logs

### DIFF
--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -172,7 +172,9 @@ jobs:
       - name: Test summary
         if: ${{ !cancelled() }}
         run: |
-          if [ ! -f ctest_output.log ]; then
+          LAST_TEST_LOG="build/Testing/Temporary/LastTest.log"
+          if [ ! -f ctest_output.log ] || [ ! -f "${LAST_TEST_LOG}" ]; then
+            echo "No test logs found." >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
 
@@ -182,23 +184,38 @@ jobs:
           SUMMARY=$(grep "tests passed" ctest_output.log)
           echo "**${SUMMARY}**" >> $GITHUB_STEP_SUMMARY
 
-          FAILED=$(grep -c "Failed" ctest_output.log || true)
-
-          if [ "${FAILED}" -gt 0 ]; then
+          FAILED_LOG="build/Testing/Temporary/LastTestsFailed.log"
+          if [ -s "${FAILED_LOG}" ]; then
             echo "## Failed tests" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            cat build/Testing/Temporary/LastTestsFailed.log >> $GITHUB_STEP_SUMMARY
+            cat "${FAILED_LOG}" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
             echo "<details><summary>Failed tests output</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            awk '/^[[:space:]]*Start[[:space:]]+[0-9]+:/ {found=0; next} /\*\*\*/ && !/Passed/ {found=1} found' ctest_output.log >> $GITHUB_STEP_SUMMARY
+            
+            awk '
+              /^[0-9]+\/[0-9]+ Testing: / { if (inblock && failed) print block; block = $0; inblock = 1; failed = 0; seen_result = 0; next }
+              inblock { block = block "\n" $0 }
+              /^Test Failed\.$/ { failed = 1; seen_result = 1 }
+              /^Test Passed\.$/ { seen_result = 1 }
+              /^-+$/ { if (inblock && seen_result) { if (failed) print block; inblock = 0 } }
+              END { if (inblock && failed) print block }
+            ' "${LAST_TEST_LOG}" >> $GITHUB_STEP_SUMMARY
+            
             echo '```' >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Upload test logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.sanity-check.outputs.rocm_version || steps.install-tarball.outputs.rocm_version }}-${{ matrix.install_method }}
+          path: build/Testing/Temporary/
 
       - name: Clean the workspace
         if: always()


### PR DESCRIPTION
## Motivation

Test summary only checked for `FAILED` tests, but ctest also outputs `SIGFAULT` or `Exception` for other failures. Use the `LastTest.log` log file generated by CTest for better summary output.

## Technical Details

Example `LastTest.log` log for a failed test that shows as `Subprocess aborted***Exception` instead of Failed in the test output. The log file always writes `Test Failed.` or `Test Passed.` so we can reliably use that as a condition for end of a test log block.
```
292/304 Testing: rocprof-systems-advanced
292/304 Test: rocprof-systems-advanced
Command: "/workspace/rocm-examples/build/bin/Tools/rocprof-systems-advanced.sh"
Directory: /workspace/rocm-examples/build/bin/Tools
"rocprof-systems-advanced" start time: Mar 04 20:31 UTC
Output:
----------------------------------------------------------
...
----------------------------------------------------------
Test Failed.
"rocprof-systems-advanced" end time: Mar 04 20:31 UTC
"rocprof-systems-advanced" time elapsed: 00:00:01
----------------------------------------------------------
```

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
