### PR TITLE
Graph API tutorial: Use `__HIP_NO_IMAGE_SUPPORT` macro

### DIFF
--- a/HIP-Doc/Tutorials/graph_api/src/backprojection.hip
+++ b/HIP-Doc/Tutorials/graph_api/src/backprojection.hip
@@ -84,7 +84,8 @@ __global__ void backprojection_kernel(
     float d_so
 )
 {
-#ifndef __GFX9__ // GFX9 devices don't support texture instructions
+    // Guard against devices without image / texture support
+#if !defined(__HIP_NO_IMAGE_SUPPORT) || (__HIP_NO_IMAGE_SUPPORT == 0)
     auto const x_in = blockIdx.x * blockDim.x + threadIdx.x;
     auto const y_in = blockIdx.y * blockDim.y + threadIdx.y;
     auto z_in = blockIdx.z * blockDim.z + threadIdx.z;


### PR DESCRIPTION
## Motivation

In the Graph API tutorial, we are guarding against GPUs without image / texture support by using the `__GFX9__` macro. This isn't future proof; fortunately, HIP features the `__HIP_NO_IMAGE_SUPPORT` macro for exactly this case.

## Technical Details

Changes the `__GFX9__` macro to `__HIP_NO_IMAGE_SUPPORT`.

## Test Plan

n/a

## Test Result

N/a

## Added/Updated documentation?

- [ ] Yes
- [X] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [X] No, does not apply to this PR.

## Submission Checklist

- [X] New examples contain proper CMake and Make files.
- [x ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [X] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
