### PR TITLE
fix(monte_carlo_pi): migrate off hipcub iterators removed in CUB 3.0

### DIFF
--- a/Applications/monte_carlo_pi/CMakeLists.txt
+++ b/Applications/monte_carlo_pi/CMakeLists.txt
@@ -39,10 +39,12 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../Common/ROCmPath.cmake")
 find_package(hipcub REQUIRED)
 find_package(hiprand REQUIRED)
 # Workaround for hipRAND, requires manual linking with backend.
+# rocThrust provides the iterators on AMD; NVIDIA gets Thrust from CUDAToolkit.
 if(ROCM_EXAMPLES_HIP_PLATFORM STREQUAL "nvidia")
     find_package(CUDAToolkit REQUIRED)
 else()
     find_package(rocrand REQUIRED)
+    find_package(rocthrust REQUIRED)
 endif()
 
 add_executable(${example_name} main.hip)
@@ -53,7 +55,7 @@ target_link_libraries(${example_name} PRIVATE hip::hipcub hip::hiprand)
 if(ROCM_EXAMPLES_HIP_PLATFORM STREQUAL "nvidia")
     target_link_libraries(${example_name} PRIVATE CUDA::curand)
 else()
-    target_link_libraries(${example_name} PRIVATE roc::rocrand)
+    target_link_libraries(${example_name} PRIVATE roc::rocrand roc::rocthrust)
 endif()
 target_include_directories(
     ${example_name}

--- a/Applications/monte_carlo_pi/main.hip
+++ b/Applications/monte_carlo_pi/main.hip
@@ -27,7 +27,6 @@
 #include <hipcub/device/device_reduce.hpp>
 #include <hiprand/hiprand.h>
 
-// CUB 3.0 removed hipcub's CUB-style iterators; use portable Thrust ones.
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 

--- a/Applications/monte_carlo_pi/main.hip
+++ b/Applications/monte_carlo_pi/main.hip
@@ -25,10 +25,11 @@
 #include "hiprand_utils.hpp"
 
 #include <hipcub/device/device_reduce.hpp>
-#include <hipcub/iterator/counting_input_iterator.hpp>
-#include <hipcub/iterator/discard_output_iterator.hpp>
-#include <hipcub/iterator/transform_input_iterator.hpp>
 #include <hiprand/hiprand.h>
+
+// CUB 3.0 removed hipcub's CUB-style iterators; use portable Thrust ones.
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
 
 #include <hip/hip_runtime.h>
 
@@ -66,13 +67,11 @@ float calculate_pi(int sample_count, float* d_data)
     // 4. Set up the input and output iterator for hipCUB's Sum.
 
     // Represents the samples' index.
-    auto input_counting = hipcub::CountingInputIterator<int>(0);
+    auto input_counting = thrust::counting_iterator<int>(0);
 
     // Converts the sample's index to a 0 or 1, indicating whether the sample lies within the disk.
     conversion_op convert_op(sample_count, d_data);
-    auto input = hipcub::TransformInputIterator<bool, conversion_op, decltype(input_counting)>(
-        input_counting,
-        convert_op);
+    auto          input = thrust::make_transform_iterator(input_counting, convert_op);
 
     int* d_output{};
     HIP_CHECK(hipMalloc(&d_output, sizeof(int)));


### PR DESCRIPTION
## Problem

`Applications/monte_carlo_pi` fails to build against current hipCUB:

```
main.hip:28:10: fatal error: 'hipcub/iterator/counting_input_iterator.hpp' file not found
```

hipCUB's CCCL 3.0 update (ROCm/rocm-libraries#9931, merged to `develop` 2026-07-25) removed the CUB-style iterator headers (`counting_input_iterator`, `constant_input_iterator`, `transform_input_iterator`, `discard_output_iterator`). CUB 3.0 dropped these in favor of the portable Thrust iterators. `monte_carlo_pi` was the only example still including them.

## Fix

- **main.hip**: replace `hipcub::CountingInputIterator` / `hipcub::TransformInputIterator` with `thrust::counting_iterator` / `thrust::make_transform_iterator`; drop the unused `discard_output_iterator` include. `hipcub::DeviceReduce::Sum` is unchanged — it accepts Thrust iterators (the CCCL-recommended pattern).
- **CMakeLists.txt**: find + link rocThrust on the AMD path (`roc::rocthrust`). On NVIDIA the Thrust headers ship with the already-required CUDA Toolkit, so both platforms keep building.
