### PR TITLE
Add 7.14 ubuntu 24.04 amdrocm-core-sdk dockerfile

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -120,6 +120,5 @@ jobs:
             context: Dockerfiles/
             file: Dockerfiles/${{ matrix.file }}
             push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-            build-args: ${{ matrix.file == 'ubuntu-24.04-rocm.Dockerfile' && format('ROCM_VERSION={0}', steps.rocm-version.outputs.version) || '' }}
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -76,6 +76,15 @@ jobs:
             echo "name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
             echo "Image name: ${IMAGE_NAME}"
 
+        - name: Extract ROCm version
+          id: rocm-version
+          if: matrix.file == 'ubuntu-24.04-rocm.Dockerfile'
+          run: |
+            # Read the ARG ROCM_VERSION default from the Dockerfile (single source of truth)
+            VERSION=$(grep -oP 'ARG ROCM_VERSION=\K[0-9.]+' "Dockerfiles/${{ matrix.file }}")
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            echo "ROCm version: ${VERSION}"
+
         - name: Log in to GHCR
           if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
           uses: docker/login-action@v3
@@ -92,6 +101,7 @@ jobs:
             tags: |
               type=raw,value=latest,enable={{is_default_branch}}
               type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+              type=raw,value=${{ steps.rocm-version.outputs.version }},enable=${{ matrix.file == 'ubuntu-24.04-rocm.Dockerfile' && steps.rocm-version.outputs.version != '' }}
 
         - name: Build and push Docker image for ${{ matrix.file }}
           uses: docker/build-push-action@v5
@@ -99,5 +109,6 @@ jobs:
             context: Dockerfiles/
             file: Dockerfiles/${{ matrix.file }}
             push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+            build-args: ${{ matrix.file == 'ubuntu-24.04-rocm.Dockerfile' && format('ROCM_VERSION={0}', steps.rocm-version.outputs.version) || '' }}
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -2,6 +2,11 @@ name: Build Docker
 
 on:
   workflow_dispatch:
+    inputs:
+      tag_latest:
+        description: 'Tag pushed images as latest'
+        type: boolean
+        default: false
   push:
     branches: [ amd-staging ]
     paths:
@@ -100,7 +105,7 @@ jobs:
             images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ steps.image-tag.outputs.name }}
             tags: |
               type=raw,value=latest,enable={{is_default_branch}}
-              type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+              type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag_latest }}
               type=raw,value=${{ steps.rocm-version.outputs.version }},enable=${{ matrix.file == 'ubuntu-24.04-rocm.Dockerfile' && steps.rocm-version.outputs.version != '' }}
 
         - name: Build and push Docker image for ${{ matrix.file }}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -106,7 +106,13 @@ jobs:
             tags: |
               type=raw,value=latest,enable={{is_default_branch}}
               type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && inputs.tag_latest }}
-              type=raw,value=${{ steps.rocm-version.outputs.version }},enable=${{ matrix.file == 'ubuntu-24.04-rocm.Dockerfile' && steps.rocm-version.outputs.version != '' }}
+              # Fallback so every push/dispatch has a tag: use the branch name whenever
+              # 'latest' is not applied (i.e. not the default branch and not an opt-in dispatch),
+              # so non-default builds never clobber latest.
+              type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) && !(github.event_name == 'workflow_dispatch' && inputs.tag_latest) }}
+              # ROCm-version tag tracks the stable channel: apply it only alongside 'latest'
+              # (default branch, or an opt-in dispatch) so dev builds never clobber the shared 7.14 tag.
+              type=raw,value=${{ steps.rocm-version.outputs.version }},enable=${{ matrix.file == 'ubuntu-24.04-rocm.Dockerfile' && steps.rocm-version.outputs.version != '' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || (github.event_name == 'workflow_dispatch' && inputs.tag_latest)) }}
 
         - name: Build and push Docker image for ${{ matrix.file }}
           uses: docker/build-push-action@v5

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -29,11 +29,25 @@ This is environment is based on Ubuntu targeting the CUDA platform. It has the
 HIP runtime and the ROCm libraries installed. CMake is also installed in the image.
 It can be used with the samples that support the CUDA target.
 
-### CI base images
+### ROCm installed via apt based on Ubuntu
 
-Lightweight base images for CI workflows based on various supported Linux distributions. The images include a Python virtual environment and complete system dependencies to build rocm-examples from source, but they **do not include  any ROCm installation**.
+Dockerfile: [ubuntu-24.04-rocm.Dockerfile](ubuntu-24.04-rocm.Dockerfile)
+
+This is an Ubuntu 24.04 image with ROCm installed from the AMD apt repositories, along with the
+system and Python dependencies needed to build rocm-examples. It registers both
+the stable (`repo.amd.com`) and prerelease (`rocm.prereleases.amd.com`) repos;
+the prerelease repo is pinned to priority 1 so only packages absent from stable
+are pulled from it. This is used to install test packages such as `amdrocm-decode-test`
+(prerelease-only, `7.14.0~pre3`), which provides the video and utility assets the
+rocDecode examples need to build and run their tests.
+
+### CI base images (multi-arch)
+
+Lightweight base images for CI workflows based on various supported Linux distributions. The images include a Python virtual environment and complete system dependencies to build rocm-examples from source, but they **do not include any ROCm installation** — ROCm is installed at CI runtime (multi-arch wheel or tarball) by the build workflow.
 
 Dockerfiles:
 
