### PR TITLE
Add FFmpeg to docker images and fix rocDecode on SLES

### DIFF
--- a/Dockerfiles/sles-15.7.Dockerfile
+++ b/Dockerfiles/sles-15.7.Dockerfile
@@ -17,6 +17,7 @@ RUN zypper -qni update -y && \
         wget \
         git \
         curl \
+        nasm \
         python313 \
         libdw-devel \
         Mesa-libGL-devel \
@@ -64,6 +65,16 @@ ENV PATH="${VULKAN_SDK}/bin:${PATH}"
 ENV LD_LIBRARY_PATH="${VULKAN_SDK}/lib"
 ENV VK_ADD_LAYER_PATH="${VULKAN_SDK}/share/vulkan/explicit_layer.d"
 ENV PKG_CONFIG_PATH="${VULKAN_SDK}/share/pkgconfig:${VULKAN_SDK}/lib/pkgconfig"
+
+# build ffmpeg from source
+WORKDIR /tmp
+RUN wget https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.xz && \
+    tar -xvf ffmpeg-4.4.6.tar.xz && \
+    cd ffmpeg-4.4.6 && \
+    ./configure --enable-pic --enable-shared && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/ffmpeg-4.4.6*
 
 ENV HIP_PLATFORM=amd
 

--- a/Dockerfiles/ubuntu-22.04.Dockerfile
+++ b/Dockerfiles/ubuntu-22.04.Dockerfile
@@ -19,7 +19,10 @@ RUN apt-get update -qq && \
         libvulkan-dev \
         glslang-tools \
         libtiff-dev \
-        libopencv-dev && \
+        libopencv-dev \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Libraries/rocDecode/rocdec_decode/main.cpp
+++ b/Libraries/rocDecode/rocdec_decode/main.cpp
@@ -751,10 +751,10 @@ int main(int argc, char** argv)
     {
         for (const auto& entry : fs::directory_iterator(input_file_path))
         {
-            if (entry.is_directory())
+            if (fs::is_directory(entry.path()))
             {
                 std::vector<std::string> file_names_sub_folder;
-                for (const auto& sub_entry : fs::directory_iterator(entry))
+                for (const auto& sub_entry : fs::directory_iterator(entry.path()))
                 {
                     file_names_sub_folder.push_back(sub_entry.path());
                 }
@@ -762,7 +762,7 @@ int main(int argc, char** argv)
                 input_file_names.insert(input_file_names.end(), file_names_sub_folder.begin(), file_names_sub_folder.end());
                 file_names_sub_folder.clear();
             }
-            else if(entry.is_regular_file())
+            else if (fs::is_regular_file(entry.path()))
             {
                 b_sort_filenames = true;
                 input_file_names.push_back(entry.path());


### PR DESCRIPTION
## Motivation

Add FFmpeg dependency in docker images and fix SLES rocDecode build failure

## Technical Details

Ubuntu image already has ffmpeg installed, adding package install explicitly for readability.
Build FFmpeg 4.4.6 from source in SLES

Fix experimental filesystem not having member functions `is_directory()` and `is_regular_file()`, change it to `fs::is_directory(entry.path()))` and `fs::is_regular_file(entry.path()))`.

## Test Plan

Locally tested new SLES docker image

## Test Result

All tests pass on gfx1100

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
