### PR TITLE
Add Make-native `test` target across all examples

### DIFF
--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -247,6 +247,18 @@ jobs:
           name: ctest-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.sanity-check.outputs.rocm_version || steps.install-tarball.outputs.rocm_version }}-${{ matrix.install_method }}
           path: build/Testing/Temporary/
 
+      - name: Makefile test
+        if: ${{ !cancelled() }}
+        run: |
+          make test 2>&1 | tee makefile_test_output.log
+
+      - name: Upload Makefile test logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: makefile-test-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.sanity-check.outputs.rocm_version || steps.install-tarball.outputs.rocm_version }}-${{ matrix.install_method }}
+          path: makefile_test_output.log
+
       - name: Clean the workspace
         if: always()
         run: find "$GITHUB_WORKSPACE" -mindepth 1 -delete

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Makefile test
         if: ${{ !cancelled() }}
         run: |
-          make test 2>&1 | tee makefile_test_output.log
+          make test HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" 2>&1 | tee makefile_test_output.log
 
       - name: Upload Makefile test logs
         if: ${{ !cancelled() }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 CMakeUserPresets.json
 .cline_storage
 config.mk
+.claude/

--- a/Applications/Makefile
+++ b/Applications/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   histogram \
   prefix_sum
 
+SKIP_FROM_TEST :=
+
 ifneq ($(wildcard /usr/include/GLFW/glfw3.h),)
   EXAMPLES += sobel_filter
 endif
@@ -45,4 +47,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Applications/bitonic_sort/Makefile
+++ b/Applications/bitonic_sort/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/convolution/Makefile
+++ b/Applications/convolution/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/fdtd/Makefile
+++ b/Applications/fdtd/Makefile
@@ -25,6 +25,7 @@ COMMON_INCLUDE_DIR := ../../Common
 EXTERNAL_DIR := ../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 HIP_INCLUDE_DIR  := $(ROCM_PATH)/include
@@ -36,7 +37,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  :=
-ILDLIBS   := -lstdc++fs
+ILDLIBS   := $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu

--- a/Applications/fdtd/Makefile
+++ b/Applications/fdtd/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/floyd_warshall/Makefile
+++ b/Applications/floyd_warshall/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/histogram/Makefile
+++ b/Applications/histogram/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/monte_carlo_pi/Makefile
+++ b/Applications/monte_carlo_pi/Makefile
@@ -64,7 +64,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiprand_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/prefix_sum/Makefile
+++ b/Applications/prefix_sum/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Applications/sobel_filter/Makefile
+++ b/Applications/sobel_filter/Makefile
@@ -65,13 +65,17 @@ $(EXAMPLE): $(SRCS) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdP
 
 $(EXTERNAL_DIR)/glad/glad.cpp: $(EXTERNAL_DIR)/glad/glad.h
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/HIP-Basic/Makefile
+++ b/HIP-Basic/Makefile
@@ -44,6 +44,8 @@ EXAMPLES := \
   texture_management \
   warp_shuffle
 
+SKIP_FROM_TEST :=
+
 ifneq ($(wildcard /usr/include/GLFW/glfw3.h),)
   EXAMPLES += opengl_interop
   ifneq ($(wildcard /usr/include/vulkan/vulkan.h),)
@@ -68,4 +70,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Basic/assembly_to_executable/Makefile
+++ b/HIP-Basic/assembly_to_executable/Makefile
@@ -82,6 +82,9 @@ main_%.s: main.hip
 main_%.o: main_%.s
 	$(CLANG) -target amdgcn-amd-amdhsa -mcpu=$* -o $@ $<
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	rm -f \
 	  main_*.o \
@@ -90,4 +93,4 @@ clean:
 	  main.o \
 	  $(EXAMPLE)
 
-.PHONY: clean $(EXAMPLE)
+.PHONY: clean $(EXAMPLE) test

--- a/HIP-Basic/bandwidth/Makefile
+++ b/HIP-Basic/bandwidth/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/bit_extract/Makefile
+++ b/HIP-Basic/bit_extract/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/cooperative_groups/Makefile
+++ b/HIP-Basic/cooperative_groups/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/device_globals/Makefile
+++ b/HIP-Basic/device_globals/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/device_query/Makefile
+++ b/HIP-Basic/device_query/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/dynamic_shared/Makefile
+++ b/HIP-Basic/dynamic_shared/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/events/Makefile
+++ b/HIP-Basic/events/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/gpu_arch/Makefile
+++ b/HIP-Basic/gpu_arch/Makefile
@@ -54,7 +54,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/hello_world/Makefile
+++ b/HIP-Basic/hello_world/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/hipify/Makefile
+++ b/HIP-Basic/hipify/Makefile
@@ -58,7 +58,10 @@ main.hip: main.cu
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) main.hip *.o
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/inline_assembly/Makefile
+++ b/HIP-Basic/inline_assembly/Makefile
@@ -54,7 +54,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/llvm_ir_to_executable/Makefile
+++ b/HIP-Basic/llvm_ir_to_executable/Makefile
@@ -86,6 +86,9 @@ main_%.ll: main_%.bc
 main_%.bc: main.hip
 	$(HIPCXX) --cuda-device-only -c -emit-llvm --offload-arch=$* -o $@ -I ../../Common -std=c++17 $<
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	rm -f \
 	  main_device*.o \
@@ -96,4 +99,4 @@ clean:
 	  main_*.ll \
 	  $(EXAMPLE)
 
-.PHONY: clean $(EXAMPLE)
+.PHONY: clean $(EXAMPLE) test

--- a/HIP-Basic/matrix_multiplication/Makefile
+++ b/HIP-Basic/matrix_multiplication/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/module_api/Makefile
+++ b/HIP-Basic/module_api/Makefile
@@ -24,6 +24,7 @@ EXAMPLE := hip_module_api
 COMMON_INCLUDE_DIR := ../../Common
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 ifneq ($(GPU_RUNTIME), HIP)
     $(error GPU_RUNTIME is set to "$(GPU_RUNTIME)". GPU_RUNTIME must be HIP.)
 endif
@@ -40,7 +41,7 @@ CXXFLAGS  ?= -Wall -Wextra
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -I $(COMMON_INCLUDE_DIR)
 ILDFLAGS  :=
-ILDLIBS   :=  -lstdc++fs
+ILDLIBS   :=  $(CXX_FS_LIB)
 
 ICXXFLAGS += $(CXXFLAGS)
 ICPPFLAGS += $(CPPFLAGS)

--- a/HIP-Basic/module_api/Makefile
+++ b/HIP-Basic/module_api/Makefile
@@ -53,7 +53,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp module.co
 module.co: module.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) --genco -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) module.co
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/moving_average/Makefile
+++ b/HIP-Basic/moving_average/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/multi_gpu_data_transfer/Makefile
+++ b/HIP-Basic/multi_gpu_data_transfer/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/occupancy/Makefile
+++ b/HIP-Basic/occupancy/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/opengl_interop/Makefile
+++ b/HIP-Basic/opengl_interop/Makefile
@@ -67,13 +67,16 @@ $(EXTERNAL_DIR)/glad/glad.h: $(EXTERNAL_DIR)/KHR/khrplatform.h
 
 $(EXTERNAL_DIR)/glad/glad.cpp: $(EXTERNAL_DIR)/glad/glad.h
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/HIP-Basic/runtime_compilation/Makefile
+++ b/HIP-Basic/runtime_compilation/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/saxpy/Makefile
+++ b/HIP-Basic/saxpy/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/shared_memory/Makefile
+++ b/HIP-Basic/shared_memory/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/static_device_library/Makefile
+++ b/HIP-Basic/static_device_library/Makefile
@@ -55,7 +55,9 @@ $(LIBEXAMPLE): library.o
 library.o: library/library.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) -c -o $@ $< -fgpu-rdc
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE) $(LIBEXAMPLE) library.o
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/HIP-Basic/static_host_library/Makefile
+++ b/HIP-Basic/static_host_library/Makefile
@@ -81,7 +81,10 @@ $(LIBOBJ): library/library.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 $(LIBEXAMPLE): $(LIBOBJ)
 	$(AR) rcs $@ $(LIBOBJ)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE_CXX) $(EXAMPLE) $(LIBEXAMPLE) $(LIBOBJ)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/HIP-Basic/streams/Makefile
+++ b/HIP-Basic/streams/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/texture_management/Makefile
+++ b/HIP-Basic/texture_management/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Basic/vulkan_interop/Makefile
+++ b/HIP-Basic/vulkan_interop/Makefile
@@ -74,13 +74,16 @@ sinewave.vert.spv.h: sinewave.vert
 sinewave.frag.spv.h: sinewave.frag
 	glslangValidator $< -o $@ $(IGLSLFLAGS) --vn sinewave_frag
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE) sinewave.frag.spv.h sinewave.vert.spv.h
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/HIP-Basic/warp_shuffle/Makefile
+++ b/HIP-Basic/warp_shuffle/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Makefile
+++ b/HIP-Doc/Makefile
@@ -25,6 +25,8 @@ SUBDIRECTORIES := \
   Reference  \
   Tutorials
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/Makefile
@@ -29,6 +29,8 @@ EXAMPLES := \
   timer \
   warp_size_reduction
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -37,4 +39,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/calling_global_functions/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/calling_global_functions/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/extern_shared_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/extern_shared_memory/Makefile
@@ -52,7 +52,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/launch_bounds/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/launch_bounds/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/set_constant_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/set_constant_memory/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/template_warp_size_reduction/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/timer/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/Makefile
+++ b/HIP-Doc/Programming-Guide/HIP-C++-Language-Extensions/warp_size_reduction/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Introduction-to-the-HIP-Programming-Model/Makefile
+++ b/HIP-Doc/Programming-Guide/Introduction-to-the-HIP-Programming-Model/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
     add_kernel
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Introduction-to-the-HIP-Programming-Model/add_kernel/Makefile
+++ b/HIP-Doc/Programming-Guide/Introduction-to-the-HIP-Programming-Model/add_kernel/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Makefile
+++ b/HIP-Doc/Programming-Guide/Makefile
@@ -27,6 +27,8 @@ SUBDIRECTORIES := \
   Programming-for-HIP-Runtime-Compiler \
   Using-HIP-Runtime-API
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/Makefile
@@ -31,6 +31,8 @@ EXAMPLES := \
   per_thread_default_stream \
   pointer_memory_type
 
