### PR TITLE
Fix low-precision float CUDA guards

### DIFF
--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp16/CMakeLists.txt
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp16/CMakeLists.txt
@@ -25,16 +25,16 @@ set(example_name hip_low_precision_float_fp16)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")
-    message(FATAL_ERROR "This example is not supported for the CUDA runtime.")
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     message(FATAL_ERROR "This example is not supported on Windows.")
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
 select_gpu_language()
+
+if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")
+    message(FATAL_ERROR "This example is not supported for the CUDA runtime.")
+endif()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()

--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/CMakeLists.txt
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/CMakeLists.txt
@@ -25,12 +25,12 @@ set(example_name hip_low_precision_float_fp8)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
+include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
+select_gpu_language()
+
 if(${ROCM_EXAMPLES_GPU_LANGUAGE} STREQUAL "CUDA")
     message(FATAL_ERROR "This example is not supported for the CUDA runtime.")
 endif()
-
-include("${CMAKE_CURRENT_LIST_DIR}/../../../../Common/HipPlatform.cmake")
-select_gpu_language()
 
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
 select_hip_platform()


### PR DESCRIPTION
## Motivation

The CUDA guard in the low precision floating-point examples' `CMakeLists.txt` is called before `ROCM_EXAMPLES_GPU_LANGUAGE` is defined. This will cause an error when building the examples individually.

## Technical Details

Moves the guard to the correct location.

## Test Plan

Tested locally.

## Test Result

Works.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
