### PR TITLE
Update hipDNN conv backward examples

### DIFF
--- a/Libraries/hipDNN/conv_dgrad/README.md
+++ b/Libraries/hipDNN/conv_dgrad/README.md
@@ -21,7 +21,7 @@ dx[n, c, h, w] = sum(sum(sum(dy[n, k, p, q] * w[k, c, r, s]
 4. Compute output gradient dimensions from input dimensions and convolution parameters.
 5. Create tensor attributes for the output gradient (`dy`) and filter (`w`) tensors.
 6. Configure `ConvDgradAttributes` with pre-padding, post-padding, stride, and dilation, and add the backward data convolution node to the graph.
-7. Mark the output tensor (`dx`) and build the graph.
+7. Set the output tensor (`dx`) dimensions to the original forward input shape, mark it as an output, and build the graph.
 8. Allocate host tensors and initialize with random values.
 9. Create a variant pack, query workspace size, and allocate workspace memory.
 10. Execute the graph with the variant pack and workspace.
@@ -33,6 +33,7 @@ dx[n, c, h, w] = sum(sum(sum(dy[n, k, p, q] * w[k, c, r, s]
 - The [hipDNN Frontend graph API](https://github.com/ROCm/hipDNN) is used to construct and execute the operation graph. A `graph::Graph` is created, configured with data types, and built against a hipDNN handle before execution.
 - `graph::ConvDgradAttributes` configures the convolution backward data operation, including pre-padding, post-padding, stride, and dilation parameters.
 - Unlike `ConvFpropAttributes` which uses a single `set_padding()`, the backward data operation uses `set_pre_padding()` and `set_post_padding()` to specify asymmetric padding.
+- The `dx` dimensions are set explicitly because convolution backward data output shape is not inferred from `dy`, `w`, and convolution parameters.
 - Workspace memory is required for convolution operations. The required size is queried with `graph->get_workspace_size()` and allocated before calling `graph->execute()`.
 
 ## Demonstrated API Calls

--- a/Libraries/hipDNN/conv_dgrad/main.cpp
+++ b/Libraries/hipDNN/conv_dgrad/main.cpp
@@ -82,6 +82,7 @@ bool SampleRunner::operator()(const TensorLayout& layout)
     convAttributes.set_dilation({dilH, dilW});
 
     auto dxAttr = graph->conv_dgrad(dyAttr, wAttr, convAttributes);
+    dxAttr->set_dim({n, c, h, w});
     dxAttr->set_output(true);
 
     HIPDNN_FE_CHECK_SKIPPABLE(graph->build(handle));

--- a/Libraries/hipDNN/conv_wgrad/README.md
+++ b/Libraries/hipDNN/conv_wgrad/README.md
@@ -21,7 +21,7 @@ dw[k, c, r, s] = sum(sum(sum(dy[n, k, p, q] * x[n, c, h, w]
 4. Compute output gradient dimensions from input dimensions and convolution parameters.
 5. Create tensor attributes for the output gradient (`dy`) and input (`x`) tensors.
 6. Configure `ConvWgradAttributes` with pre-padding, post-padding, stride, and dilation, and add the backward filter convolution node to the graph.
-7. Mark the output tensor (`dw`) and build the graph.
+7. Set the output tensor (`dw`) dimensions to the original forward filter shape, mark it as an output, and build the graph.
 8. Allocate host tensors and initialize with random values.
 9. Create a variant pack, query workspace size, and allocate workspace memory.
 10. Execute the graph with the variant pack and workspace.
@@ -33,6 +33,7 @@ dw[k, c, r, s] = sum(sum(sum(dy[n, k, p, q] * x[n, c, h, w]
 - The [hipDNN Frontend graph API](https://github.com/ROCm/hipDNN) is used to construct and execute the operation graph. A `graph::Graph` is created, configured with data types, and built against a hipDNN handle before execution.
 - `graph::ConvWgradAttributes` configures the convolution backward filter operation, including pre-padding, post-padding, stride, and dilation parameters.
 - Like `ConvDgradAttributes`, this uses `set_pre_padding()` and `set_post_padding()` to specify asymmetric padding.
+- The `dw` dimensions are set explicitly because convolution backward filter output shape is not inferred from `dy`, `x`, and convolution parameters.
 - Workspace memory is required for convolution operations. The required size is queried with `graph->get_workspace_size()` and allocated before calling `graph->execute()`.
 
 ## Demonstrated API Calls

--- a/Libraries/hipDNN/conv_wgrad/main.cpp
+++ b/Libraries/hipDNN/conv_wgrad/main.cpp
@@ -82,6 +82,7 @@ bool SampleRunner::operator()(const TensorLayout& layout)
     convAttributes.set_dilation({dilH, dilW});
 
     auto dwAttr = graph->conv_wgrad(dyAttr, xAttr, convAttributes);
+    dwAttr->set_dim({k, c, r, s});
     dwAttr->set_output(true);
 
     HIPDNN_FE_CHECK_SKIPPABLE(graph->build(handle));


### PR DESCRIPTION
## Summary

This PR updates the hipDNN convolution backward examples for the frontend behavior change tracked by [ROCm/rocm-libraries issue #8530](https://github.com/ROCm/rocm-libraries/issues/8530). The companion rocm-libraries change requires convolution backward data `dx` and backward weight `dw` dimensions to be set explicitly because those shapes are ambiguous to infer from `dy`, input/filter tensors, and convolution parameters.

Companion to [ROCm/rocm-libraries PR #8612](https://github.com/ROCm/rocm-libraries/pull/8612).

## Risk Assessment

Low risk. This only updates two hipDNN examples and their README descriptions so they continue to build against the new frontend contract; it does not change shared build logic or runtime libraries.

## Testing Summary

- Built the affected hipDNN examples against the local rocm-libraries feature install.
- Ran both examples with CPU verification enabled; local execution gracefully skipped provider execution because no applicable engine was available, matching the current local hipDNN sample behavior.

## Testing Checklist

- [x] hipDNN example configure/build - `cmake -S Libraries/hipDNN -B build-hipdnn -GNinja -DCMAKE_PREFIX_PATH=/home/AMD/bharriso/Source/claude-workspace/worktrees/WIP/worktrees/rocm-libraries/hipdnn-conv-bwd-explicit-output-dims/hipdnn_install -DCMAKE_CXX_COMPILER=/opt/rocm/lib/llvm/bin/clang++ && cmake --build build-hipdnn --target hipdnn_conv_dgrad hipdnn_conv_wgrad` - Status: Passed
- [x] hipDNN conv dgrad example - `./build-hipdnn/bin/hipdnn_conv_dgrad --verify-cpu` - Status: Passed; local provider reported no applicable engine and skipped execution
- [x] hipDNN conv wgrad example - `./build-hipdnn/bin/hipdnn_conv_wgrad --verify-cpu` - Status: Passed; local provider reported no applicable engine and skipped execution
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Sets `dx` dimensions explicitly in `Libraries/hipDNN/conv_dgrad/main.cpp` before marking the tensor as graph output.
- Sets `dw` dimensions explicitly in `Libraries/hipDNN/conv_wgrad/main.cpp` before marking the tensor as graph output.
- Updates the conv dgrad/wgrad READMEs to document that these output dimensions are explicit rather than frontend-inferred.