### PR TITLE
fix: guard HMM examples behind HSA_XNACK=1 in Makefile test

### DIFF
--- a/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/Makefile
+++ b/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Memory-Management/Unified-Memory-Management/Makefile
@@ -21,17 +21,20 @@
 # SOFTWARE.
 
 EXAMPLES := \
-  data_prefetching \
-  dynamic_unified_memory \
-  explicit_memory \
-  memory_range_attributes \
-  static_unified_memory \
-  unified_memory_advice
+  explicit_memory
 
 SKIP_FROM_TEST :=
 
+# hipMallocManaged, __managed__, and hipMemPrefetchAsync require HSA_XNACK=1 on AMD GPUs.
+# Without it, hipDeviceSynchronize blocks indefinitely after the kernel faults.
 ifeq ($(HSA_XNACK), 1)
-  EXAMPLES += standard_unified_memory 
+  EXAMPLES += \
+    data_prefetching \
+    dynamic_unified_memory \
+    memory_range_attributes \
+    standard_unified_memory \
+    static_unified_memory \
+    unified_memory_advice
 endif
 
 all: $(EXAMPLES)


### PR DESCRIPTION
Moved from #462 per review. HMM examples (hipMallocManaged/__managed__/hipMemPrefetchAsync) hang the gfx1151 Makefile test without HSA_XNACK=1 —
  hipDeviceSynchronize blocks on the faulted kernel. Guards them behind the XNACK conditional; only explicit_memory runs without it.