### PR TITLE
fix: make rocProfiler-SDK temporal ordering check non-fatal by default

### DIFF
--- a/Common/rocprofiler_utils.hpp
+++ b/Common/rocprofiler_utils.hpp
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -166,6 +167,28 @@
 
 namespace common
 {
+/// \brief Parse a boolean environment variable, mirroring rocprofiler-sdk's own
+///   get_env(env_id, bool) semantics: unset -> default; a purely numeric value
+///   is true when non-zero; the words off/false/no/n/f/0 (case-insensitive) are
+///   false; any other non-empty value is true.
+inline bool get_env_bool(const char* env_id, bool default_value)
+{
+    const char* env_var = std::getenv(env_id);
+    if(env_var == nullptr || env_var[0] == '\0') return default_value;
+
+    std::string value{env_var};
+    if(value.find_first_not_of("0123456789") == std::string::npos)
+        return std::stoi(value) != 0;
+
+    for(char& c : value)
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+    for(const char* falsy : {"off", "false", "no", "n", "f", "0"})
+        if(value == falsy) return false;
+
+    return true;
+}
+
 /// \brief Device information structure for HIP device management
 struct device_info
 {

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/README.md
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/README.md
@@ -41,6 +41,7 @@ This example demonstrates how to use the rocProfiler SDK's external correlation 
 
 - **Data Validation**:
   - The `tool_fini` function performs rigorous checks to ensure that the correlation ID mechanism is working correctly, which is a good practice for tool developers.
+  - The temporal-ordering check between operation end timestamps and correlation ID retirement timestamps is reported but non-fatal by default, because GPU/CPU clock-domain skew on some hardware (for example RDNA3.5 APUs) produces benign timestamp inversions that rocprofiler itself only warns about. Set the environment variable `ROCPROFILER_CI_STRICT_TIMESTAMPS=1` to turn a violation into a hard failure.
 
 ## Demonstrated API Calls
 

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/client.cpp
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/client.cpp
@@ -582,10 +582,7 @@ tool_fini(void* tool_data)
     // rocprofiler uses), so genuine ordering bugs are still catchable in strict CI.
     if(temporal_ordering_violations > 0)
     {
-        const char* strict_ts_env = std::getenv("ROCPROFILER_CI_STRICT_TIMESTAMPS");
-        const bool  strict_timestamps
-            = (strict_ts_env != nullptr && strict_ts_env[0] != '\0' && strict_ts_env[0] != '0');
-        if(strict_timestamps)
+        if(common::get_env_bool("ROCPROFILER_CI_STRICT_TIMESTAMPS", false))
             throw std::runtime_error{"temporal ordering violation in correlation id retirement"};
         std::cerr << "warning: temporal ordering violations detected (tolerated; set "
                      "ROCPROFILER_CI_STRICT_TIMESTAMPS=1 to fail instead)\n"

--- a/Libraries/rocProfiler-SDK/external_correlation_id_request/client.cpp
+++ b/Libraries/rocProfiler-SDK/external_correlation_id_request/client.cpp
@@ -573,8 +573,24 @@ tool_fini(void* tool_data)
 
     if(unseen > 0) throw std::runtime_error{"unseen external correlation id data"};
     if(unretired > 0) throw std::runtime_error{"unretired internal correlation id values"};
+
+    // GPU dispatch and CPU-side retirement timestamps come from different clock
+    // domains. On some hardware (e.g. RDNA3.5 APUs) they skew enough to make a
+    // correctly-ordered retirement look early; rocprofiler itself only warns and
+    // swaps such inversions by default. Mirror that policy: report the violation
+    // but only fail when ROCPROFILER_CI_STRICT_TIMESTAMPS is set (the same switch
+    // rocprofiler uses), so genuine ordering bugs are still catchable in strict CI.
     if(temporal_ordering_violations > 0)
-        throw std::runtime_error{"temporal ordering violation in correlation id retirement"};
+    {
+        const char* strict_ts_env = std::getenv("ROCPROFILER_CI_STRICT_TIMESTAMPS");
+        const bool  strict_timestamps
+            = (strict_ts_env != nullptr && strict_ts_env[0] != '\0' && strict_ts_env[0] != '0');
+        if(strict_timestamps)
+            throw std::runtime_error{"temporal ordering violation in correlation id retirement"};
+        std::cerr << "warning: temporal ordering violations detected (tolerated; set "
+                     "ROCPROFILER_CI_STRICT_TIMESTAMPS=1 to fail instead)\n"
+                  << std::flush;
+    }
 
     delete _call_stack;
 }


### PR DESCRIPTION
## Summary
- `external_correlation_id_request` aborted whenever a correlation ID appeared to retire before its operation's end timestamp.
- GPU dispatch and CPU-side retirement timestamps are in different clock domains; on RDNA3.5 APUs (gfx1151) they skew up to ~200 µs, so a correctly-ordered retirement
looks early and the example throws. gfx1100 (discrete) is unaffected.
- rocprofiler itself only warns and swaps these inversions by default, failing only under `ROCPROFILER_CI_STRICT_TIMESTAMPS`. This mirrors that policy: always print the
violation + count, only throw when that env var is set. The `unseen`/`unretired` invariants stay unconditional.

## Evidence
Nightly CI on gfx1151:
`terminate called ... what(): temporal ordering violation in correlation id retirement`
Observed skews: 1524 ns, 99057 ns, 209100 ns. Preceded by rocprofiler's own `hsa_amd_profiling_get_dispatch_time ... start time is after end time ... Swapping the values`
warning.
https://github.com/ROCm/rocm-examples/actions/runs/28764875296

## Test plan
- [x] Build the example
- [x] Run on gfx1151: exits 0, prints the tolerated warning
- [x] Run with `ROCPROFILER_CI_STRICT_TIMESTAMPS=1`: still aborts on violation