+SKIP_FROM_TEST :=
+
 ifeq ($(GPU_RUNTIME), CUDA)
   EXAMPLES += load_module_ex_cuda
 endif
@@ -43,4 +45,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/address_retrieval/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/address_retrieval/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/device_code_feature_identification/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/device_code_feature_identification/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/host_code_feature_identification/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/host_code_feature_identification/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/identifying_compilation_target_platform/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/identifying_compilation_target_platform/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/identifying_host_device_compilation_pass/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/identifying_host_device_compilation_pass/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/load_module/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/load_module/Makefile
@@ -59,8 +59,11 @@ $(EXAMPLE): main.cpp vcpy_isa.ptx
 vcpy_isa.ptx: vcpy.hip
 	$(HIPCXX) -x cu $(ICXXFLAGS) -I $(HIP_INCLUDE_DIR) $(ICPPFLAGS) $(ILDFLAGS) --genco -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) vcpy_isa.ptx
 endif
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/load_module_ex/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/load_module_ex/Makefile
@@ -59,8 +59,11 @@ $(EXAMPLE): main.cpp myKernel.ptx
 myKernel.ptx: myKernel.hip
 	$(HIPCXX) -x cu $(ICXXFLAGS) -I $(HIP_INCLUDE_DIR) $(ICPPFLAGS) $(ILDFLAGS) --genco -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) myKernel.hsaco
 endif
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/load_module_ex_cuda/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/load_module_ex_cuda/Makefile
@@ -55,7 +55,10 @@ $(EXAMPLE): main.cpp myKernel.ptx
 myKernel.ptx: myKernel.cu
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) --genco -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) myKernel.ptx
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/per_thread_default_stream/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/per_thread_default_stream/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/pointer_memory_type/Makefile
+++ b/HIP-Doc/Programming-Guide/Porting-CUDA-code-to-HIP/pointer_memory_type/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   lowered_names \
   rtc_error_handling
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -36,4 +38,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/compilation_apis/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/compilation_apis/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/Makefile
@@ -23,6 +23,7 @@
 EXAMPLE := hip_linker_apis_file
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 HIP_INCLUDE_DIR  := $(ROCM_PATH)/include
@@ -34,7 +35,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS :=
 ILDFLAGS  :=
-ILDLIBS   := -lstdc++fs
+ILDLIBS   := $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), CUDA)
   ICXXFLAGS += -x cu

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_file/Makefile
@@ -21,9 +21,11 @@
 # SOFTWARE.
 
 EXAMPLE := hip_linker_apis_file
+COMMON_INCLUDE_DIR := ../../../../Common
 GPU_RUNTIME ?= HIP
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
+
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 HIP_INCLUDE_DIR  := $(ROCM_PATH)/include

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/linker_apis_options/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/lowered_names/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/lowered_names/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/rtc_error_handling/Makefile
+++ b/HIP-Doc/Programming-Guide/Programming-for-HIP-Runtime-Compiler/rtc_error_handling/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/Makefile
@@ -25,6 +25,8 @@ EXAMPLES := \
   event_based_synchronization \
   sequential_kernel_execution
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/async_kernel_execution/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/async_kernel_execution/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/event_based_synchronization/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/event_based_synchronization/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/sequential_kernel_execution/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Asynchronous-Concurrent-Execution/sequential_kernel_execution/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   call_stack_management \
   device_recursion
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/call_stack_management/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/call_stack_management/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/device_recursion/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/device_recursion/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   error_handling
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/error_handling/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Error-Handling/error_handling/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/Makefile
@@ -22,9 +22,9 @@
 
 EXAMPLES := \
   graph_capture \
+  graph_creation
 
 SKIP_FROM_TEST :=
-  graph_creation   
 
 all: $(EXAMPLES)
 

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/Makefile
@@ -22,6 +22,8 @@
 
 EXAMPLES := \
   graph_capture \
+
+SKIP_FROM_TEST :=
   graph_creation   
 
 all: $(EXAMPLES)
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/graph_capture/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/graph_capture/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/graph_creation/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/HIP-Graphs/graph_creation/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   simple_device_query
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/simple_device_query/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Initialization/simple_device_query/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Makefile
@@ -29,6 +29,8 @@ SUBDIRECTORIES := \
   Memory-Management \
   Multi-Device-Management
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -37,4 +39,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
   kernel_memory_allocation \
   static_shared_memory
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/constant_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/constant_memory/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/dynamic_shared_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/dynamic_shared_memory/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/explicit_copy/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/explicit_copy/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/kernel_memory_allocation/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/kernel_memory_allocation/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/static_shared_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Device-Memory/static_shared_memory/Makefile
@@ -54,7 +54,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   pageable_host_memory \
   pinned_host_memory
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pageable_host_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pageable_host_memory/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pinned_host_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Host-Memory/pinned_host_memory/Makefile
@@ -55,7 +55,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Makefile
@@ -27,6 +27,8 @@ SUBDIRECTORIES := \
   Unified-Memory-Management \
   Virtual-Memory-Management
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   ordinary_memory_allocation \
   stream_ordered_memory_allocation
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -36,4 +38,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_resource_usage_statistics/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_resource_usage_statistics/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_threshold/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_threshold/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_trim/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/memory_pool_trim/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/ordinary_memory_allocation/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/ordinary_memory_allocation/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/stream_ordered_memory_allocation/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/SOMA/stream_ordered_memory_allocation/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   static_unified_memory \
   unified_memory_advice
 
+SKIP_FROM_TEST :=
+
 ifeq ($(HSA_XNACK), 1)
   EXAMPLES += standard_unified_memory 
 endif
@@ -40,4 +42,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/data_prefetching/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/data_prefetching/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/dynamic_unified_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/dynamic_unified_memory/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/explicit_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/explicit_memory/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/memory_range_attributes/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/memory_range_attributes/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/standard_unified_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/standard_unified_memory/Makefile
@@ -57,7 +57,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/static_unified_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/static_unified_memory/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/unified_memory_advice/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/unified_memory_advice/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   virtual_memory
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/virtual_memory/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Virtual-Memory-Management/virtual_memory/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
   p2p_memory_access \
   p2p_memory_access_host_staging
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/device_enumeration/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/device_enumeration/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/device_selection/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/device_selection/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/multi_device_synchronization/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/multi_device_synchronization/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/p2p_memory_access/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/p2p_memory_access/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/p2p_memory_access_host_staging/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Multi-Device-Management/p2p_memory_access_host_staging/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Reference/CUDA-to-HIP-API-Function-Comparison/Makefile
+++ b/HIP-Doc/Reference/CUDA-to-HIP-API-Function-Comparison/Makefile
@@ -25,6 +25,8 @@ ifeq ($(GPU_RUNTIME), CUDA) # Only supported on CUDA
     block_reduction
 endif
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Reference/CUDA-to-HIP-API-Function-Comparison/block_reduction/Makefile
+++ b/HIP-Doc/Reference/CUDA-to-HIP-API-Function-Comparison/block_reduction/Makefile
@@ -51,7 +51,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cu
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Reference/HIP-Complex-Math-API/Makefile
+++ b/HIP-Doc/Reference/HIP-Complex-Math-API/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   complex_math
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Reference/HIP-Complex-Math-API/complex_math/Makefile
+++ b/HIP-Doc/Reference/HIP-Complex-Math-API/complex_math/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Reference/HIP-Math-API/Makefile
+++ b/HIP-Doc/Reference/HIP-Math-API/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   math
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Reference/HIP-Math-API/math/Makefile
+++ b/HIP-Doc/Reference/HIP-Math-API/math/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/Makefile
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/Makefile
@@ -26,6 +26,8 @@ ifeq ($(GPU_RUNTIME), HIP) # Only supported on HIP
     low_precision_float_fp16
 endif
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -34,4 +36,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp16/Makefile
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp16/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/Makefile
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Reference/Makefile
+++ b/HIP-Doc/Reference/Makefile
@@ -26,6 +26,8 @@ SUBDIRECTORIES := \
   HIP-Math-API \
   Low-Precision-Floating-Point-Types
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -34,4 +36,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Tutorials/Makefile
+++ b/HIP-Doc/Tutorials/Makefile
@@ -23,6 +23,8 @@
 SUBDIRECTORIES := \
   Programming-Patterns
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Tutorials/Programming-Patterns/Makefile
+++ b/HIP-Doc/Tutorials/Programming-Patterns/Makefile
@@ -27,6 +27,8 @@ SUBDIRECTORIES := \
   kmeans \
   matrix_multiplication
 
