### PR TITLE
hipFile: Clean up after tests

### DIFF
--- a/Systems/hipFile/CMakeLists.txt
+++ b/Systems/hipFile/CMakeLists.txt
@@ -48,9 +48,19 @@ endif()
 
 # Directory used for test I/O. Must be on a local filesystem that supports
 # O_DIRECT (ext4 or xfs). The GitHub Actions runner workspace is on an overlay
-# filesystem that does not support O_DIRECT, so we default to /tmp.
-set(HIPFILE_TEST_DIR "/tmp" CACHE PATH
+# filesystem that does not support O_DIRECT, so we default to /tmp. The
+# directory name is namespaced per-user to avoid collisions when multiple
+# users share the same /tmp on a workstation or CI runner. Each leaf example
+# also registers a FIXTURES_CLEANUP test that removes its own files once its
+# tests finish.
+if(DEFINED ENV{USER})
+    set(hipfile_test_dir_default "/tmp/hipfile-test-$ENV{USER}")
+else()
+    set(hipfile_test_dir_default "/tmp/hipfile-test")
+endif()
+set(HIPFILE_TEST_DIR "${hipfile_test_dir_default}" CACHE PATH
     "Directory for hipFile test I/O. Must be on an O_DIRECT-capable filesystem.")
+file(MAKE_DIRECTORY "${HIPFILE_TEST_DIR}")
 
 file(RELATIVE_PATH folder_bin ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/${folder_bin})

--- a/Systems/hipFile/aiscp/CMakeLists.txt
+++ b/Systems/hipFile/aiscp/CMakeLists.txt
@@ -61,4 +61,12 @@ add_test(
 )
 set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
 
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/aiscp_src.bin"
+        "${HIPFILE_TEST_DIR}/aiscp_dst.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
+
 install(TARGETS ${example_name})

--- a/Systems/hipFile/async/roundtrip_async/CMakeLists.txt
+++ b/Systems/hipFile/async/roundtrip_async/CMakeLists.txt
@@ -58,5 +58,14 @@ add_test(
         "${HIPFILE_TEST_DIR}/roundtrip_async_read.bin"
         "${HIPFILE_TEST_DIR}/roundtrip_async_write.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/roundtrip_async_read.bin"
+        "${HIPFILE_TEST_DIR}/roundtrip_async_write.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/async/roundtrip_async_multi_stream/CMakeLists.txt
+++ b/Systems/hipFile/async/roundtrip_async_multi_stream/CMakeLists.txt
@@ -59,5 +59,14 @@ add_test(
         "${HIPFILE_TEST_DIR}/roundtrip_async_ms_read.bin"
         "${HIPFILE_TEST_DIR}/roundtrip_async_ms_write.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/roundtrip_async_ms_read.bin"
+        "${HIPFILE_TEST_DIR}/roundtrip_async_ms_write.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/async/roundtrip_async_multi_stream_registered/CMakeLists.txt
+++ b/Systems/hipFile/async/roundtrip_async_multi_stream_registered/CMakeLists.txt
@@ -59,5 +59,14 @@ add_test(
         "${HIPFILE_TEST_DIR}/roundtrip_async_msr_read.bin"
         "${HIPFILE_TEST_DIR}/roundtrip_async_msr_write.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/roundtrip_async_msr_read.bin"
+        "${HIPFILE_TEST_DIR}/roundtrip_async_msr_write.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/async/roundtrip_async_nonblocking_stream/CMakeLists.txt
+++ b/Systems/hipFile/async/roundtrip_async_nonblocking_stream/CMakeLists.txt
@@ -59,5 +59,14 @@ add_test(
         "${HIPFILE_TEST_DIR}/roundtrip_async_nb_read.bin"
         "${HIPFILE_TEST_DIR}/roundtrip_async_nb_write.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/roundtrip_async_nb_read.bin"
+        "${HIPFILE_TEST_DIR}/roundtrip_async_nb_write.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/bufregister_write/CMakeLists.txt
+++ b/Systems/hipFile/basics/bufregister_write/CMakeLists.txt
@@ -56,5 +56,12 @@ add_test(
     NAME ${example_name}
     COMMAND ${example_name} "${HIPFILE_TEST_DIR}/bufregister_write_out.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f "${HIPFILE_TEST_DIR}/bufregister_write_out.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/iterative_devmem_offset_read/CMakeLists.txt
+++ b/Systems/hipFile/basics/iterative_devmem_offset_read/CMakeLists.txt
@@ -67,4 +67,12 @@ add_test(
 )
 set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
 
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/iterative_devmem_offset_read_input.bin"
+        "${HIPFILE_TEST_DIR}/iterative_devmem_offset_read_output.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
+
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/iterative_read/CMakeLists.txt
+++ b/Systems/hipFile/basics/iterative_read/CMakeLists.txt
@@ -66,4 +66,12 @@ add_test(
 )
 set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
 
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/iterative_read_input.bin"
+        "${HIPFILE_TEST_DIR}/iterative_read_output.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
+
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/no_bufregister_write/CMakeLists.txt
+++ b/Systems/hipFile/basics/no_bufregister_write/CMakeLists.txt
@@ -56,5 +56,12 @@ add_test(
     NAME ${example_name}
     COMMAND ${example_name} "${HIPFILE_TEST_DIR}/no_bufregister_write_out.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f "${HIPFILE_TEST_DIR}/no_bufregister_write_out.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/no_odirect_write/CMakeLists.txt
+++ b/Systems/hipFile/basics/no_odirect_write/CMakeLists.txt
@@ -56,5 +56,12 @@ add_test(
     NAME ${example_name}
     COMMAND ${example_name} "${HIPFILE_TEST_DIR}/no_odirect_write_out.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f "${HIPFILE_TEST_DIR}/no_odirect_write_out.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/roundtrip_verify/CMakeLists.txt
+++ b/Systems/hipFile/basics/roundtrip_verify/CMakeLists.txt
@@ -58,5 +58,14 @@ add_test(
         "${HIPFILE_TEST_DIR}/roundtrip_verify_created.bin"
         "${HIPFILE_TEST_DIR}/roundtrip_verify_copied.bin"
 )
+set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
+
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/roundtrip_verify_created.bin"
+        "${HIPFILE_TEST_DIR}/roundtrip_verify_copied.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
 
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/subregion_write/CMakeLists.txt
+++ b/Systems/hipFile/basics/subregion_write/CMakeLists.txt
@@ -66,4 +66,12 @@ add_test(
 )
 set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
 
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/subregion_write_input.bin"
+        "${HIPFILE_TEST_DIR}/subregion_write_output.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
+
 install(TARGETS ${example_name})

--- a/Systems/hipFile/basics/various_mem_rw/CMakeLists.txt
+++ b/Systems/hipFile/basics/various_mem_rw/CMakeLists.txt
@@ -69,4 +69,12 @@ add_test(
 )
 set_tests_properties(${example_name} PROPERTIES FIXTURES_REQUIRED ${example_name}_fixture)
 
+add_test(
+    NAME ${example_name}_cleanup
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        "${HIPFILE_TEST_DIR}/various_mem_rw_input.bin"
+        "${HIPFILE_TEST_DIR}/various_mem_rw_output.bin"
+)
+set_tests_properties(${example_name}_cleanup PROPERTIES FIXTURES_CLEANUP ${example_name}_fixture)
+
 install(TARGETS ${example_name})


### PR DESCRIPTION
## Motivation

As reported by QA, the current CTest setup for the hipFile examples breaks when multiple users try to test them. Since the tests don't clean up after themselves in `/tmp`, name and permission collisions happen.

## Technical Details

Each user stores the hipFile test data in their own directory inside `/tmp`. Additionally, these directories are deleted after the test passes / fails.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [X] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