-- [ubuntu-22.04.Dockerfile](ubuntu-22.04.Dockerfile)
-- [sles-15.7.Dockerfile](sles-15.7.Dockerfile)
+- [ubuntu-24.04-multiarch.Dockerfile](ubuntu-24.04-multiarch.Dockerfile)
+- [ubuntu-26.04-multiarch.Dockerfile](ubuntu-26.04-multiarch.Dockerfile)
+- [almalinux-8-multiarch.Dockerfile](almalinux-8-multiarch.Dockerfile)
+- [sles-15.7-multiarch.Dockerfile](sles-15.7-multiarch.Dockerfile)

--- a/Dockerfiles/almalinux-8-multiarch.Dockerfile
+++ b/Dockerfiles/almalinux-8-multiarch.Dockerfile
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 FROM almalinux:8
 
 ARG VULKAN_SDK_VERSION=1.4.335.0

--- a/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-cuda-ubuntu.Dockerfile
@@ -1,6 +1,28 @@
 # syntax=docker/dockerfile:latest
 # Above is required for substitutions in environment variables
 
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # CUDA based docker image
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 

--- a/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
+++ b/Dockerfiles/hip-libraries-rocm-ubuntu.Dockerfile
@@ -1,6 +1,28 @@
 # syntax=docker/dockerfile:latest
 # Above is required for substitutions in environment variables
 
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # Ubuntu based docker image
 FROM ubuntu:22.04
 

--- a/Dockerfiles/sles-15.7-multiarch.Dockerfile
+++ b/Dockerfiles/sles-15.7-multiarch.Dockerfile
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 FROM registry.suse.com/suse/sle15:15.7
 
 ARG VULKAN_SDK_VERSION=1.4.335.0

--- a/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
+++ b/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
@@ -63,7 +63,12 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
     apt update
 
 # Install ROCm
-RUN apt install -y amdrocm-core-sdk${ROCM_VERSION}
+RUN apt install -y \
+        amdrocm-core-sdk${ROCM_VERSION} \
+        amdrocm-hiptensor-dev${ROCM_VERSION} \
+        amdrocm-hiptensor-host${ROCM_VERSION} \
+        amdrocm-rocalution-dev${ROCM_VERSION} \
+        amdrocm-rocalution-host${ROCM_VERSION}
 
 WORKDIR /workspace
 CMD ["/bin/bash"]

--- a/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
+++ b/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
@@ -55,20 +55,28 @@ RUN apt-get update -qq && \
         libdw-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Register ROCm repositories
+# Register ROCm repositories. The stable repo provides the runtime/dev
+# packages; the prerelease repo is pinned to priority 1 so only packages
+# absent from stable (the -test data packages) are pulled from it.
 RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
     wget https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg -O - | \
     gpg --dearmor | tee /etc/apt/keyrings/amdrocm.gpg > /dev/null && \
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" | tee /etc/apt/sources.list.d/rocm.list && \
+    wget https://rocm.prereleases.amd.com/packages-multi-arch/gpg/rocm.gpg -O - | \
+    gpg --dearmor | tee /etc/apt/keyrings/amdrocm-prerelease.gpg > /dev/null && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm-prerelease.gpg] https://rocm.prereleases.amd.com/packages-multi-arch/ubuntu2404 stable main" | tee /etc/apt/sources.list.d/rocm-prerelease.list && \
+    echo "Package: *\nPin: origin \"rocm.prereleases.amd.com\"\nPin-Priority: 1" | tee /etc/apt/preferences.d/rocm-prerelease > /dev/null && \
     apt update
 
 # Install ROCm
+# amdrocm-decode-test is only published in the prerelease repo (7.14.0~pre3)
 RUN apt install -y \
         amdrocm-core-sdk${ROCM_VERSION} \
         amdrocm-hiptensor-dev${ROCM_VERSION} \
         amdrocm-hiptensor${ROCM_VERSION} \
         amdrocm-rocalution-dev${ROCM_VERSION} \
-        amdrocm-rocalution${ROCM_VERSION}
+        amdrocm-rocalution${ROCM_VERSION} \
+        amdrocm-decode-test${ROCM_VERSION}
 
 # Setup ROCm environment
 ENV PATH="/opt/rocm/bin:${PATH}"