+SKIP_FROM_TEST :=
+
 all: $(SUBDIRECTORIES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(SUBDIRECTORIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(SUBDIRECTORIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUBDIRECTORIES))
+
+.PHONY: all clean test $(SUBDIRECTORIES)

--- a/HIP-Doc/Tutorials/Programming-Patterns/bfs/Makefile
+++ b/HIP-Doc/Tutorials/Programming-Patterns/bfs/Makefile
@@ -22,6 +22,7 @@
 
 EXAMPLE := hip_bfs
 GRAPHGEN := graphgen
+TEST_ARGS := graph4096.txt
 GPU_RUNTIME := HIP
 
 # HIP variables
@@ -55,7 +56,7 @@ ICPPFLAGS += $(CPPFLAGS)
 ILDFLAGS  += $(LDFLAGS)
 ILDLIBS   += $(LDLIBS)
 
-.PHONY: all clean
+.PHONY: all clean test
 
 all: $(EXAMPLE) $(GRAPHGEN)
 
@@ -64,6 +65,9 @@ $(EXAMPLE): main.hip
 
 $(GRAPHGEN): graphgen.cpp
 	$(HOSTCXX) $(HOSTCXXFLAGS) -o $@ $<
+
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
 
 clean:
 	$(RM) $(EXAMPLE) $(GRAPHGEN) result.txt

--- a/HIP-Doc/Tutorials/Programming-Patterns/histogram_atomics/Makefile
+++ b/HIP-Doc/Tutorials/Programming-Patterns/histogram_atomics/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip image.h stb_image.h
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.hip $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Tutorials/Programming-Patterns/image_convolution/Makefile
+++ b/HIP-Doc/Tutorials/Programming-Patterns/image_convolution/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip image.h stb_image.h stb_image_write.h
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.hip $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) test_out.jpg
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Tutorials/Programming-Patterns/kmeans/Makefile
+++ b/HIP-Doc/Tutorials/Programming-Patterns/kmeans/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) kmeans_results.txt
 
-.PHONY: clean
+.PHONY: clean test

--- a/HIP-Doc/Tutorials/Programming-Patterns/matrix_multiplication/Makefile
+++ b/HIP-Doc/Tutorials/Programming-Patterns/matrix_multiplication/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/ComposableKernel/basic/Makefile
+++ b/Libraries/ComposableKernel/basic/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
 	permute \
 	reduce
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/ComposableKernel/convolution/Makefile
+++ b/Libraries/ComposableKernel/convolution/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
 	grouped_convolution
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/ComposableKernel/gemm/Makefile
+++ b/Libraries/ComposableKernel/gemm/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
 	gemm_multi_d \
 	grouped_gemm
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -36,4 +38,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/MIGraphX/Makefile
+++ b/Libraries/MIGraphX/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
 	migraphx \
 	vision
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/MIGraphX/migraphx/Makefile
+++ b/Libraries/MIGraphX/migraphx/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
 	custom_op_miopen_kernel \
 	custom_op_rocblas_kernel
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/MIGraphX/migraphx/cpp_dynamic_batch/Makefile
+++ b/Libraries/MIGraphX/migraphx/cpp_dynamic_batch/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/migraphx_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIGraphX/migraphx/cpp_parse_load_save/Makefile
+++ b/Libraries/MIGraphX/migraphx/cpp_parse_load_save/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/migraphx_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIGraphX/migraphx/custom_op_hip_kernel/Makefile
+++ b/Libraries/MIGraphX/migraphx/custom_op_hip_kernel/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/migraphx_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIGraphX/migraphx/custom_op_miopen_kernel/Makefile
+++ b/Libraries/MIGraphX/migraphx/custom_op_miopen_kernel/Makefile
@@ -57,7 +57,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/migraphx_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIGraphX/migraphx/custom_op_rocblas_kernel/Makefile
+++ b/Libraries/MIGraphX/migraphx/custom_op_rocblas_kernel/Makefile
@@ -57,7 +57,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/migraphx_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIGraphX/vision/Makefile
+++ b/Libraries/MIGraphX/vision/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
 	cpp_mnist
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/MIGraphX/vision/cpp_mnist/Makefile
+++ b/Libraries/MIGraphX/vision/cpp_mnist/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/migraphx_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIVisionX/Makefile
+++ b/Libraries/MIVisionX/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
 	canny \
 	mv_objdetect
+
+SKIP_FROM_TEST :=
 # opencv_orb
 
 all: $(EXAMPLES)
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/MIVisionX/canny/Makefile
+++ b/Libraries/MIVisionX/canny/Makefile
@@ -51,7 +51,9 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/mivisionx_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/MIVisionX/mv_objdetect/Makefile
+++ b/Libraries/MIVisionX/mv_objdetect/Makefile
@@ -74,7 +74,7 @@ GENERATED_FILES := $(BUILD_DIR)/lib/libmv_deploy.so \
                    $(BUILD_DIR)/weights.bin \
                    $(BUILD_DIR)/mv_extras/mv_extras_postproc.cpp
 
-.PHONY: all clean
+.PHONY: all clean test
 
 all: $(EXAMPLE)
 
@@ -97,6 +97,8 @@ $(GENERATED_FILES): $(MODEL_FILE)
 # Build the example
 $(EXAMPLE): main.cpp visualize.cpp $(BUILD_DIR)/mvdeploy_api.cpp $(BUILD_DIR)/mv_extras/mv_extras_postproc.cpp $(COMMON_INCLUDE_DIR)/mivisionx_utils.hpp $(GENERATED_FILES)
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp visualize.cpp $(BUILD_DIR)/mvdeploy_api.cpp $(BUILD_DIR)/mv_extras/mv_extras_postproc.cpp $(ILDLIBS)
+
+test:
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/MIVisionX/opencv_orb/Makefile
+++ b/Libraries/MIVisionX/opencv_orb/Makefile
@@ -51,7 +51,9 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/mivisionx_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/Makefile
+++ b/Libraries/Makefile
@@ -30,6 +30,8 @@ LIBRARIES := \
 	rocRAND \
 	hipRAND
 
+SKIP_FROM_TEST :=
+
 ifneq ($(GPU_RUNTIME), CUDA)
 
 ROCM_PATH ?= /opt/rocm
