### PR TITLE
fix: redirect assembly_to_executable generated .s files to build directory

### DIFF
--- a/HIP-Basic/assembly_to_executable/CMakeLists.txt
+++ b/HIP-Basic/assembly_to_executable/CMakeLists.txt
@@ -80,13 +80,13 @@ endif()
 # Generate device assemblies
 foreach(HIP_ARCHITECTURE ${GPU_ARCHITECTURES})
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/main_${HIP_ARCHITECTURE}.s
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/main_${HIP_ARCHITECTURE}.s
         COMMAND
             ${CMAKE_HIP_COMPILER} -S --cuda-device-only
             --offload-arch=${HIP_ARCHITECTURE} -I
             ${CMAKE_CURRENT_SOURCE_DIR}/../../Common
             ${CMAKE_CURRENT_SOURCE_DIR}/main.hip -o
-            ${CMAKE_CURRENT_SOURCE_DIR}/main_${HIP_ARCHITECTURE}.s
+            ${CMAKE_CURRENT_BINARY_DIR}/main_${HIP_ARCHITECTURE}.s
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/main.hip
         VERBATIM
         COMMENT "Generating ASM main_${HIP_ARCHITECTURE}.s"
@@ -102,9 +102,9 @@ foreach(HIP_ARCHITECTURE ${GPU_ARCHITECTURES})
         COMMAND
             ${CMAKE_HIP_COMPILER} -fPIC -target amdgcn-amd-amdhsa
             -mcpu=${HIP_ARCHITECTURE}
-            ${CMAKE_CURRENT_SOURCE_DIR}/main_${HIP_ARCHITECTURE}.s -o
+            ${CMAKE_CURRENT_BINARY_DIR}/main_${HIP_ARCHITECTURE}.s -o
             ${CMAKE_CURRENT_BINARY_DIR}/main_${HIP_ARCHITECTURE}.${OBJ_TYPE}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/main_${HIP_ARCHITECTURE}.s
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/main_${HIP_ARCHITECTURE}.s
         VERBATIM
         COMMENT "Compiling ASM main_${HIP_ARCHITECTURE}.${OBJ_TYPE}"
     )


### PR DESCRIPTION
## Problem

The two foreach loops in `HIP-Basic/assembly_to_executable/CMakeLists.txt` that generate and assemble device `.s` files were writing output to `CMAKE_CURRENT_SOURCE_DIR`. This causes a hard build failure when the source tree is not writable, which is the case in any Docker-based CI setup where the source is mounted read-only (e.g. `-v /path/to/rocm-examples:/workspace/rocm-examples:ro`):

**Error Log**: 
```
error: unable to open output file '/workspace/rocm-examples/HIP-Basic/assembly_to_executable/main_gfx1100.s': 'Operation not permitted'
```

## Fix

Redirect the OUTPUT, the `-o` compiler flag, and DEPENDS in both loops to `CMAKE_CURRENT_BINARY_DIR`, which is the correct location for all generated build artifacts per standard CMake convention. The source directory is left untouched.