### PR TITLE
Define ENABLE_ROCDECODE using option outside of if statement

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -30,7 +30,7 @@ file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
 option(ROCM_EXAMPLES_ENABLE_CK "Enable Composable Kernel examples (disabled by default)" OFF)
-option(ENABLE_ROCDECODE "Enable rocDecode examples (enabled by default)" ON)
+option(ROCM_EXAMPLES_ENABLE_ROCDECODE "Enable rocDecode examples (enabled by default)" ON)
 
 # CMake configuration files for CUDA versions of HIP libraries are not yet
 # included under the HIP SDK for Windows.
@@ -67,7 +67,7 @@ if(
     add_subdirectory(rocBLAS)
     add_subdirectory(rocCV)
 
-    if(ENABLE_ROCDECODE)
+    if(ROCM_EXAMPLES_ENABLE_ROCDECODE)
         add_subdirectory(rocDecode)
     else()
         message(STATUS "rocDecode examples disabled, not building rocDecode examples.")

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -30,6 +30,7 @@ file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
 option(ROCM_EXAMPLES_ENABLE_CK "Enable Composable Kernel examples (disabled by default)" OFF)
+option(ENABLE_ROCDECODE "Enable rocDecode examples (enabled by default)" ON)
 
 # CMake configuration files for CUDA versions of HIP libraries are not yet
 # included under the HIP SDK for Windows.
@@ -66,7 +67,6 @@ if(
     add_subdirectory(rocBLAS)
     add_subdirectory(rocCV)
 
-    option(ENABLE_ROCDECODE "Enable rocDecode examples (enabled by default)" ON)
     if(ENABLE_ROCDECODE)
         add_subdirectory(rocDecode)
     else()


### PR DESCRIPTION
## Motivation

`ENABLE_ROCDECODE` is getting ignored by CMake because it isn't defined using `option`. If you build it with `cmake -B build -DROCDECODE_ENABLE=NO`, you get this warning message. This flag is needed because rocdecode tests don't compile for ROCm 7.13.

```
CMake Warning:
Manually-specified variables were not used by the project:

ENABLE_ROCDECODE
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
