### PR TITLE
Skip rocDecode examples if rocDecode utility sources are not found

### DIFF
--- a/Libraries/rocDecode/video_decode/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode/CMakeLists.txt
@@ -50,6 +50,18 @@ find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+if(rocdecode-host_FOUND AND NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp")
+    message(WARNING "rocDecode host utility source ffmpeg_video_dec.cpp not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 set(SOURCES
     main.cpp
     "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp"

--- a/Libraries/rocDecode/video_decode/Makefile
+++ b/Libraries/rocDecode/video_decode/Makefile
@@ -30,16 +30,10 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
-
-HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
-ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
-
-HIPCXX ?= $(ROCM_PATH)/bin/hipcc
 
 # Detect which rocdecode host library is available
 ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_PATH)/lib/librocdecode-host.so ]; then \
@@ -47,6 +41,28 @@ ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_PATH)/lib/librocdecode-host.so ]; t
                               elif [ -f $(ROCM_PATH)/lib/librocdecodehost.so ]; then \
                                   echo "rocdecodehost"; \
                               fi)
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+# When the host decode library is present, the host utility source is compiled in too.
+ifneq ($(ROCDECODE_HOST_LIB),)
+    ifeq ($(wildcard $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp),)
+        $(info $(EXAMPLE): Skipping build — rocDecode host utility source ffmpeg_video_dec.cpp not found under $(UTILS_DIR))
+        SKIP_BUILD := 1
+    endif
+endif
+
+ifneq ($(SKIP_BUILD),1)
+
+HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
+ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_PATH)/bin/hipcc
 
 # Common variables and flags
 CXX_STD   := c++17

--- a/Libraries/rocDecode/video_decode_batch/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_batch/CMakeLists.txt
@@ -50,6 +50,14 @@ find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 find_package(FFmpeg REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 add_executable(${example_name}
     main.cpp
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp

--- a/Libraries/rocDecode/video_decode_batch/Makefile
+++ b/Libraries/rocDecode/video_decode_batch/Makefile
@@ -30,11 +30,20 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+
+ifneq ($(SKIP_BUILD),1)
 
 HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)

--- a/Libraries/rocDecode/video_decode_mem/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_mem/CMakeLists.txt
@@ -48,6 +48,14 @@ find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(FFmpeg REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 add_executable(${example_name}
     main.cpp
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp

--- a/Libraries/rocDecode/video_decode_mem/Makefile
+++ b/Libraries/rocDecode/video_decode_mem/Makefile
@@ -30,11 +30,20 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+
+ifneq ($(SKIP_BUILD),1)
 
 HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)

--- a/Libraries/rocDecode/video_decode_multi_files/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_multi_files/CMakeLists.txt
@@ -48,6 +48,14 @@ find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(FFmpeg REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 add_executable(${example_name}
     main.cpp
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp

--- a/Libraries/rocDecode/video_decode_multi_files/Makefile
+++ b/Libraries/rocDecode/video_decode_multi_files/Makefile
@@ -30,11 +30,20 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+
+ifneq ($(SKIP_BUILD),1)
 
 HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)

--- a/Libraries/rocDecode/video_decode_perf/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_perf/CMakeLists.txt
@@ -50,6 +50,18 @@ find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+if(rocdecode-host_FOUND AND NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp")
+    message(WARNING "rocDecode host utility source ffmpeg_video_dec.cpp not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 set(SOURCES
     main.cpp
     "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp"

--- a/Libraries/rocDecode/video_decode_perf/Makefile
+++ b/Libraries/rocDecode/video_decode_perf/Makefile
@@ -30,16 +30,10 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
-
-HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
-ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
-
-HIPCXX ?= $(ROCM_PATH)/bin/hipcc
 
 # Detect which rocdecode host library is available
 ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_PATH)/lib/librocdecode-host.so ]; then \
@@ -47,6 +41,28 @@ ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_PATH)/lib/librocdecode-host.so ]; t
                               elif [ -f $(ROCM_PATH)/lib/librocdecodehost.so ]; then \
                                   echo "rocdecodehost"; \
                               fi)
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+# When the host decode library is present, the host utility source is compiled in too.
+ifneq ($(ROCDECODE_HOST_LIB),)
+    ifeq ($(wildcard $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp),)
+        $(info $(EXAMPLE): Skipping build — rocDecode host utility source ffmpeg_video_dec.cpp not found under $(UTILS_DIR))
+        SKIP_BUILD := 1
+    endif
+endif
+
+ifneq ($(SKIP_BUILD),1)
+
+HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
+ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_PATH)/bin/hipcc
 
 # Common variables and flags
 CXX_STD   := c++17

--- a/Libraries/rocDecode/video_decode_pic_files/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_pic_files/CMakeLists.txt
@@ -50,6 +50,18 @@ find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+if(rocdecode-host_FOUND AND NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp")
+    message(WARNING "rocDecode host utility source ffmpeg_video_dec.cpp not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 set(SOURCES
     main.cpp
     "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp"

--- a/Libraries/rocDecode/video_decode_pic_files/Makefile
+++ b/Libraries/rocDecode/video_decode_pic_files/Makefile
@@ -30,16 +30,10 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
-
-HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
-ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
-
-HIPCXX ?= $(ROCM_PATH)/bin/hipcc
 
 # Detect which rocdecode host library is available
 ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_PATH)/lib/librocdecode-host.so ]; then \
