### PR TITLE
Only build hipDNN tests if GCC version >= 13

### DIFF
--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -52,6 +52,8 @@ if(
     add_subdirectory(hipCUB)
     if(CMAKE_VERSION VERSION_LESS "3.25.2")
         message(WARNING "CMake version < 3.25.2, not building hipDNN examples.")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
+        message(WARNING "GCC version < 13, not building hipDNN examples.")
     else()
         if (ROCM_EXAMPLES_ENABLE_HIPDNN)
             add_subdirectory(hipDNN)

--- a/Libraries/CMakeLists.txt
+++ b/Libraries/CMakeLists.txt
@@ -53,7 +53,7 @@ if(
     if(CMAKE_VERSION VERSION_LESS "3.25.2")
         message(WARNING "CMake version < 3.25.2, not building hipDNN examples.")
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
-        message(WARNING "GCC version < 13, not building hipDNN examples.")
+        message(WARNING "Current GCC version is ${CMAKE_CXX_COMPILER_VERSION} which is < 13, not building hipDNN examples.")
     else()
         if (ROCM_EXAMPLES_ENABLE_HIPDNN)
             add_subdirectory(hipDNN)


### PR DESCRIPTION
## Motivation

If the compiler on their system is GCC and its version is < 13, then users will encounter a build error when building rocm-examples.

## Technical Details

This is the build error users will encounter if it tries to compile hipDNN tests when GCC < 13.

```
/mnt/therock-tarball/install/include/hipdnn/test_sdk/hipdnn_test_sdk/utilities/TestTolerances.hpp:163:23: error: static assertion failed: Type not supported
  163 |         static_assert(false, "Type not supported");
```

## Test Plan

1. Install tarball 7.14 RC2 on RHEL 8.10, Ubuntu 22.04, 24.04 and SLES 15.7.
2. Build and run rocm-examples on these distros. Some of them like Ubuntu 22.04 has GCC < 13 and others have GCC >= 13.

## Test Result

1. Correctly skips buildling hipDNN tests on Ubuntu 22.04 where GCC < 13 and correctly built hipDNN tests on the other distros when GCC >= 13.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
