### PR TITLE
Enable hipTensor examples on Windows

### DIFF
--- a/Libraries/hipTensor/CMakeLists.txt
+++ b/Libraries/hipTensor/CMakeLists.txt
@@ -27,11 +27,6 @@ include(CTest)
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})
 
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
 include("${CMAKE_CURRENT_LIST_DIR}/../../Common/ROCmPath.cmake")
 
 find_package(hiptensor QUIET)

--- a/Libraries/hipTensor/README.md
+++ b/Libraries/hipTensor/README.md
@@ -2,26 +2,32 @@
 
 ## Summary
 
-The examples in this subdirectory showcase the functionality of the [hipTensor](https://github.com/ROCm/hipTensor) library. The examples build only on Linux for the ROCm (AMD GPU) backend.
+The examples in this subdirectory showcase the functionality of the [hipTensor](https://github.com/ROCm/hipTensor) library. The examples build on both Linux and Windows for the ROCm (AMD GPU) backend.
 
 ## Prerequisites
 
 ### Linux
 
-- [CMake](https://cmake.org/download/) (at least version 3.21).
-- Or GNU Make - available via the distribution's package manager.
-- [ROCm](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html) (at least version 7.x.x).
+- [CMake](https://cmake.org/download/) (at least version 3.21)
+- OR GNU Make - available via the distribution's package manager
+- [ROCm](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html) (at least version 7.x.x)
 - [hipTensor](https://github.com/ROCm/hipTensor): `hiptensor` package available from [repo.radeon.com](https://repo.radeon.com/rocm/). The repository is added during the standard ROCm [install procedure](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html).
 
 ### Windows
 
-Support for Windows will be included in the future.
+- [Visual Studio](https://visualstudio.microsoft.com/) 2019 or 2022 with the "Desktop Development with C++" workload
+- ROCm toolchain for Windows (No public release yet)
+  - The Visual Studio ROCm extension needs to be installed to build with the solution files.
+- [hipTensor](https://github.com/ROCm/hipTensor)
+  - Installed as part of the ROCm SDK on Windows for ROCm platform.
+- [CMake](https://cmake.org/download/) (optional, to build with CMake. Requires at least version 3.21)
+- [Ninja](https://ninja-build.org/) (optional, to build with CMake)
 
 ## Building
 
 ### Linux
 
-Ensure the dependencies are installed, or use the [provided Dockerfiles](../../Dockerfiles/) to build and run the examples in a containerized environment that has all prerequisites installed.
+Make sure that the dependencies are installed, or use the [provided Dockerfiles](../../Dockerfiles/) to build and run the examples in a containerized environment that has all prerequisites installed.
 
 #### Using CMake
 
@@ -37,3 +43,15 @@ All examples can be built by a single invocation to Make or be built independent
 
 - `$ cd Libraries/hipTensor`
 - `$ make`
+
+### Windows
+
+#### Visual Studio
+
+Visual Studio solution files are available for the individual examples. To build all examples for hipTensor open the top level solution file [ROCm-Examples-VS2019.sln](../../ROCm-Examples-VS2019.sln) and filter for hipTensor.
+
+For more detailed build instructions refer to the top level [README.md](../../README.md#visual-studio).
+
+#### CMake
+
+All examples in the `hipTensor` subdirectory can either be built by a single CMake project or be built independently. For build instructions refer to the top-level [README.md](../../README.md#cmake-2).

--- a/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/bf16_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/cf32_cf32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f16_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_bf16/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f16/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f32_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/bilinear/f64_f64/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/bf16_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/cf32_cf32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f16_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_bf16/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f16/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f32_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f32/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
+++ b/Libraries/hipTensor/contraction/scale/f64_f64/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/binary/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/permute/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
+++ b/Libraries/hipTensor/elementwise/trinary/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()

--- a/Libraries/hipTensor/reduction/CMakeLists.txt
+++ b/Libraries/hipTensor/reduction/CMakeLists.txt
@@ -34,6 +34,8 @@ endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/ROCmPath.cmake")
+
 find_package(hiptensor REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/FilterHIPArchitectures.cmake")
@@ -47,13 +49,6 @@ set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD 17)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_EXTENSIONS OFF)
 set(CMAKE_${ROCM_EXAMPLES_GPU_LANGUAGE}_STANDARD_REQUIRED ON)
 select_hip_platform()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    message(WARNING "hipTensor examples are only available on Linux")
-    return()
-endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../Common/ROCmPath.cmake")
 
 add_executable(${example_name} main.cpp)
 # Make example runnable using ctest
@@ -69,3 +64,7 @@ target_include_directories(
 set_source_files_properties(main.cpp PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
 
 install(TARGETS ${example_name})
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)
+endif()


### PR DESCRIPTION
## Motivation

hipTensor now supports Windows. The previous PR #454 incorrectly blocked building hipTensor examples on Windows with a Linux-only guard. This PR removes that restriction.

## Technical Details

- Remove `if(CMAKE_SYSTEM_NAME MATCHES "Windows") ... return() endif()` guards from all 21 hipTensor CMakeLists files
- Add `install(IMPORTED_RUNTIME_ARTIFACTS hiptensor)` for Windows in each leaf CMakeLists
- Hoist `ROCmPath.cmake` include to before `find_package(hiptensor)` in all leaf files, so `CMAKE_PREFIX_PATH` is populated before package discovery on Windows

## Test Plan

- Linux: existing CI coverage
- Windows: hipTensor examples should now configure and build

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.