@@ -94,4 +96,7 @@ clean: all
 $(LIBRARIES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(LIBRARIES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(LIBRARIES))
+
+.PHONY: all clean test $(LIBRARIES)

--- a/Libraries/RCCL/Makefile
+++ b/Libraries/RCCL/Makefile
@@ -31,6 +31,8 @@ EXAMPLES := \
 	reducescatter \
 	send_recv
 
+SKIP_FROM_TEST :=
+
 
 all: $(EXAMPLES)
 
@@ -40,4 +42,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/RCCL/allgather/Makefile
+++ b/Libraries/RCCL/allgather/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/allreduce/Makefile
+++ b/Libraries/RCCL/allreduce/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/broadcast/Makefile
+++ b/Libraries/RCCL/broadcast/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/buffer_registration/Makefile
+++ b/Libraries/RCCL/buffer_registration/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/device_api/Makefile
+++ b/Libraries/RCCL/device_api/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/gradient_allreduce/Makefile
+++ b/Libraries/RCCL/gradient_allreduce/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/reduce/Makefile
+++ b/Libraries/RCCL/reduce/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/reducescatter/Makefile
+++ b/Libraries/RCCL/reducescatter/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RCCL/send_recv/Makefile
+++ b/Libraries/RCCL/send_recv/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rccl_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/RPP/Makefile
+++ b/Libraries/RPP/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
 	gamma_correction \
 	resize
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -36,4 +38,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/RPP/box_filter/Makefile
+++ b/Libraries/RPP/box_filter/Makefile
@@ -65,13 +65,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rpp_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/RPP/brightness/Makefile
+++ b/Libraries/RPP/brightness/Makefile
@@ -65,13 +65,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rpp_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/RPP/contrast/Makefile
+++ b/Libraries/RPP/contrast/Makefile
@@ -65,13 +65,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rpp_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/RPP/flip/Makefile
+++ b/Libraries/RPP/flip/Makefile
@@ -65,13 +65,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rpp_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/RPP/gamma_correction/Makefile
+++ b/Libraries/RPP/gamma_correction/Makefile
@@ -65,13 +65,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rpp_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/RPP/resize/Makefile
+++ b/Libraries/RPP/resize/Makefile
@@ -65,13 +65,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rpp_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/hipBLAS/Makefile
+++ b/Libraries/hipBLAS/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   her \
   scal
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipBLAS/gemm_strided_batched/Makefile
+++ b/Libraries/hipBLAS/gemm_strided_batched/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLAS/her/Makefile
+++ b/Libraries/hipBLAS/her/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLAS/scal/Makefile
+++ b/Libraries/hipBLAS/scal/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/Makefile
+++ b/Libraries/hipBLASLt/Makefile
@@ -63,6 +63,8 @@ EXAMPLES := \
   groupedgemm_fixed_mk_ext \
   weight_swizzle_padding
 
+SKIP_FROM_TEST :=
+
 
 all: $(EXAMPLES)
 
@@ -72,4 +74,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipBLASLt/ext_op_amax/Makefile
+++ b/Libraries/hipBLASLt/ext_op_amax/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/ext_op_layernorm/Makefile
+++ b/Libraries/hipBLASLt/ext_op_layernorm/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm/Makefile
+++ b/Libraries/hipBLASLt/gemm/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_alphavec_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_alphavec_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_amax/Makefile
+++ b/Libraries/hipBLASLt/gemm_amax/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_amax_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_amax_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_amax_with_scale/Makefile
+++ b/Libraries/hipBLASLt/gemm_amax_with_scale/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_amax_with_scale_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_amax_with_scale_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_attr_tciA_tciB/Makefile
+++ b/Libraries/hipBLASLt/gemm_attr_tciA_tciB/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_batched/Makefile
+++ b/Libraries/hipBLASLt/gemm_batched/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_batched_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_batched_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_bgradb/Makefile
+++ b/Libraries/hipBLASLt/gemm_bgradb/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_bias/Makefile
+++ b/Libraries/hipBLASLt/gemm_bias/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_bias_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_bias_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_bias_swizzle_a_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_bias_swizzle_a_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_clamp_bias/Makefile
+++ b/Libraries/hipBLASLt/gemm_clamp_bias/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_dgelu_bgradb/Makefile
+++ b/Libraries/hipBLASLt/gemm_dgelu_bgradb/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_dgelu_bgradb_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_dgelu_bgradb_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_ext_bgradb/Makefile
+++ b/Libraries/hipBLASLt/gemm_ext_bgradb/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_gelu_aux_bias/Makefile
+++ b/Libraries/hipBLASLt/gemm_gelu_aux_bias/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_gelu_aux_bias_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_gelu_aux_bias_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_get_algo_by_index_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_get_algo_by_index_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_get_all_algos/Makefile
+++ b/Libraries/hipBLASLt/gemm_get_all_algos/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_get_all_algos_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_get_all_algos_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_is_tuned_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_is_tuned_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_mix_precision/Makefile
+++ b/Libraries/hipBLASLt/gemm_mix_precision/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_mix_precision_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_mix_precision_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_mix_precision_with_amax_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_mix_precision_with_amax_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_swish_bias/Makefile
+++ b/Libraries/hipBLASLt/gemm_swish_bias/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_swizzle_a/Makefile
+++ b/Libraries/hipBLASLt/gemm_swizzle_a/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_swizzle_b/Makefile
+++ b/Libraries/hipBLASLt/gemm_swizzle_b/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_tuning_splitk_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_tuning_splitk_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_tuning_wgm_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_tuning_wgm_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_with_TF32/Makefile
+++ b/Libraries/hipBLASLt/gemm_with_TF32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_with_scale_a_b/Makefile
+++ b/Libraries/hipBLASLt/gemm_with_scale_a_b/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_with_scale_a_b_ext/Makefile
+++ b/Libraries/hipBLASLt/gemm_with_scale_a_b_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/gemm_with_scale_a_b_vector/Makefile
+++ b/Libraries/hipBLASLt/gemm_with_scale_a_b_vector/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/groupedgemm_ext/Makefile
+++ b/Libraries/hipBLASLt/groupedgemm_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/groupedgemm_fixed_mk_ext/Makefile
+++ b/Libraries/hipBLASLt/groupedgemm_fixed_mk_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/groupedgemm_get_all_algos_ext/Makefile
+++ b/Libraries/hipBLASLt/groupedgemm_get_all_algos_ext/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipBLASLt/weight_swizzle_padding/Makefile
+++ b/Libraries/hipBLASLt/weight_swizzle_padding/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblaslt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipCUB/Makefile
+++ b/Libraries/hipCUB/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   device_radix_sort \
   device_sum
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipCUB/device_radix_sort/Makefile
+++ b/Libraries/hipCUB/device_radix_sort/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipCUB/device_sum/Makefile
+++ b/Libraries/hipCUB/device_sum/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/Makefile
+++ b/Libraries/hipFFT/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   plan_z2z \
   setworkarea
 
+SKIP_FROM_TEST :=
+
 ifneq ($(GPU_RUNTIME), CUDA)
   EXAMPLES += \
     callback
@@ -41,4 +43,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipFFT/callback/Makefile
+++ b/Libraries/hipFFT/callback/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/multi_gpu/Makefile
+++ b/Libraries/hipFFT/multi_gpu/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/plan_d2z/Makefile
+++ b/Libraries/hipFFT/plan_d2z/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/plan_many_2d_r2c/Makefile
+++ b/Libraries/hipFFT/plan_many_2d_r2c/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/plan_many_2d_z2z/Makefile
+++ b/Libraries/hipFFT/plan_many_2d_z2z/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/plan_z2z/Makefile
+++ b/Libraries/hipFFT/plan_z2z/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipFFT/setworkarea/Makefile
+++ b/Libraries/hipFFT/setworkarea/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipRAND/Makefile
+++ b/Libraries/hipRAND/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   c_cpp_api \
   device_api
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipRAND/c_cpp_api/Makefile
+++ b/Libraries/hipRAND/c_cpp_api/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   simple_distributions_cpp
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp/Makefile
+++ b/Libraries/hipRAND/c_cpp_api/simple_distributions_cpp/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipRAND/device_api/Makefile
+++ b/Libraries/hipRAND/device_api/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   pseudorandom_generations \
   quasirandom_generations
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipRAND/device_api/pseudorandom_generations/Makefile
+++ b/Libraries/hipRAND/device_api/pseudorandom_generations/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipRAND/device_api/quasirandom_generations/Makefile
+++ b/Libraries/hipRAND/device_api/quasirandom_generations/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/Makefile
+++ b/Libraries/hipSOLVER/Makefile
@@ -32,6 +32,8 @@ EXAMPLES := \
   syevj_batched \
   sygvd
 
+SKIP_FROM_TEST :=
+
 # this example currently does not work with CUDA
 # https://github.com/ROCm/hipSOLVER/issues/152
 ifneq ($(GPU_RUNTIME), CUDA)
@@ -47,4 +49,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipSOLVER/gels/Makefile
+++ b/Libraries/hipSOLVER/gels/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/geqrf/Makefile
+++ b/Libraries/hipSOLVER/geqrf/Makefile
@@ -63,7 +63,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/gesvd/Makefile
+++ b/Libraries/hipSOLVER/gesvd/Makefile
@@ -63,7 +63,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/getrf/Makefile
+++ b/Libraries/hipSOLVER/getrf/Makefile
@@ -63,7 +63,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/potrf/Makefile
+++ b/Libraries/hipSOLVER/potrf/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/syevd/Makefile
+++ b/Libraries/hipSOLVER/syevd/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/syevdx/Makefile
+++ b/Libraries/hipSOLVER/syevdx/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/syevj/Makefile
+++ b/Libraries/hipSOLVER/syevj/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/syevj_batched/Makefile
+++ b/Libraries/hipSOLVER/syevj_batched/Makefile
@@ -63,7 +63,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp  $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/sygvd/Makefile
+++ b/Libraries/hipSOLVER/sygvd/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipblas_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSOLVER/sygvj/Makefile
+++ b/Libraries/hipSOLVER/sygvj/Makefile
@@ -62,7 +62,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsolver_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSPARSE/Makefile
+++ b/Libraries/hipSPARSE/Makefile
@@ -25,6 +25,8 @@ EXAMPLES := \
   handle \
   hybmv
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipSPARSE/axpyi/Makefile
+++ b/Libraries/hipSPARSE/axpyi/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsparse_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSPARSE/csrmv/Makefile
+++ b/Libraries/hipSPARSE/csrmv/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsparse_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSPARSE/handle/Makefile
+++ b/Libraries/hipSPARSE/handle/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsparse_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSPARSE/hybmv/Makefile
+++ b/Libraries/hipSPARSE/hybmv/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsparse_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSPARSELt/Makefile
+++ b/Libraries/hipSPARSELt/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   spmm \
   spmm_advanced
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipSPARSELt/spmm/Makefile
+++ b/Libraries/hipSPARSELt/spmm/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsparselt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipSPARSELt/spmm_advanced/Makefile
+++ b/Libraries/hipSPARSELt/spmm_advanced/Makefile
@@ -61,7 +61,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hipsparselt_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/Makefile
+++ b/Libraries/hipTensor/Makefile
@@ -25,6 +25,8 @@ EXAMPLES := \
   elementwise \
   reduction
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/Makefile
+++ b/Libraries/hipTensor/contraction/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   bilinear \
   scale
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/bilinear/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/Makefile
@@ -30,6 +30,8 @@ EXAMPLES := \
   f64_f32 \
   f64_f64
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -38,4 +40,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/Makefile
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/Makefile
+++ b/Libraries/hipTensor/contraction/scale/Makefile
@@ -30,6 +30,8 @@ EXAMPLES := \
   f64_f32 \
   f64_f64
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -38,4 +40,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/f16_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/f32_f16/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/f32_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/f64_f32/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/contraction/scale/f64_f64/Makefile
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/elementwise/Makefile
+++ b/Libraries/hipTensor/elementwise/Makefile
@@ -25,6 +25,8 @@ EXAMPLES := \
   permute \
   trinary
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/hipTensor/elementwise/binary/Makefile
+++ b/Libraries/hipTensor/elementwise/binary/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/elementwise/permute/Makefile
+++ b/Libraries/hipTensor/elementwise/permute/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/elementwise/trinary/Makefile
+++ b/Libraries/hipTensor/elementwise/trinary/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/hipTensor/reduction/Makefile
+++ b/Libraries/hipTensor/reduction/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/hiptensor_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocAL/Makefile
+++ b/Libraries/rocAL/Makefile
@@ -26,6 +26,8 @@ EXAMPLES := \
 	image_augmentation \
 	video
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -34,4 +36,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocAL/basic/Makefile
+++ b/Libraries/rocAL/basic/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocAL/dataloader/Makefile
+++ b/Libraries/rocAL/dataloader/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocAL/image_augmentation/Makefile
+++ b/Libraries/rocAL/image_augmentation/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocAL/video/Makefile
+++ b/Libraries/rocAL/video/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/Makefile
+++ b/Libraries/rocALUTION/Makefile
@@ -51,6 +51,8 @@ EXAMPLES := \
   var_precond \
   itsolve
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -59,4 +61,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocALUTION/amg/Makefile
+++ b/Libraries/rocALUTION/amg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/as_precond/Makefile
+++ b/Libraries/rocALUTION/as_precond/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/async/Makefile
+++ b/Libraries/rocALUTION/async/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/benchmark/Makefile
+++ b/Libraries/rocALUTION/benchmark/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/bicgstab/Makefile
+++ b/Libraries/rocALUTION/bicgstab/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/block_precond/Makefile
+++ b/Libraries/rocALUTION/block_precond/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/cg/Makefile
+++ b/Libraries/rocALUTION/cg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/cg_amg/Makefile
+++ b/Libraries/rocALUTION/cg_amg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/cg_rsamg/Makefile
+++ b/Libraries/rocALUTION/cg_rsamg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/cg_saamg/Makefile
+++ b/Libraries/rocALUTION/cg_saamg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/cmk/Makefile
+++ b/Libraries/rocALUTION/cmk/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/complex/Makefile
+++ b/Libraries/rocALUTION/complex/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/direct/Makefile
+++ b/Libraries/rocALUTION/direct/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/fcg/Makefile
+++ b/Libraries/rocALUTION/fcg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/fgmres/Makefile
+++ b/Libraries/rocALUTION/fgmres/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/fixed_point/Makefile
+++ b/Libraries/rocALUTION/fixed_point/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/gmres/Makefile
+++ b/Libraries/rocALUTION/gmres/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/idr/Makefile
+++ b/Libraries/rocALUTION/idr/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/itsolve/Makefile
+++ b/Libraries/rocALUTION/itsolve/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/key/Makefile
+++ b/Libraries/rocALUTION/key/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/me_preconditioner/Makefile
+++ b/Libraries/rocALUTION/me_preconditioner/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/mixed_precision/Makefile
+++ b/Libraries/rocALUTION/mixed_precision/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/power_method/Makefile
+++ b/Libraries/rocALUTION/power_method/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/sa_amg/Makefile
+++ b/Libraries/rocALUTION/sa_amg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/simple_spmv/Makefile
+++ b/Libraries/rocALUTION/simple_spmv/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/stencil/Makefile
+++ b/Libraries/rocALUTION/stencil/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/tns/Makefile
+++ b/Libraries/rocALUTION/tns/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/ua_amg/Makefile
+++ b/Libraries/rocALUTION/ua_amg/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocALUTION/var_precond/Makefile
+++ b/Libraries/rocALUTION/var_precond/Makefile
@@ -45,7 +45,10 @@ ILDLIBS   := -lrocalution
 $(EXAMPLE): main.cpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/Makefile
+++ b/Libraries/rocBLAS/Makefile
@@ -25,6 +25,8 @@ EXAMPLES := \
   level_2 \
   level_3
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocBLAS/level_1/Makefile
+++ b/Libraries/rocBLAS/level_1/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
   scal \
   swap
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocBLAS/level_1/axpy/Makefile
+++ b/Libraries/rocBLAS/level_1/axpy/Makefile
@@ -55,7 +55,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_1/dot/Makefile
+++ b/Libraries/rocBLAS/level_1/dot/Makefile
@@ -55,7 +55,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_1/nrm2/Makefile
+++ b/Libraries/rocBLAS/level_1/nrm2/Makefile
@@ -55,7 +55,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_1/scal/Makefile
+++ b/Libraries/rocBLAS/level_1/scal/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_1/swap/Makefile
+++ b/Libraries/rocBLAS/level_1/swap/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_2/Makefile
+++ b/Libraries/rocBLAS/level_2/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   gemv \
   her
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocBLAS/level_2/gemv/Makefile
+++ b/Libraries/rocBLAS/level_2/gemv/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_2/her/Makefile
+++ b/Libraries/rocBLAS/level_2/her/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_3/Makefile
+++ b/Libraries/rocBLAS/level_3/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   gemm \
   gemm_strided_batched
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocBLAS/level_3/gemm/Makefile
+++ b/Libraries/rocBLAS/level_3/gemm/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocBLAS/level_3/gemm_strided_batched/Makefile
+++ b/Libraries/rocBLAS/level_3/gemm_strided_batched/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocCV/Makefile
+++ b/Libraries/rocCV/Makefile
@@ -32,6 +32,8 @@ EXAMPLES := \
 	normalize \
 	warp_perspective
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -40,4 +42,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocCV/bilateral_filter/Makefile
+++ b/Libraries/rocCV/bilateral_filter/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/bnd_box/Makefile
+++ b/Libraries/rocCV/bnd_box/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/center_crop/Makefile
+++ b/Libraries/rocCV/center_crop/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/composite/Makefile
+++ b/Libraries/rocCV/composite/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/copy_make_border/Makefile
+++ b/Libraries/rocCV/copy_make_border/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/cropandresize/Makefile
+++ b/Libraries/rocCV/cropandresize/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/custom_crop/Makefile
+++ b/Libraries/rocCV/custom_crop/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/gamma_contrast/Makefile
+++ b/Libraries/rocCV/gamma_contrast/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/normalize/Makefile
+++ b/Libraries/rocCV/normalize/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocCV/warp_perspective/Makefile
+++ b/Libraries/rocCV/warp_perspective/Makefile
@@ -66,13 +66,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/Makefile
+++ b/Libraries/rocDecode/Makefile
@@ -32,6 +32,14 @@ EXAMPLES := \
 	video_decode_rgb \
 	video_to_sequence
 
+# All rocDecode tests are skipped by default: they require test data
+# (videos under $(ROCM_PATH)/share/rocdecode/) that ctest guards behind
+# `if(EXISTS …)` checks. Encoding the same conditional logic in Make is
+# possible but noisy; for now skip the whole subtree so `make test` from
+# root stays clean. To run rocDecode tests manually, cd into the leaf
+# Makefile and run `make test`.
+SKIP_FROM_TEST := $(EXAMPLES)
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -40,4 +48,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocDecode/rocdec_decode/Makefile
+++ b/Libraries/rocDecode/rocdec_decode/Makefile
@@ -81,8 +81,15 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+# Mirrors the single ctest invocation; skips cleanly if the test data
+# directory ROCDECODE_TEST_FRAMES_DIR isn't present.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@D=$(ROCM_PATH)/share/rocdecode/frames; \
+	if [ -e "$$D" ]; then \
+	    echo "==> ./$(EXAMPLE) -i $$D"; ./$(EXAMPLE) -i "$$D"; \
+	else \
+	    echo "==> Skipping (not found): $$D"; \
+	fi
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/rocdec_decode/Makefile
+++ b/Libraries/rocDecode/rocdec_decode/Makefile
@@ -81,7 +81,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocDecode/video_decode/Makefile
+++ b/Libraries/rocDecode/video_decode/Makefile
@@ -101,13 +101,17 @@ endif
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_decode/Makefile
+++ b/Libraries/rocDecode/video_decode/Makefile
@@ -101,8 +101,22 @@ endif
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+# Mirrors ctest's per-codec test entries (HEVC, AVC, AV1, VP9). Each variant
+# is skipped cleanly if its test video isn't present; runs all available
+# codecs and returns the worst exit code.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@rc=0; \
+	for v in $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 \
+	         $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4 \
+	         $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4 \
+	         $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf; do \
+	    if [ -e "$$v" ]; then \
+	        echo "==> ./$(EXAMPLE) -i $$v"; \
+	        ./$(EXAMPLE) -i "$$v" || rc=$$?; \
+	    else \
+	        echo "==> Skipping (not found): $$v"; \
+	    fi; \
+	done; exit $$rc
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/video_decode_batch/Makefile
+++ b/Libraries/rocDecode/video_decode_batch/Makefile
@@ -82,13 +82,17 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_decode_batch/Makefile
+++ b/Libraries/rocDecode/video_decode_batch/Makefile
@@ -82,8 +82,14 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+# Mirrors the single ctest invocation; skips cleanly if the test video directory isn't present.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@D=$(ROCM_PATH)/share/rocdecode/video; \
+	if [ -e "$$D" ]; then \
+	    echo "==> ./$(EXAMPLE) -i $$D -t 2"; ./$(EXAMPLE) -i "$$D" -t 2; \
+	else \
+	    echo "==> Skipping (not found): $$D"; \
+	fi
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/video_decode_mem/Makefile
+++ b/Libraries/rocDecode/video_decode_mem/Makefile
@@ -81,13 +81,17 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_decode_mem/Makefile
+++ b/Libraries/rocDecode/video_decode_mem/Makefile
@@ -81,8 +81,14 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+# Mirrors the single ctest invocation; skips cleanly if the test video isn't present.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@V=$(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4; \
+	if [ -e "$$V" ]; then \
+	    echo "==> ./$(EXAMPLE) -i $$V"; ./$(EXAMPLE) -i "$$V"; \
+	else \
+	    echo "==> Skipping (not found): $$V"; \
+	fi
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/video_decode_multi_files/Makefile
+++ b/Libraries/rocDecode/video_decode_multi_files/Makefile
@@ -81,13 +81,16 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_decode_perf/Makefile
+++ b/Libraries/rocDecode/video_decode_perf/Makefile
@@ -101,8 +101,14 @@ endif
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+# Mirrors the single ctest invocation; skips cleanly if the test video isn't present.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@V=$(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4; \
+	if [ -e "$$V" ]; then \
+	    echo "==> ./$(EXAMPLE) -i $$V"; ./$(EXAMPLE) -i "$$V"; \
+	else \
+	    echo "==> Skipping (not found): $$V"; \
+	fi
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/video_decode_perf/Makefile
+++ b/Libraries/rocDecode/video_decode_perf/Makefile
@@ -101,13 +101,17 @@ endif
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_decode_pic_files/Makefile
+++ b/Libraries/rocDecode/video_decode_pic_files/Makefile
@@ -101,13 +101,16 @@ endif
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_decode_raw/Makefile
+++ b/Libraries/rocDecode/video_decode_raw/Makefile
@@ -61,7 +61,10 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocDecode/video_decode_raw/Makefile
+++ b/Libraries/rocDecode/video_decode_raw/Makefile
@@ -61,8 +61,21 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+# Mirrors ctest's per-codec test entries (HEVC, AVC, AV1, VP9 raw bitstreams).
+# Each variant is skipped cleanly if its test video isn't present.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@rc=0; \
+	for v in $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H265.265 \
+	         $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H264.264 \
+	         $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf \
+	         $(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf; do \
+	    if [ -e "$$v" ]; then \
+	        echo "==> ./$(EXAMPLE) -i $$v"; \
+	        ./$(EXAMPLE) -i "$$v" || rc=$$?; \
+	    else \
+	        echo "==> Skipping (not found): $$v"; \
+	    fi; \
+	done; exit $$rc
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/video_decode_rgb/Makefile
+++ b/Libraries/rocDecode/video_decode_rgb/Makefile
@@ -81,8 +81,17 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp $(UTILS_DIR)/c
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+# Mirrors ctest: default and -resize variants on the same HEVC video.
 test: $(EXAMPLE)
-	./$(EXAMPLE) $(TEST_ARGS)
+	@V=$(ROCM_PATH)/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4; \
+	if [ -e "$$V" ]; then \
+	    rc=0; \
+	    echo "==> default";  ./$(EXAMPLE) -i "$$V" -of rgb || rc=$$?; \
+	    echo "==> -resize";  ./$(EXAMPLE) -i "$$V" -resize 640x360 -of rgb || rc=$$?; \
+	    exit $$rc; \
+	else \
+	    echo "==> Skipping (not found): $$V"; \
+	fi
 
 clean:
 	$(RM) $(EXAMPLE)

--- a/Libraries/rocDecode/video_decode_rgb/Makefile
+++ b/Libraries/rocDecode/video_decode_rgb/Makefile
@@ -81,13 +81,17 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp $(UTILS_DIR)/c
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocDecode/video_to_sequence/Makefile
+++ b/Libraries/rocDecode/video_to_sequence/Makefile
@@ -81,13 +81,16 @@ SOURCES := main.cpp $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp
 $(EXAMPLE): $(SOURCES) $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocdecode_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $(SOURCES) $(ILDLIBS)
 
+test:
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocFFT/Makefile
+++ b/Libraries/rocFFT/Makefile
@@ -30,6 +30,8 @@ EXAMPLES := \
   multi_gpu \
   real_complex
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -38,4 +40,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocFFT/callback/Makefile
+++ b/Libraries/rocFFT/callback/Makefile
@@ -58,7 +58,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/rocfft_utils.hpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocFFT/complex_complex/Makefile
+++ b/Libraries/rocFFT/complex_complex/Makefile
@@ -57,7 +57,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/rocfft_utils.hpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocFFT/complex_real/Makefile
+++ b/Libraries/rocFFT/complex_real/Makefile
@@ -57,7 +57,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/rocfft_utils.hpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocFFT/multi_gpu/Makefile
+++ b/Libraries/rocFFT/multi_gpu/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/rocfft_utils.hpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocFFT/real_complex/Makefile
+++ b/Libraries/rocFFT/real_complex/Makefile
@@ -57,7 +57,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/rocfft_utils.hpp $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocJPEG/Makefile
+++ b/Libraries/rocJPEG/Makefile
@@ -25,6 +25,8 @@ EXAMPLES := \
 	rocjpeg_decode_batched \
 	rocjpeg_decode_perf
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -33,4 +35,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocJPEG/rocjpeg_decode/Makefile
+++ b/Libraries/rocJPEG/rocjpeg_decode/Makefile
@@ -25,6 +25,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -38,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCJPEG_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -DEXAMPLE_DATA_DIR=\"$(CURDIR)/../data/images\"
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocjpeg -lstdc++fs
+ILDLIBS   := -lrocjpeg $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocJPEG/rocjpeg_decode/Makefile
+++ b/Libraries/rocJPEG/rocjpeg_decode/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocjpeg_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocJPEG/rocjpeg_decode_batched/Makefile
+++ b/Libraries/rocJPEG/rocjpeg_decode_batched/Makefile
@@ -25,6 +25,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -38,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCJPEG_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -DEXAMPLE_DATA_DIR=\"$(CURDIR)/../data/images\"
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocjpeg -lstdc++fs
+ILDLIBS   := -lrocjpeg $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocJPEG/rocjpeg_decode_batched/Makefile
+++ b/Libraries/rocJPEG/rocjpeg_decode_batched/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocjpeg_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocJPEG/rocjpeg_decode_perf/Makefile
+++ b/Libraries/rocJPEG/rocjpeg_decode_perf/Makefile
@@ -25,6 +25,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME := HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -38,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCJPEG_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR) -DEXAMPLE_DATA_DIR=\"$(CURDIR)/../data/images\"
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocjpeg -lstdc++fs -lpthread
+ILDLIBS   := -lrocjpeg $(CXX_FS_LIB) -lpthread
 
 ifeq ($(GPU_RUNTIME), HIP)
 	CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocJPEG/rocjpeg_decode_perf/Makefile
+++ b/Libraries/rocJPEG/rocjpeg_decode_perf/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocjpeg_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocPRIM/Makefile
+++ b/Libraries/rocPRIM/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   block_sum \
   device_sum
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocPRIM/block_sum/Makefile
+++ b/Libraries/rocPRIM/block_sum/Makefile
@@ -47,7 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocPRIM/device_sum/Makefile
+++ b/Libraries/rocPRIM/device_sum/Makefile
@@ -46,7 +46,10 @@ ILDLIBS   := $(LDLIBS)
 
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocProfiler-SDK/Makefile
+++ b/Libraries/rocProfiler-SDK/Makefile
@@ -30,6 +30,8 @@ EXAMPLES := \
   intercept_table \
   pc_sampling
 
+SKIP_FROM_TEST :=
+
 ifneq ($(ENABLE_OPENMP), OFF)
   _ROCM_DIR := $(or $(ROCM_PATH),/opt/rocm)
   ifneq ($(wildcard $(_ROCM_DIR)/bin/amdclang++),)
@@ -45,4 +47,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/api_callback_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/api_callback_tracing/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -lrocprofiler-sdk-roctx -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/code_object_isa_decode/Makefile
+++ b/Libraries/rocProfiler-SDK/code_object_isa_decode/Makefile
@@ -62,13 +62,17 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $^ $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test
 
 else
 all:
 clean:
-.PHONY: all clean
+test:
+.PHONY: all clean test
 endif

--- a/Libraries/rocProfiler-SDK/code_object_isa_decode/Makefile
+++ b/Libraries/rocProfiler-SDK/code_object_isa_decode/Makefile
@@ -29,6 +29,7 @@ GPU_RUNTIME ?= HIP
 REQUIRED_DEPS := LIBDW AMD_COMGR
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
@@ -44,7 +45,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -ldw -lamd_comgr -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk -ldw -lamd_comgr $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/code_object_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/code_object_tracing/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/code_object_tracing/Makefile
+++ b/Libraries/rocProfiler-SDK/code_object_tracing/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   device_profiling \
   device_profiling_sync
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -36,4 +38,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../../Common
 EXTERNAL_DIR := ../../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/buffer_device_serialization/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../../Common
 EXTERNAL_DIR := ../../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/callback/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/callback/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../../Common
 EXTERNAL_DIR := ../../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/device_profiling_sync/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../../Common
 EXTERNAL_DIR := ../../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/Makefile
+++ b/Libraries/rocProfiler-SDK/counter_collection/print_functional_counters/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../../Common
 EXTERNAL_DIR := ../../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/intercept_table/Makefile
+++ b/Libraries/rocProfiler-SDK/intercept_table/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/intercept_table/Makefile
+++ b/Libraries/rocProfiler-SDK/intercept_table/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/openmp_target/Makefile
+++ b/Libraries/rocProfiler-SDK/openmp_target/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD) -fopenmp
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/openmp_target/Makefile
+++ b/Libraries/rocProfiler-SDK/openmp_target/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -lrocprofiler-sdk-roctx -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN'
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/pc_sampling/Makefile
+++ b/Libraries/rocProfiler-SDK/pc_sampling/Makefile
@@ -26,6 +26,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -39,7 +40,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocProfiler-SDK/pc_sampling/Makefile
+++ b/Libraries/rocProfiler-SDK/pc_sampling/Makefile
@@ -62,7 +62,10 @@ $(CLIENT_LIB): client.cpp pcs.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 $(EXAMPLE): $(CLIENT_LIB) main.cpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ main.cpp -L. -l$(EXAMPLE)_client -Wl,-rpath,'$$ORIGIN' -lpthread
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(CLIENT_LIB)
 
