### PR TITLE
Fix nightly CI: remove redundant GCC/elfutils install steps, preserve LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -72,7 +72,7 @@ jobs:
           echo "HIP_PLATFORM=amd" >> $GITHUB_ENV
           echo "HIP_DEVICE_LIB_PATH=${ROCM_PATH}/lib/llvm/amdgcn/bitcode" >> $GITHUB_ENV
           echo "PATH=${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocprofiler-systems" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocprofiler-systems:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "ENABLE_OPENMP=OFF" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
@@ -103,24 +103,9 @@ jobs:
           echo "HIP_PLATFORM=amd" >> $GITHUB_ENV
           echo "HIP_DEVICE_LIB_PATH=${ROCM_PATH}/lib/llvm/amdgcn/bitcode" >> $GITHUB_ENV
           echo "PATH=${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocprofiler-systems" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocprofiler-systems:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
-
-      - name: Upgrade elfutils (SLES)
-        if: ${{ startsWith(inputs.distro, 'sles') && matrix.install_method == 'tarball' }}
-        run: |
-          zypper -qni install -y bzip2 m4 zlib-devel
-          wget https://sourceware.org/elfutils/ftp/0.186/elfutils-0.186.tar.bz2
-          tar -xjf elfutils-0.186.tar.bz2
-          cd elfutils-0.186
-          ./configure --disable-debuginfod --disable-libdebuginfod
-          make -j$(nproc)
-          make install
-          ldconfig
-          cd ..
-          rm -rf elfutils-0.186*
-          echo "LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
       - name: Upgrade GCC (Ubuntu 22.04)
         if: ${{ inputs.distro == 'ubuntu-22.04' }}
@@ -132,16 +117,6 @@ jobs:
           apt-get install -y gcc-13 g++-13
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
             --slave /usr/bin/g++ g++ /usr/bin/g++-13
-
-      - name: Upgrade GCC (SLES)
-        if: ${{ startsWith(inputs.distro, 'sles') }}
-        run: |
-          zypper -qni addrepo -G https://download.opensuse.org/distribution/leap/15.6/repo/oss/ leap-oss
-          zypper -qni install -y gcc13-c++ libstdc++6-devel-gcc13
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130
-          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 130
-          update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 130
-          update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-13 130
 
       - name: Makefile build
         run: |

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -107,17 +107,6 @@ jobs:
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
-      - name: Upgrade GCC (Ubuntu 22.04)
-        if: ${{ inputs.distro == 'ubuntu-22.04' }}
-        run: |
-          apt-get update -qq
-          apt-get install -y software-properties-common
-          add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          apt-get update -qq
-          apt-get install -y gcc-13 g++-13
-          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
-            --slave /usr/bin/g++ g++ /usr/bin/g++-13
-
       - name: Makefile build
         run: |
           ./Scripts/configure.sh --rocm-path="${ROCM_PATH}"


### PR DESCRIPTION
## Summary

The nightly CI was failing on all 4 SLES 15.7 jobs. Root cause: the workflow assumed a bare OS image, but the Docker images for both SLES 15.7 and Ubuntu 22.04 already ship with GCC 13 and elfutils pre-installed.

- The `Upgrade GCC (SLES)` step called `zypper addrepo leap-oss`, which exits code 4 because the alias already exists in the image — failing every SLES job before any build ran.
- The `Upgrade elfutils (SLES)` step built elfutils 0.186 from source, which is already installed to `/usr/local/lib` in the image.
- Both `Setup environment variables` steps overwrote `LD_LIBRARY_PATH` entirely, discarding the image's `/opt/vulkan-sdk/.../lib` path — causing `amdflang --help` to return exit code 255 in the wheel sanity check.
- The `Upgrade GCC (Ubuntu 22.04)` step installs gcc-13 from a PPA, but GCC 13.4.0 is already the default `gcc` in the Ubuntu image.

## Changes

- Remove `Upgrade GCC (SLES)` step
- Remove `Upgrade elfutils (SLES)` step
- Remove `Upgrade GCC (Ubuntu 22.04)` step
- Append to `LD_LIBRARY_PATH` (`:${LD_LIBRARY_PATH}`) in both `Setup environment variables` steps instead of overwriting it

## Test plan

- [x] Triggered `ci_nightly.yml` manually on this branch for `sles-15.7` + `gfx1100` + all install methods — **passed**
- [x] Triggered `ci_nightly.yml` manually on this branch for `sles-15.7` + `gfx1151` + all install methods — **passed**