### PR TITLE
fix: skip the entire FFmpeg-dependent build

### DIFF
--- a/Libraries/rocDecode/video_decode/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode/CMakeLists.txt
@@ -46,6 +46,17 @@ include("../../../Common/ROCmPath.cmake")
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocdecode-host 1.0.0 QUIET)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
@@ -98,13 +109,6 @@ else()
 endif()
 
 set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
-
-# disable FFmpeg tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
-# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
-set(USING_THE_ROCK OFF)
-if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
-  set(USING_THE_ROCK ON)
-endif()
 
 if (NOT USING_THE_ROCK)
     set(ROCDECODE_TEST_VIDEO_HEVC "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")

--- a/Libraries/rocDecode/video_decode_batch/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_batch/CMakeLists.txt
@@ -48,6 +48,17 @@ find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 
 add_executable(${example_name}
@@ -87,13 +98,6 @@ set_source_files_properties(
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
-
-# disable FFmpeg tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
-# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
-set(USING_THE_ROCK OFF)
-if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
-  set(USING_THE_ROCK ON)
-endif()
 
 if (NOT USING_THE_ROCK)
     set(ROCDECODE_TEST_VIDEO_DIR "${ROCM_PATH}/share/rocdecode/video")

--- a/Libraries/rocDecode/video_decode_mem/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_mem/CMakeLists.txt
@@ -46,6 +46,17 @@ include("../../../Common/ROCmPath.cmake")
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 
 add_executable(${example_name}
@@ -83,13 +94,6 @@ set_source_files_properties(
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
-
-# disable FFmpeg tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
-# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
-set(USING_THE_ROCK OFF)
-if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
-  set(USING_THE_ROCK ON)
-endif()
 
 if (NOT USING_THE_ROCK)
     set(ROCDECODE_TEST_VIDEO "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")

--- a/Libraries/rocDecode/video_decode_multi_files/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_multi_files/CMakeLists.txt
@@ -46,6 +46,17 @@ include("../../../Common/ROCmPath.cmake")
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 
 add_executable(${example_name}

--- a/Libraries/rocDecode/video_decode_perf/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_perf/CMakeLists.txt
@@ -46,6 +46,17 @@ include("../../../Common/ROCmPath.cmake")
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocdecode-host 1.0.0 QUIET)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
@@ -97,13 +108,6 @@ else()
 endif()
 
 set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE})
-
-# disable FFmpeg tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
-# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
-set(USING_THE_ROCK OFF)
-if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
-  set(USING_THE_ROCK ON)
-endif()
 
 if (NOT USING_THE_ROCK)
     set(ROCDECODE_TEST_VIDEO_HEVC "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")

--- a/Libraries/rocDecode/video_decode_pic_files/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_pic_files/CMakeLists.txt
@@ -46,6 +46,17 @@ include("../../../Common/ROCmPath.cmake")
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
 find_package(rocdecode-host 1.0.0 QUIET)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)

--- a/Libraries/rocDecode/video_decode_rgb/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_rgb/CMakeLists.txt
@@ -45,6 +45,17 @@ include("../../../Common/ROCmPath.cmake")
 
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
@@ -89,13 +100,6 @@ set_source_files_properties(
     ${ROCM_PATH}/share/rocdecode/utils/resize_kernels.cpp
     PROPERTIES LANGUAGE ${ROCM_EXAMPLES_GPU_LANGUAGE}
 )
-
-# disable FFmpeg tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
-# Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
-set(USING_THE_ROCK OFF)
-if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
-  set(USING_THE_ROCK ON)
-endif()
 
 if (NOT USING_THE_ROCK)
     set(ROCDECODE_TEST_VIDEO_HEVC "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4")

--- a/Libraries/rocDecode/video_to_sequence/CMakeLists.txt
+++ b/Libraries/rocDecode/video_to_sequence/CMakeLists.txt
@@ -46,6 +46,17 @@ include("../../../Common/ROCmPath.cmake")
 
 find_package(HIP REQUIRED)
 find_package(rocdecode REQUIRED)
+# disable FFmpeg build and tests for TheRock, see https://github.com/ROCm/rocm-systems/pull/3768
+# TheRock ships static FFmpeg libs not compiled with -fPIC, which lld rejects
+set(USING_THE_ROCK OFF)
+if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
+  set(USING_THE_ROCK ON)
+endif()
+if(USING_THE_ROCK)
+    message(STATUS "TheRock detected: skipping ${example_name} build (FFmpeg static libs not compiled with -fPIC)")
+    return()
+endif()
+
 find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
**Summary of Changes**

All 8 rocDecode CMakeLists.txt files were modified to skip the entire FFmpeg-dependent build (not just tests) when running under TheRock.

**The Problem**

A CI log for a rocDecode example on a TheRock-based system showed this linker failure:

ld.lld: error: relocation R_X86_64_64 cannot be used against local symbol; recompile with -fPIC

The offending library: /usr/local/lib/libavcodec.a (TheRock's bundled FFmpeg).

**Root cause**: TheRock ships static FFmpeg libraries that were not compiled with -fPIC. The LLVM linker (lld) used by ROCm is stricter than GNU ld and
   hard-rejects position-dependent relocations in static libs when building a shared/position-independent target.

**What Changed**

**Before**: USING_THE_ROCK was detected, but only used to guard the add_test() calls at the bottom — the build itself still ran and tried to link against the non-PIC static FFmpeg, crashing lld.

**After**: The guard block is moved to before find_package(FFmpeg REQUIRED), with an early return(). If TheRock is detected (by presence of ${ROCM_PATH}/lib/rocm_sysdeps/lib), CMake skips the entire example — no FFmpeg find, no build, no tests.

Three files (video_decode_multi_files, video_decode_pic_files, video_to_sequence) had no guard at all before these changes.

The reference: [rocm-systems/3768](https://github.com/ROCm/rocm-systems/pull/3768) is the upstream TheRock PR that documents why this is necessary.