-.PHONY: all clean
+.PHONY: all clean test

--- a/Libraries/rocProfiler-SDK/thread_trace/Makefile
+++ b/Libraries/rocProfiler-SDK/thread_trace/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp client.cpp $(COMMON_INCLUDE_DIR)/rocprofiler_utils.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $^ $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocProfiler-SDK/thread_trace/Makefile
+++ b/Libraries/rocProfiler-SDK/thread_trace/Makefile
@@ -25,6 +25,7 @@ COMMON_INCLUDE_DIR := ../../../Common
 EXTERNAL_DIR := ../../../External
 GPU_RUNTIME ?= HIP
 
+include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 
@@ -38,7 +39,7 @@ CXX_STD   := c++17
 ICXXFLAGS := -std=$(CXX_STD)
 ICPPFLAGS := -isystem $(ROCPROFILER_INCLUDE_DIR) -I $(COMMON_INCLUDE_DIR) -I $(EXTERNAL_DIR)
 ILDFLAGS  := -L $(ROCM_PATH)/lib
-ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx -ldw -lamd_comgr -lstdc++fs
+ILDLIBS   := -lrocprofiler-sdk -lrocprofiler-sdk-roctx -ldw -lamd_comgr $(CXX_FS_LIB)
 
 ifeq ($(GPU_RUNTIME), HIP)
   CXXFLAGS ?= -Wall -Wextra