@@ -47,6 +41,28 @@ ROCDECODE_HOST_LIB := $(shell if [ -f $(ROCM_PATH)/lib/librocdecode-host.so ]; t
                               elif [ -f $(ROCM_PATH)/lib/librocdecodehost.so ]; then \
                                   echo "rocdecodehost"; \
                               fi)
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+# When the host decode library is present, the host utility source is compiled in too.
+ifneq ($(ROCDECODE_HOST_LIB),)
+    ifeq ($(wildcard $(UTILS_DIR)/ffmpegvideodecode/ffmpeg_video_dec.cpp),)
+        $(info $(EXAMPLE): Skipping build — rocDecode host utility source ffmpeg_video_dec.cpp not found under $(UTILS_DIR))
+        SKIP_BUILD := 1
+    endif
+endif
+
+ifneq ($(SKIP_BUILD),1)
+
+HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
+ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
+
+HIPCXX ?= $(ROCM_PATH)/bin/hipcc
 
 # Common variables and flags
 CXX_STD   := c++17

--- a/Libraries/rocDecode/video_decode_raw/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_raw/CMakeLists.txt
@@ -47,6 +47,14 @@ find_package(rocdecode REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 add_executable(${example_name}
     main.cpp
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp

--- a/Libraries/rocDecode/video_decode_raw/Makefile
+++ b/Libraries/rocDecode/video_decode_raw/Makefile
@@ -31,6 +31,16 @@ include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
 
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+
+ifneq ($(SKIP_BUILD),1)
+
 HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)
 
@@ -81,3 +91,10 @@ clean:
 	$(RM) $(EXAMPLE)
 
 .PHONY: clean test
+
+else
+all:
+clean:
+test:
+.PHONY: all clean test
+endif

--- a/Libraries/rocDecode/video_decode_rgb/CMakeLists.txt
+++ b/Libraries/rocDecode/video_decode_rgb/CMakeLists.txt
@@ -49,6 +49,19 @@ find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+foreach(rocdecode_util
+    "rocvideodecode/roc_video_dec.cpp"
+    "colorspace_kernels.cpp"
+    "resize_kernels.cpp")
+    if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/${rocdecode_util}")
+        message(WARNING "rocDecode utility source ${ROCM_PATH}/share/rocdecode/utils/${rocdecode_util} not found, skipping ${example_name}")
+        return()
+    endif()
+endforeach()
+
 add_executable(${example_name}
     main.cpp
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp

--- a/Libraries/rocDecode/video_decode_rgb/Makefile
+++ b/Libraries/rocDecode/video_decode_rgb/Makefile
@@ -30,11 +30,21 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if any are not installed.
+ROCDECODE_UTILS := rocvideodecode/roc_video_dec.cpp colorspace_kernels.cpp resize_kernels.cpp
+ifneq ($(strip $(foreach util,$(ROCDECODE_UTILS),$(if $(wildcard $(UTILS_DIR)/$(util)),,$(util)))),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+
+ifneq ($(SKIP_BUILD),1)
 
 HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)

--- a/Libraries/rocDecode/video_to_sequence/CMakeLists.txt
+++ b/Libraries/rocDecode/video_to_sequence/CMakeLists.txt
@@ -50,6 +50,14 @@ find_package(FFmpeg REQUIRED)
 find_package(rocprofiler-register REQUIRED)
 find_package(Threads REQUIRED)
 
+# rocDecode ships its shared utility sources under ${ROCM_PATH}/share/rocdecode/utils (tarball)
+# and with the amdrocm-decode-test package. The files are not available with pip wheels.
+# They are required to build this example; skip it if they are not installed.
+if(NOT EXISTS "${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp")
+    message(WARNING "rocDecode utility sources not found under ${ROCM_PATH}/share/rocdecode/utils, skipping ${example_name}")
+    return()
+endif()
+
 add_executable(${example_name}
     main.cpp
     ${ROCM_PATH}/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp

--- a/Libraries/rocDecode/video_to_sequence/Makefile
+++ b/Libraries/rocDecode/video_to_sequence/Makefile
@@ -30,11 +30,20 @@ REQUIRED_DEPS := FFMPEG
 include $(COMMON_INCLUDE_DIR)/require_deps.mk
 
 include $(COMMON_INCLUDE_DIR)/find_filesystem.mk
-ifneq ($(SKIP_BUILD),1)
 
 # HIP variables
 ROCM_PATH ?= /opt/rocm
 UTILS_DIR := ${ROCM_PATH}/share/rocdecode/utils
+
+# rocDecode ships its shared utility sources under $(ROCM_PATH)/share/rocdecode/utils
+# (tarball) and with the amdrocm-decode-test package. They are not available with pip
+# wheels but are required to build this example; skip it if they are not installed.
+ifeq ($(wildcard $(UTILS_DIR)/rocvideodecode/roc_video_dec.cpp),)
+    $(info $(EXAMPLE): Skipping build — rocDecode utility sources not found under $(UTILS_DIR))
+    SKIP_BUILD := 1
+endif
+
+ifneq ($(SKIP_BUILD),1)
 
 HIP_INCLUDE_DIR       := $(ROCM_PATH)/include
 ROCDECODE_INCLUDE_DIR := $(HIP_INCLUDE_DIR)


### PR DESCRIPTION
## Motivation

Tighten the file checks for rocDecode examples. The examples require rocDecode utility source files to compile, these sources are not available in pip wheels, they are only available from packaged release (`amdrocm-decode-test`) and tarball.

Replaces #466. Avoid extra maintenance and potential desync issues.

## Technical Details

Check if all sources are present in rocDecode examples' `CMakeLists.txt`. Emit warning and skip the build if anything is missing. Check only from `${ROCM_PATH}/share/rocdecode/utils`, consistent with the test files checks.

Also updated corresponding Makefiles.

## Test Plan

Tested with `7.14.0a20260608` wheel and `therock-dist-linux-gfx110X-all-7.14.0a20260622.tar.gz` tarball

## Test Result

rocDecode examples (skip) build correctly.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] New examples contain proper CMake and Make files.
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [x] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