--- a/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
+++ b/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
@@ -66,9 +66,18 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
 RUN apt install -y \
         amdrocm-core-sdk${ROCM_VERSION} \
         amdrocm-hiptensor-dev${ROCM_VERSION} \
-        amdrocm-hiptensor-host${ROCM_VERSION} \
+        amdrocm-hiptensor${ROCM_VERSION} \
         amdrocm-rocalution-dev${ROCM_VERSION} \
-        amdrocm-rocalution-host${ROCM_VERSION}
+        amdrocm-rocalution${ROCM_VERSION}
+
+# Setup ROCm environment
+ENV PATH="/opt/rocm/bin:${PATH}"
+RUN echo "/opt/rocm/lib" >> /etc/ld.so.conf.d/rocm.conf \
+    && ldconfig
+ENV ROCM_PATH="/opt/rocm"
+
+# Python packages required by ROCm tooling
+RUN python3 -m pip install --no-cache-dir --break-system-packages pyyaml
 
 WORKDIR /workspace
 CMD ["/bin/bash"]

--- a/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
+++ b/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
@@ -22,6 +22,8 @@
 
 FROM ubuntu:24.04
 
+ARG ROCM_VERSION=7.14
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ── System packages ───────────────────────────────────────────────────────────
@@ -61,7 +63,7 @@ RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
     apt update
 
 # Install ROCm
-RUN apt install -y amdrocm-core-sdk7.14
+RUN apt install -y amdrocm-core-sdk${ROCM_VERSION}
 
 WORKDIR /workspace
 CMD ["/bin/bash"]

--- a/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
+++ b/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
@@ -1,0 +1,67 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ───────────────────────────────────────────────────────────
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+        sudo \
+        gpg \
+        libatomic1 \
+        libquadmath0 \
+        ca-certificates \
+        git \
+        wget \
+        curl \
+        build-essential \
+        cmake \
+        ninja-build \
+        python3 \
+        python3-venv \
+        python3-pip \
+        pkg-config \
+        libglfw3-dev \
+        libvulkan-dev \
+        glslang-tools \
+        vulkan-validationlayers \
+        libopencv-dev \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev \
+        libdw-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Register ROCm repositories
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings && \
+    wget https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg -O - | \
+    gpg --dearmor | tee /etc/apt/keyrings/amdrocm.gpg > /dev/null && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" | tee /etc/apt/sources.list.d/rocm.list && \
+    apt update
+
+# Install ROCm
+RUN apt install -y amdrocm-core-sdk7.14
+
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/Libraries/rocDecode/README.md
+++ b/Libraries/rocDecode/README.md
@@ -12,6 +12,7 @@ The examples in this subdirectory showcase the functionality of the [rocDecode](
 - Or GNU Make - available via the distribution's package manager
 - [ROCm](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html) (at least version 6.0)
 - [rocDecode](https://github.com/ROCm/rocDecode): `rocdecode` and `rocdecode-dev` packages available from [repo.radeon.com](https://repo.radeon.com/rocm/). The repository is added during the standard ROCm [install procedure](https://rocm.docs.amd.com/projects/HIP/en/latest/install/install.html)
+- rocDecode shared utility sources and sample videos, installed under `${ROCM_PATH}/share/rocdecode/`. These are required to build the examples and to run their tests; examples missing them are skipped at configure time. They ship with a rocDecode tarball install or via the `amdrocm-decode-test` package, but are **not** included in the pip wheels.
 - [FFMPEG](https://ffmpeg.org/about.html) development libraries:
   - On Ubuntu: `sudo apt install libavcodec-dev libavformat-dev libavutil-dev`
   - On RHEL/SLES: Install FFMPEG development packages manually or use the [rocDecode-setup.py](https://github.com/ROCm/rocDecode/blob/develop/rocDecode-setup.py) script


### PR DESCRIPTION
## Motivation

Add package manager installed ROCm docker image. Reusable for per category CI workflow, inheriting previous mainline workflows. This image contains all necessary packages to build and run rocm-examples, no additional installation or setup needed.

## Technical Details

Add a ubuntu 24.04 based ROCm-installed image. Installs 7.14 for all supported archs.
Add ROCm version tagging for the new image only.
Add license statement to dockerfiles.

Register the prerelease repo (`rocm.prereleases.amd.com`) alongside the stable repo (`repo.amd.com`), pinned to priority 1 so only packages absent from stable are pulled from it. This installs `amdrocm-decode-test` (prerelease-only, `7.14.0~pre3`), which provides the video and utility assets the rocDecode examples need to build and run their tests; the `-dev`/runtime decode packages come in transitively from stable. Updated rocDecode README to reflect this.

*hipDNN, MIGraphX, MIVisionX, RPP, rocAL, rocCV are not available from packaged install.*

## Test Plan

Local build and test

## Test Result

Built https://github.com/ROCm/rocm-examples/pkgs/container/rocm-examples-ubuntu-24.04-rocm/1057904364?tag=7.14 and ctest runs successfully.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [x] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