--- a/Libraries/rocRAND/Makefile
+++ b/Libraries/rocRAND/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   c_cpp_api \
   device_api
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocRAND/c_cpp_api/Makefile
+++ b/Libraries/rocRAND/c_cpp_api/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   simple_distributions_cpp
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocRAND/c_cpp_api/simple_distributions_cpp/Makefile
+++ b/Libraries/rocRAND/c_cpp_api/simple_distributions_cpp/Makefile
@@ -65,7 +65,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocRAND/device_api/Makefile
+++ b/Libraries/rocRAND/device_api/Makefile
@@ -24,6 +24,8 @@ EXAMPLES := \
   pseudorandom_generations \
   quasirandom_generations
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -32,4 +34,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocRAND/device_api/pseudorandom_generations/Makefile
+++ b/Libraries/rocRAND/device_api/pseudorandom_generations/Makefile
@@ -65,7 +65,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocrand_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocRAND/device_api/quasirandom_generations/Makefile
+++ b/Libraries/rocRAND/device_api/quasirandom_generations/Makefile
@@ -65,7 +65,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocrand_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(COMPILER) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSOLVER/Makefile
+++ b/Libraries/rocSOLVER/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
   syev_batched \
   syev_strided_batched
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocSOLVER/getf2/Makefile
+++ b/Libraries/rocSOLVER/getf2/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSOLVER/getri/Makefile
+++ b/Libraries/rocSOLVER/getri/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSOLVER/syev/Makefile
+++ b/Libraries/rocSOLVER/syev/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSOLVER/syev_batched/Makefile
+++ b/Libraries/rocSOLVER/syev_batched/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSOLVER/syev_strided_batched/Makefile
+++ b/Libraries/rocSOLVER/syev_strided_batched/Makefile
@@ -56,7 +56,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocblas_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/Makefile
+++ b/Libraries/rocSPARSE/Makefile
@@ -26,6 +26,8 @@ EXAMPLES := \
   level_3 \
   preconditioner
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -34,4 +36,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocSPARSE/level_1/Makefile
+++ b/Libraries/rocSPARSE/level_1/Makefile
@@ -27,6 +27,8 @@ EXAMPLES := \
   roti \
   sctr
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -35,4 +37,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocSPARSE/level_1/axpyi/Makefile
+++ b/Libraries/rocSPARSE/level_1/axpyi/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_1/doti/Makefile
+++ b/Libraries/rocSPARSE/level_1/doti/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_1/gthr/Makefile
+++ b/Libraries/rocSPARSE/level_1/gthr/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_1/roti/Makefile
+++ b/Libraries/rocSPARSE/level_1/roti/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_1/sctr/Makefile
+++ b/Libraries/rocSPARSE/level_1/sctr/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/Makefile
+++ b/Libraries/rocSPARSE/level_2/Makefile
@@ -35,6 +35,8 @@ EXAMPLES := \
   spmv \
   spsv
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -43,4 +45,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocSPARSE/level_2/bsrmv/Makefile
+++ b/Libraries/rocSPARSE/level_2/bsrmv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/bsrsv/Makefile
+++ b/Libraries/rocSPARSE/level_2/bsrsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/bsrxmv/Makefile
+++ b/Libraries/rocSPARSE/level_2/bsrxmv/Makefile
@@ -53,7 +53,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp $(EXTERNAL_DIR)/CmdParser/cmdparser.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/coomv/Makefile
+++ b/Libraries/rocSPARSE/level_2/coomv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/csritsv/Makefile
+++ b/Libraries/rocSPARSE/level_2/csritsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/csrmv/Makefile
+++ b/Libraries/rocSPARSE/level_2/csrmv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/csrsv/Makefile
+++ b/Libraries/rocSPARSE/level_2/csrsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/ellmv/Makefile
+++ b/Libraries/rocSPARSE/level_2/ellmv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/gebsrmv/Makefile
+++ b/Libraries/rocSPARSE/level_2/gebsrmv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/gemvi/Makefile
+++ b/Libraries/rocSPARSE/level_2/gemvi/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/spitsv/Makefile
+++ b/Libraries/rocSPARSE/level_2/spitsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/spmv/Makefile
+++ b/Libraries/rocSPARSE/level_2/spmv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_2/spsv/Makefile
+++ b/Libraries/rocSPARSE/level_2/spsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/Makefile
+++ b/Libraries/rocSPARSE/level_3/Makefile
@@ -30,6 +30,8 @@ EXAMPLES := \
   sddmm \
   spsm
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -38,4 +40,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocSPARSE/level_3/bsrmm/Makefile
+++ b/Libraries/rocSPARSE/level_3/bsrmm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/bsrsm/Makefile
+++ b/Libraries/rocSPARSE/level_3/bsrsm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/csrmm/Makefile
+++ b/Libraries/rocSPARSE/level_3/csrmm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/csrsm/Makefile
+++ b/Libraries/rocSPARSE/level_3/csrsm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/gebsrmm/Makefile
+++ b/Libraries/rocSPARSE/level_3/gebsrmm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/gemmi/Makefile
+++ b/Libraries/rocSPARSE/level_3/gemmi/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/sddmm/Makefile
+++ b/Libraries/rocSPARSE/level_3/sddmm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/spmm/Makefile
+++ b/Libraries/rocSPARSE/level_3/spmm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/level_3/spsm/Makefile
+++ b/Libraries/rocSPARSE/level_3/spsm/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/Makefile
@@ -29,6 +29,8 @@ EXAMPLES := \
   gpsv \
   gtsv
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -37,4 +39,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocSPARSE/preconditioner/bsric0/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/bsric0/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/bsrilu0/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/bsrilu0/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/csric0/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/csric0/Makefile
@@ -52,7 +52,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/csrilu0/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/csrilu0/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/csritilu0/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/csritilu0/Makefile
@@ -52,7 +52,10 @@ ILDLIBS += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/gpsv/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/gpsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocSPARSE/preconditioner/gtsv/Makefile
+++ b/Libraries/rocSPARSE/preconditioner/gtsv/Makefile
@@ -52,7 +52,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): main.cpp $(COMMON_INCLUDE_DIR)/example_utils.hpp $(COMMON_INCLUDE_DIR)/rocsparse_utils.hpp
 	$(CXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocThrust/Makefile
+++ b/Libraries/rocThrust/Makefile
@@ -28,6 +28,8 @@ EXAMPLES := \
   saxpy \
   vectors
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -36,4 +38,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocThrust/device_ptr/Makefile
+++ b/Libraries/rocThrust/device_ptr/Makefile
@@ -47,8 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
-
+.PHONY: clean test

--- a/Libraries/rocThrust/norm/Makefile
+++ b/Libraries/rocThrust/norm/Makefile
@@ -47,7 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocThrust/reduce_sum/Makefile
+++ b/Libraries/rocThrust/reduce_sum/Makefile
@@ -47,7 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocThrust/remove_points/Makefile
+++ b/Libraries/rocThrust/remove_points/Makefile
@@ -47,7 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocThrust/saxpy/Makefile
+++ b/Libraries/rocThrust/saxpy/Makefile
@@ -47,7 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocThrust/vectors/Makefile
+++ b/Libraries/rocThrust/vectors/Makefile
@@ -47,7 +47,10 @@ ILDLIBS   := $(LDLIBS)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/Makefile
+++ b/Libraries/rocWMMA/Makefile
@@ -33,6 +33,8 @@ EXAMPLES := \
   simple_sgemm \
   simple_sgemv
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -41,4 +43,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocWMMA/hiprtc_gemm/Makefile
+++ b/Libraries/rocWMMA/hiprtc_gemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/perf_dgemm/Makefile
+++ b/Libraries/rocWMMA/perf_dgemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/perf_hgemm/Makefile
+++ b/Libraries/rocWMMA/perf_hgemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/perf_i8gemm/Makefile
+++ b/Libraries/rocWMMA/perf_i8gemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/perf_sgemm/Makefile
+++ b/Libraries/rocWMMA/perf_sgemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/simple_dgemm/Makefile
+++ b/Libraries/rocWMMA/simple_dgemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/simple_dgemv/Makefile
+++ b/Libraries/rocWMMA/simple_dgemv/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/simple_dlrm/Makefile
+++ b/Libraries/rocWMMA/simple_dlrm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/simple_hgemm/Makefile
+++ b/Libraries/rocWMMA/simple_hgemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/simple_sgemm/Makefile
+++ b/Libraries/rocWMMA/simple_sgemm/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Libraries/rocWMMA/simple_sgemv/Makefile
+++ b/Libraries/rocWMMA/simple_sgemv/Makefile
@@ -56,7 +56,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(OFFLOAD_ARCH_FLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 endif
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ SUB_PROJECTS := \
   Programming-Guide \
   Tools
 
+SKIP_FROM_TEST :=
+
 all: $(SUB_PROJECTS)
 
 configure:
@@ -39,4 +41,7 @@ clean: all
 $(SUB_PROJECTS):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all configure clean $(SUB_PROJECTS)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(SUB_PROJECTS))
+
+.PHONY: all configure clean test $(SUB_PROJECTS)

--- a/Programming-Guide/Makefile
+++ b/Programming-Guide/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   Tutorials
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Programming-Guide/Tutorials/Makefile
+++ b/Programming-Guide/Tutorials/Makefile
@@ -23,6 +23,8 @@
 EXAMPLES := \
   Performance-Optimization
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -31,4 +33,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Programming-Guide/Tutorials/Performance-Optimization/Makefile
+++ b/Programming-Guide/Tutorials/Performance-Optimization/Makefile
@@ -26,6 +26,8 @@ EXAMPLES := \
   tiling_matrix_multiply \
   tiling_matrix_transpose
 
+SKIP_FROM_TEST :=
+
 all: $(EXAMPLES)
 
 clean: TARGET=clean
@@ -34,4 +36,7 @@ clean: all
 $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean $(EXAMPLES)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+
+.PHONY: all clean test $(EXAMPLES)

--- a/Programming-Guide/Tutorials/Performance-Optimization/basic_image_gamma_correction/Makefile
+++ b/Programming-Guide/Tutorials/Performance-Optimization/basic_image_gamma_correction/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): basic_image_gamma_correction.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Programming-Guide/Tutorials/Performance-Optimization/grid_stride_image_gamma_correction/Makefile
+++ b/Programming-Guide/Tutorials/Performance-Optimization/grid_stride_image_gamma_correction/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): grid_stride_image_gamma_correction.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Programming-Guide/Tutorials/Performance-Optimization/tiling_matrix_multiply/Makefile
+++ b/Programming-Guide/Tutorials/Performance-Optimization/tiling_matrix_multiply/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): tiling_matrix_multiply.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Programming-Guide/Tutorials/Performance-Optimization/tiling_matrix_transpose/Makefile
+++ b/Programming-Guide/Tutorials/Performance-Optimization/tiling_matrix_transpose/Makefile
@@ -53,7 +53,10 @@ ILDLIBS   += $(LDLIBS)
 $(EXAMPLE): tiling_matrix_transpose.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Only a subset of the examples support building via Make. Some examples depend on
 
 The configure script writes a `config.mk` file that each Makefile includes to check for required dependencies. To rebuild after installing new libraries, re-run `./configure.sh` and then `make clean && make`.
 
