### PR TITLE
Add option ROCM_EXAMPLES_ENABLE_HIPDNN when buildling rocm-examples to give users option to not build any hipDNN tests. hipDNN requires gcc13 to build tests for it.

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
 option(ROCM_EXAMPLES_ENABLE_CK "Enable Composable Kernel examples (disabled by default)" OFF)
 option(ROCM_EXAMPLES_ENABLE_ROCDECODE "Enable rocDecode examples (enabled by default)" ON)
+option(ROCM_EXAMPLES_ENABLE_HIPDNN "Enable hipDNN examples (enabled by default)" ON)
 
 # CMake configuration files for CUDA versions of HIP libraries are not yet
 # included under the HIP SDK for Windows.
@@ -52,7 +53,11 @@ if(
     if(CMAKE_VERSION VERSION_LESS "3.25.2")
         message(WARNING "CMake version < 3.25.2, not building hipDNN examples.")
     else()
-        add_subdirectory(hipDNN)
+        if (ROCM_EXAMPLES_ENABLE_HIPDNN)
+            add_subdirectory(hipDNN)
+        else()
+            message(STATUS "hipDNN examples disabled, not building hipDNN examples.")
+        endif()
     endif()
     add_subdirectory(hipFFT)
     add_subdirectory(hipRAND)


### PR DESCRIPTION
## Motivation

hipDNN requires users to have gcc 13 installed on the machine. If they don't have this installed, rocm-examples will fail to compile on the `amd-staging` branch due to the error below. Users should be able to disable hipDNN tests from building if they don't have gcc13 installed so that they can still build rocm-examples.

```
opt/rocm/core/include/hipdnn/test_sdk/hipdnn_test_sdk/utilities/TestTolerances.hpp: In function ‘constexpr float hipdnn_test_sdk::utilities::layernorm::getTolerance()’:
/opt/rocm/core/include/hipdnn/test_sdk/hipdnn_test_sdk/utilities/TestTolerances.hpp:344:23: error: static assertion failed: Type not supported
  344 |         static_assert(false, "Type not supported");
      |                       ^~~~~
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

I was able to build rocm-examples by setting -DROCM_EXAMPLES_ENABLE_HIPDNN="OFF" and DROCM_EXAMPLES_ENABLE_HIPDNN="ON"

## Test Result

Was able to build and run rocm-examples.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
