### PR TITLE
Cleanup arch filtering & Fix LLVM library path

### DIFF
--- a/.github/build_tools/setup_whl_env.py
+++ b/.github/build_tools/setup_whl_env.py
@@ -15,11 +15,11 @@ with open(os.environ["GITHUB_ENV"], "a") as f:
     f.write(f"HIP_PLATFORM=amd\n")
     f.write(f"HIP_PATH={rocm}\n")
     f.write(f"HIP_DEVICE_LIB_PATH={rocm}/lib/llvm/amdgcn/bitcode\n")
-    f.write(f"PATH={rocm}/bin:{rocm}/llvm/bin:{venv}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n")
+    f.write(f"PATH={rocm}/bin:{rocm}/lib/llvm/bin:{venv}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n")
     f.write(f"CPATH={rocm}/include\n")
     f.write(f"PKG_CONFIG_PATH={rocm}/lib/pkgconfig\n")
     f.write(f"LIBRARY_PATH={rocm}/lib:{rocm}/lib64\n")
-    f.write(f"LD_LIBRARY_PATH={core}:{libs}:{rocm}/lib:{rocm}/llvm/lib\n")
+    f.write(f"LD_LIBRARY_PATH={core}:{libs}:{rocm}/lib:{rocm}/lib/llvm/lib\n")
     # whl-multi-arch omits amdllvm needed for OpenMP GPU offloading
     f.write("ENABLE_OPENMP=OFF\n")
     # hipDNN headers require C++20; system g++ on AlmaLinux 8 is too old

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -96,8 +96,8 @@ jobs:
           echo "HIP_PATH=${ROCM_PATH}" >> $GITHUB_ENV
           echo "HIP_PLATFORM=amd" >> $GITHUB_ENV
           echo "HIP_DEVICE_LIB_PATH=${ROCM_PATH}/lib/llvm/amdgcn/bitcode" >> $GITHUB_ENV
-          echo "PATH=${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH}" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:${ROCM_PATH}/lib/rocprofiler-systems:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          echo "PATH=${ROCM_PATH}/bin:${ROCM_PATH}/lib/llvm/bin:${PATH}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${ROCM_PATH}/lib:${ROCM_PATH}/lib/llvm/lib:${ROCM_PATH}/lib/rocprofiler-systems:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 

--- a/Libraries/ComposableKernel/CMakeLists.txt
+++ b/Libraries/ComposableKernel/CMakeLists.txt
@@ -51,7 +51,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../Common/ROCmPath.cmake")
 
 find_package(composable_kernel)
 if(NOT composable_kernel_FOUND)
-    message(STATUS "Composable Kernel could not be found, not building Composable Kernel examples")
+    message(WARNING "Composable Kernel could not be found, not building Composable Kernel examples")
 else()
     add_subdirectory(attention)
     add_subdirectory(basic)

--- a/Libraries/rocAL/CMakeLists.txt
+++ b/Libraries/rocAL/CMakeLists.txt
@@ -39,7 +39,7 @@ find_library(ROCAL_LIBRARY
 )
 
 if(NOT ROCAL_LIBRARY)
-    message(STATUS "rocAL could not be found, not building rocAL examples")
+    message(WARNING "rocAL could not be found, not building rocAL examples")
     return()
 endif()
 

--- a/Libraries/rocCV/CMakeLists.txt
+++ b/Libraries/rocCV/CMakeLists.txt
@@ -41,7 +41,7 @@ find_library(ROCCV_LIBRARY
 )
 
 if(NOT ROCCV_LIBRARY)
-    message(STATUS "rocCV could not be found, not building rocCV examples")
+    message(WARNING "rocCV could not be found, not building rocCV examples")
     return()
 endif()
 

--- a/Tools/rocprof-compute/CMakeLists.txt
+++ b/Tools/rocprof-compute/CMakeLists.txt
@@ -33,15 +33,6 @@ set(example_occupancy ${example_name}-occupancy)
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(${example_name} LANGUAGES CXX)
 
-set(ROCPROF_COMPUTE_SUPPORTED_ARCH gfx908 gfx90a gfx940 gfx941 gfx942 gfx950)
-
-foreach(ARCH ${CMAKE_HIP_ARCHITECTURES})
-    if(NOT ARCH IN_LIST ROCPROF_COMPUTE_SUPPORTED_ARCH)
-        message(WARNING "${example_name} does not support architecture ${ARCH}. Not building ${example_name} examples")
-        return()
-    endif()
-endforeach()
-
 include("${CMAKE_CURRENT_LIST_DIR}/../../Common/HipPlatform.cmake")
 select_gpu_language()
 enable_language(${ROCM_EXAMPLES_GPU_LANGUAGE})
@@ -49,6 +40,13 @@ select_hip_platform()
 
 if(ROCM_EXAMPLES_GPU_LANGUAGE STREQUAL "CUDA")
     message(STATUS "${example_name} does not support CUDA accelerators. Not building ${example_name} examples.")
+    return()
+endif()
+
+set(ROCPROF_COMPUTE_SUPPORTED_ARCH gfx908 gfx90a gfx940 gfx941 gfx942 gfx950)
+include("${CMAKE_CURRENT_LIST_DIR}/../../Common/FilterHIPArchitectures.cmake")
+filter_hip_architectures("${example_name}" "${ROCPROF_COMPUTE_SUPPORTED_ARCH}" SHOULD_SKIP)
+if(SHOULD_SKIP)
     return()
 endif()
 


### PR DESCRIPTION
## Motivation

Fixes arch filtering.

## Technical Details

Fixes CK, rocCV, rocAL to warn instead of status when library not found.

Move rocprofiler-compute to use `FilterHIPArchitectures`.

Correct LLVM library path to fix rocprofiler-sdk_openmp_target.
## Test Plan

CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