+`make test` from the repo root cascades through every leaf Makefile and runs each example binary as a smoke test. A leaf can declare its test invocation via the `TEST_ARGS` variable (e.g. `TEST_ARGS := graph4096.txt` in `HIP-Doc/Tutorials/Programming-Patterns/bfs/Makefile`); the default is no arguments. To override at runtime — for example to point a rocDecode test at custom video data — set `TEST_ARGS` on the command line or in the environment:
+
+```sh
+$ make test TEST_ARGS="--size=8192 --verbose"     # one-off
+$ TEST_ARGS="-i /path/to/video.mp4" make test     # via environment
+```
+
+Per-directory test exclusions live in each parent Makefile's `SKIP_FROM_TEST` list (e.g. `Libraries/rocDecode/Makefile` skips its leaves by default because they need test data not always installed).
+
 ### Linux with Docker
 
 Alternatively, instead of installing the prerequisites on the system, the [Dockerfiles](https://github.com/ROCm/rocm-examples/tree/amd-staging/Dockerfiles/) in this repository can be used to build images that provide all required prerequisites. Note, that the ROCm kernel GPU driver still needs to be installed on the host system.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The configure script writes a `config.mk` file that each Makefile includes to ch
 `make test` from the repo root cascades through every leaf Makefile and runs each example binary as a smoke test. A leaf can declare its test invocation via the `TEST_ARGS` variable (e.g. `TEST_ARGS := graph4096.txt` in `HIP-Doc/Tutorials/Programming-Patterns/bfs/Makefile`); the default is no arguments. To override at runtime — for example to point a rocDecode test at custom video data — set `TEST_ARGS` on the command line or in the environment:
 
 ```sh
-$ make test TEST_ARGS="--size=8192 --verbose"     # one-off
-$ TEST_ARGS="-i /path/to/video.mp4" make test     # via environment
+make test TEST_ARGS="--size=8192 --verbose"     # one-off
+TEST_ARGS="-i /path/to/video.mp4" make test     # via environment
 ```
 
 Per-directory test exclusions live in each parent Makefile's `SKIP_FROM_TEST` list (e.g. `Libraries/rocDecode/Makefile` skips its leaves by default because they need test data not always installed).

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -23,6 +23,8 @@
 TOOLS :=
 
 ifneq ($(GPU_RUNTIME), CUDA)
+
+SKIP_FROM_TEST :=
 TOOLS += \
 	ROCgdb \
 	rocprof-compute \
@@ -38,4 +40,7 @@ clean: all
 $(TOOLS):
 	$(MAKE) -C $@
 
-.PHONY: all clean $(TOOLS)
+test: TARGET=test
+test: $(filter-out $(SKIP_FROM_TEST),$(TOOLS))
+
+.PHONY: all clean test $(TOOLS)

--- a/Tools/ROCgdb/Makefile
+++ b/Tools/ROCgdb/Makefile
@@ -49,7 +49,10 @@ all: $(EXAMPLE)
 $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Tools/rocprof-compute/Makefile
+++ b/Tools/rocprof-compute/Makefile
@@ -48,7 +48,10 @@ all: $(EXAMPLE)
 $(EXAMPLE): occupancy.hip
 	$(HIPCXX) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Tools/rocprof-systems/Makefile
+++ b/Tools/rocprof-systems/Makefile
@@ -57,7 +57,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 $(EXAMPLE_ROCTX): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(USER_API_DEFS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS) $(USER_API_LIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE) $(EXAMPLE_ROCTX)
 
-.PHONY: clean
+.PHONY: clean test

--- a/Tools/rocprofv3/Makefile
+++ b/Tools/rocprofv3/Makefile
@@ -57,7 +57,10 @@ $(EXAMPLE): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 $(EXAMPLE_ROCTX): main.hip $(COMMON_INCLUDE_DIR)/example_utils.hpp
 	$(HIPCXX) $(ICXXFLAGS) $(ROCTX_DEFS) $(ICPPFLAGS) $(ILDFLAGS) -o $@ $< $(ILDLIBS) $(ROCTX_LIBS)
 
+test: $(EXAMPLE)
+	./$(EXAMPLE) $(TEST_ARGS)
+
 clean:
 	$(RM) $(EXAMPLE)
 
-.PHONY: clean
+.PHONY: clean test


### PR DESCRIPTION
## Motivation

Closes the testing half of the Make-build CI work that was deferred from #442. With this PR `make test` from the repo root builds and runs every leaf example that registered an `add_test` in CMake, matching the existing CMake/CTest coverage. CI just orchestrates; all test command/args/timeout logic lives in the Makefiles.

This PR is **stacked on top of #442** — its diff against `amd-staging` will look much smaller once #442 lands.

## Technical Details

### Leaf Makefile `test:` target

Every leaf Makefile gains a `test:` target depending on its build target. Default invocation:

```makefile
.PHONY: test
test: $(EXAMPLE)
	./$(EXAMPLE) $(TEST_ARGS)
```

- `TEST_ARGS` is empty by default. `HIP-Doc/Tutorials/Programming-Patterns/bfs/Makefile` sets `TEST_ARGS := graph4096.txt` to mirror its CMake `add_test`.
- Leaves whose CMakeLists has no `add_test()` get an empty no-op `test:` (e.g. `HIP-Basic/{opengl_interop, vulkan_interop, static_device_library}`, `Libraries/MIVisionX/{canny, mv_objdetect, opencv_orb}`, three rocDecode examples that don't register).
- REQUIRED_DEPS leaves (~28) extend their existing SKIP_BUILD `else` no-op block with `test:` alongside `all:`/`clean:`.

### Parent Makefile cascade with per-parent skip list

Every parent Makefile (root + ~80 intermediates) declares `SKIP_FROM_TEST :=` and:

```makefile
test: TARGET=test
test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
```

So `make test` cascades through the tree, skipping any subdirs the parent has explicitly excluded.

`Libraries/rocDecode/Makefile` populates `SKIP_FROM_TEST := $(EXAMPLES)`: all rocDecode examples need test data (videos under `$(ROCM_PATH)/share/rocdecode/`) that ctest currently guards behind `if(EXISTS …)` checks. Encoding that conditional logic in Make is doable but noisy; deferring to a follow-up. The leaf rocDecode Makefiles still have working `test:` targets so they can be run standalone via `cd Libraries/rocDecode/<example> && make test`.

### `Common/find_filesystem.mk` cleanup

The PR also converts the 19 remaining leaves with hard-coded `-lstdc++fs` to use the same `Common/find_filesystem.mk` probe introduced in #442 for the rocDecode leaves. After this, no leaf Makefile in the tree has a literal `-lstdc++fs`. Hygiene, not a bug fix — they currently work on all three CI distros.

### CI workflow

Adds `Makefile test` step after the existing test steps and `Upload Makefile test logs` artifact upload. Both gated with `if: !cancelled()` to mirror the rest of the test-side steps.

### Out of scope (potential follow-ups)

- **Per-GPU-arch test skipping** — `generate_skip_tests.py` is still used by the existing ctest step; PR2's per-directory `SKIP_FROM_TEST` is coarser.
- **Reduction tutorial gtest binaries** (`Tutorials/reduction/test/*.hip`) — no Makefile builds them today.
- **Wiring up rocDecode's conditional test-data probing** (CMake's `if(EXISTS ${ROCDECODE_TEST_VIDEO_HEVC})` pattern) — currently the entire rocDecode subtree is skipped at parent level.

## Test Plan

- Smoke-tested locally: `bitonic_sort` (bare run), `bfs` (with `TEST_ARGS`), root cascade dry-run reaches every leaf, `Libraries/rocDecode` cascade correctly does nothing.
- CI run after push: pending.

## Added/Updated documentation?

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] New examples contain proper CMake and Make files. *(no new examples)*
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [x] Check and guard against unsupported ASICs if relevant dependent libraries have limited support. *(handled via per-parent `SKIP_FROM_TEST`)*
- [x] Look over the contributing guidelines at <https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests>.