### PR TITLE
Add unified manifest-driven skip mechanism for CI builds and tests

### DIFF
--- a/.github/build_tools/generate_skip_tests.py
+++ b/.github/build_tools/generate_skip_tests.py
@@ -1,84 +1,162 @@
 #!/usr/bin/env python3
-"""Generate skip_tests.txt for rocm-examples CI.
+"""Generate CI skip artifacts for rocm-examples from the unified manifest.
 
-Output file is used by ctest --exclude-from-file in the workflow.
-Run from repo root or with --output-dir pointing at .github/build_tools.
+Reads ``skip_manifest.SKIP_MANIFEST`` (the single source of truth) and, filtered
+by the requested channel/target/distro, emits:
+
+  * ``skip_tests.txt``  -- ctest names (scope contains "test", ctest key set).
+                           Consumed by ``ctest --exclude-from-file``.
+  * ``skip_build.txt``  -- repo-relative paths (scope contains "build").
+                           Consumed by ``Common/SkipExamples.cmake``.
+  * ``SKIP_FROM_TEST``  -- space-separated repo-relative leaf paths (scope test).
+  * ``SKIP_FROM_BUILD`` -- space-separated repo-relative leaf paths (scope build).
+
+``SKIP_FROM_*`` carry full paths (e.g. ``Libraries/hipFFT/callback``), not bare
+dir names, so a shared leaf name like ``callback`` — which exists under hipFFT,
+rocFFT, AND rocProfiler-SDK/counter_collection — only skips the intended one. The
+participating parent Makefiles match these paths against their own directory; all
+other Makefiles filter bare names and therefore ignore the path entries.
+
+The two ``SKIP_FROM_*`` values are echoed to stdout and, when running under
+GitHub Actions, appended to ``$GITHUB_ENV`` so the build/test steps can pass them
+on the ``make`` command line. A human-readable summary is printed and, when
+available, appended to ``$GITHUB_STEP_SUMMARY``.
+
+NOTE: a bare local ``make``/``make test`` (without running this generator) skips
+nothing — CI passes the generated lists explicitly. To reproduce a CI skip
+locally, run this script and pass the echoed SKIP_FROM_* on the make line.
 """
 
 import argparse
 import os
 
-# Tests to skip unconditionally on all targets/distros (upstream bugs in TheRock nightlies).
-GLOBAL_SKIP_TESTS = [
-    # ROCm/rocm-systems#7263: HIP CLR cannot resolve static device symbols via hipModuleGetGlobal.
-    # rocFFT's default store callback (store_cb_default_complex_double) is a static local
-    # function whose .static.<hash> mangled name causes an abort at runtime.
-    "hipfft_callback",
-    "rocfft_callback",
-]
+from skip_manifest import SKIP_MANIFEST
 
-# Tests to skip per GPU target (one list per target that has skips)
-SKIP_TESTS = {
-    # Add more targets as needed, e.g.:
-    # "gfx1100": [],
-}
 
-# Tests to skip for a specific GPU target + distro combination.
-# Keys are "<gpu_target>:<distro_key>", e.g. "gfx1151:sles-15.7".
-DISTRO_SKIP_TESTS = {
-    # Example:
-    # "gfx1151:sles-15.7": ["some_test"],
-}
+def _entry_applies(entry, channel, target, distro):
+    """Return True if this manifest entry applies to the requested context.
+
+    A filter that is absent from the entry matches everything. A filter that is
+    present must contain the requested value.
+    """
+    if "channels" in entry and channel not in entry["channels"]:
+        return False
+    if target and "targets" in entry and target not in entry["targets"]:
+        return False
+    if distro and "distros" in entry and distro not in entry["distros"]:
+        return False
+    return True
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate skip_tests.txt for rocm-examples CI."
+        description="Generate CI skip artifacts for rocm-examples."
     )
     parser.add_argument(
         "--output-dir",
         default=os.path.join(os.path.dirname(__file__)),
-        help="Directory to write skip_tests.txt (default: script dir)",
+        help="Directory to write skip_tests.txt / skip_build.txt (default: script dir)",
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        choices=["stable", "nightly"],
+        help="CI channel: 'stable' = pinned rocm:7.14 native workflows, "
+        "'nightly' = TheRock multi-arch reusable workflow",
     )
     parser.add_argument(
         "--target",
-        required=True,
-        help="GPU target whose skip list to write (e.g. gfx1151)",
+        default="",
+        help="GPU target for target-specific skips (e.g. gfx1100)",
     )
     parser.add_argument(
         "--distro",
         default="",
-        help="Distro key for distro-specific skips (e.g. sles-15.7)",
+        help="Distro key for distro-specific skips (e.g. ubuntu-24.04)",
     )
     args = parser.parse_args()
 
-    lines = list(GLOBAL_SKIP_TESTS)
-    for test in SKIP_TESTS.get(args.target, []):
-        if test not in lines:
-            lines.append(test)
+    applicable = [
+        e
+        for e in SKIP_MANIFEST
+        if _entry_applies(e, args.channel, args.target, args.distro)
+    ]
 
-    if args.distro:
-        combo_key = f"{args.target}:{args.distro}"
-        distro_lines = DISTRO_SKIP_TESTS.get(combo_key, [])
-        for test in distro_lines:
-            if test not in lines:
-                lines.append(test)
+    # Preserve manifest order, de-dup while keeping first occurrence.
+    def _unique(seq):
+        seen = set()
+        out = []
+        for x in seq:
+            if x not in seen:
+                seen.add(x)
+                out.append(x)
+        return out
+
+    skip_tests = _unique(
+        e["ctest"]
+        for e in applicable
+        if "test" in e["scope"] and e.get("ctest")
+    )
+    skip_build_paths = _unique(
+        e["path"] for e in applicable if "build" in e["scope"]
+    )
+    skip_from_test = _unique(
+        e["path"] for e in applicable if "test" in e["scope"]
+    )
+    skip_from_build = _unique(
+        e["path"] for e in applicable if "build" in e["scope"]
+    )
 
     os.makedirs(args.output_dir, exist_ok=True)
-    path = os.path.join(args.output_dir, "skip_tests.txt")
-    with open(path, "w") as f:
-        if lines:
-            f.write("\n".join(lines))
-            f.write("\n")
 
-    label = args.target
+    tests_path = os.path.join(args.output_dir, "skip_tests.txt")
+    with open(tests_path, "w") as f:
+        if skip_tests:
+            f.write("\n".join(skip_tests) + "\n")
+
+    build_path = os.path.join(args.output_dir, "skip_build.txt")
+    with open(build_path, "w") as f:
+        if skip_build_paths:
+            f.write("\n".join(skip_build_paths) + "\n")
+
+    skip_from_test_str = " ".join(skip_from_test)
+    skip_from_build_str = " ".join(skip_from_build)
+
+    # Echo the make variables so they can be captured / eyeballed.
+    print(f"SKIP_FROM_TEST={skip_from_test_str}")
+    print(f"SKIP_FROM_BUILD={skip_from_build_str}")
+
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with open(github_env, "a") as f:
+            f.write(f"SKIP_FROM_TEST={skip_from_test_str}\n")
+            f.write(f"SKIP_FROM_BUILD={skip_from_build_str}\n")
+
+    # Human-readable summary.
+    label_bits = [f"channel={args.channel}"]
+    if args.target:
+        label_bits.append(f"target={args.target}")
     if args.distro:
-        label = f"{args.target} + {args.distro}"
+        label_bits.append(f"distro={args.distro}")
+    label = ", ".join(label_bits)
 
-    if not lines:
-        print(f"No tests to skip for {label}.")
+    summary_lines = [f"### rocm-examples skip manifest ({label})", ""]
+    if applicable:
+        summary_lines.append("| example | scope | reason |")
+        summary_lines.append("| --- | --- | --- |")
+        for e in applicable:
+            summary_lines.append(
+                f"| `{e['path']}` | {'+'.join(e['scope'])} | {e['reason']} |"
+            )
     else:
-        print(f"Wrote {path} ({len(lines)} tests for {label})")
+        summary_lines.append("_No examples skipped._")
+    summary = "\n".join(summary_lines)
+    print(summary)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(summary + "\n")
 
 
 if __name__ == "__main__":

--- a/.github/build_tools/generate_skip_tests.py
+++ b/.github/build_tools/generate_skip_tests.py
@@ -33,7 +33,7 @@ import os
 from skip_manifest import SKIP_MANIFEST
 
 
-def _entry_applies(entry, channel, target, distro):
+def _entry_applies(entry, channel, target, distro, install_method):
     """Return True if this manifest entry applies to the requested context.
 
     A filter that is absent from the entry matches everything. A filter that is
@@ -44,6 +44,12 @@ def _entry_applies(entry, channel, target, distro):
     if target and "targets" in entry and target not in entry["targets"]:
         return False
     if distro and "distros" in entry and distro not in entry["distros"]:
+        return False
+    if (
+        install_method
+        and "install_methods" in entry
+        and install_method not in entry["install_methods"]
+    ):
         return False
     return True
 
@@ -74,12 +80,21 @@ def main():
         default="",
         help="Distro key for distro-specific skips (e.g. ubuntu-24.04)",
     )
+    parser.add_argument(
+        "--install-method",
+        default="",
+        help="Install method for method-specific skips (e.g. whl-multi-arch, "
+        "tarball-multi-arch, preinstalled). whl and tarball are both the "
+        "'nightly' channel but ship different payloads.",
+    )
     args = parser.parse_args()
 
     applicable = [
         e
         for e in SKIP_MANIFEST
-        if _entry_applies(e, args.channel, args.target, args.distro)
+        if _entry_applies(
+            e, args.channel, args.target, args.distro, args.install_method
+        )
     ]
 
     # Preserve manifest order, de-dup while keeping first occurrence.
@@ -138,6 +153,8 @@ def main():
         label_bits.append(f"target={args.target}")
     if args.distro:
         label_bits.append(f"distro={args.distro}")
+    if args.install_method:
+        label_bits.append(f"install_method={args.install_method}")
     label = ", ".join(label_bits)
 
     summary_lines = [f"### rocm-examples skip manifest ({label})", ""]

--- a/.github/build_tools/skip_manifest.py
+++ b/.github/build_tools/skip_manifest.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Single source of truth for rocm-examples CI skips.
+
+Every skip in the repo — whether it applies to the ctest run, the `make test`
+run, the CMake build, or the `make` build — is one entry in ``SKIP_MANIFEST``.
+The generator (``generate_skip_tests.py``) reads this list and produces the
+per-consumer artifacts:
+
+  * ``skip_tests.txt``  -> consumed by ``ctest --exclude-from-file``
+  * ``skip_build.txt``  -> consumed by ``Common/SkipExamples.cmake``
+  * ``SKIP_FROM_TEST``  -> passed on the ``make test`` command line
+  * ``SKIP_FROM_BUILD`` -> passed on the ``make`` command line
+
+Entry fields
+------------
+ctest    : str | None
+    The leaf ``example_name`` (globally unique CMake target / ctest name, set at
+    ``<leaf>/CMakeLists.txt`` line 23, e.g. ``rocfft_callback``). Used ONLY by
+    ctest: it is what goes into ``skip_tests.txt`` for ``ctest
+    --exclude-from-file``. ``None`` when the example registers no ctest test, or
+    when ctest already self-guards the test (rocDecode guards on test-data
+    existence via ``if(EXISTS ...)``) -- then there is nothing for ctest to skip.
+path     : str
+    Repo-root-relative path to the leaf (e.g. ``Libraries/hipFFT/callback``).
+    Used by everything EXCEPT ctest: the ``make`` skip (``SKIP_FROM_*``, matched
+    per-directory in the Makefiles) and the CMake ``add_subdirectory`` override
+    (exact match). It disambiguates the three ``callback`` directories so a skip
+    never hits the wrong one (e.g. rocProfiler-SDK's callback stays built).
+scope    : list[str]
+    Subset of {"build", "test"}. "build" removes the example from compilation
+    (CMake + make); "test" removes it only from the test run (ctest + make test).
+reason   : str
+    Human-readable justification (shown in the CI step summary).
+
+Optional filters (absent = applies everywhere)
+----------------------------------------------
+channels : list[str]  -- subset of {"stable", "nightly"}. "stable" = the pinned
+    native workflows; "nightly" = the TheRock multi-arch reusable workflow. Use
+    this to scope a skip to only one CI channel.
+targets  : list[str]  -- match against the --target value (e.g. "gfx1100").
+distros  : list[str]  -- match against the --distro value (e.g. "ubuntu-24.04").
+
+How to add a skip
+-----------------
+``path`` is essentially always required -- it drives make (both build and test)
+and the CMake build. ``ctest`` is only added on top when you are skipping a test
+that the ctest run actually registers.
+
+A BUILD skip implies a TEST skip everywhere -- scope = ["build"] is enough.
+On the ctest side the CMake override makes add_test never register. On the make
+side the `test:` target filters out SKIP_FROM_BUILD in addition to
+SKIP_FROM_TEST (an example that isn't built can't be tested), so `make test`
+won't try to rebuild+run a build-skipped example. You only need scope "test"
+when you want to skip a test WITHOUT skipping its build (the example compiles
+fine but the test itself must not run).
+
+Pick the row that matches what you want:
+
+  * Skip the BUILD (example won't compile on this image/target):
+        scope = ["build"], set ``path``, leave ``ctest`` = None.
+        -> CMake override + `make` (SKIP_FROM_BUILD) drop it from the build;
+           ctest skips it implicitly (add_test never registers) and `make test`
+           skips it too (its `test:` target also filters SKIP_FROM_BUILD).
+
+  * Skip only the TEST, and the test IS registered in ctest (runs and fails):
+        scope = ["test"], set ``path`` AND ``ctest``.
+        -> ctest --exclude-from-file (via ctest) + `make test` (via path).
+
+  * Skip only the TEST, but CMake self-guards add_test (e.g. `if(EXISTS ...)`,
+    like rocDecode) so ctest never sees it:
+        scope = ["test"], set ``path``, leave ``ctest`` = None.
+        -> only `make test` needs skipping (via path); ctest has nothing to skip.
+
+Then optionally narrow with channels / targets / distros (absent =
+applies everywhere). Always include a ``reason``.
+"""
+
+# rocDecode leaf directories. All ten need the same test-only skip: they require
+# video test data under $ROCM_PATH/share/rocdecode that CI images don't carry.
+# ctest self-guards each on `if(EXISTS ...)`, so ctest key is None; only the
+# `make test` path needs the explicit skip.
+_ROCDECODE_DIRS = [
+    "rocdec_decode",
+    "video_decode",
+    "video_decode_batch",
+    "video_decode_mem",
+    "video_decode_multi_files",
+    "video_decode_perf",
+    "video_decode_pic_files",
+    "video_decode_raw",
+    "video_decode_rgb",
+    "video_to_sequence",
+]
+
+SKIP_MANIFEST = [
+    # --- FFT callbacks: test-only, all channels ---------------------------
+    # ROCm/rocm-systems#7263: HIP CLR cannot resolve static device symbols via
+    # hipModuleGetGlobal; the default store callback aborts at runtime.
+    {
+        "ctest": "hipfft_callback",
+        "path": "Libraries/hipFFT/callback",
+        "scope": ["test"],
+        "reason": "ROCm/rocm-systems#7263 static device symbol abort at runtime",
+    },
+    {
+        "ctest": "rocfft_callback",
+        "path": "Libraries/rocFFT/callback",
+        "scope": ["test"],
+        "reason": "ROCm/rocm-systems#7263 static device symbol abort at runtime",
+    },
+    # --- rocDecode: test-only, all channels, no ctest key -----------------
+    *[
+        {
+            "ctest": None,
+            "path": f"Libraries/rocDecode/{d}",
+            "scope": ["test"],
+            "reason": "requires video test data under $ROCM_PATH/share/rocdecode",
+        }
+        for d in _ROCDECODE_DIRS
+    ],
+    # --- Stable-only build skip (channel-scoping demonstrator) ------------
+    # NOTE: HIP-Basic/cooperative_groups_prefix_sum does not currently exist on
+    # amd-staging (only HIP-Basic/cooperative_groups). This entry is inert until
+    # that example lands; it documents the stable-only build-skip mechanism.
+    # hip_scan.h is absent from the pinned 7.14 stable image (version skew),
+    # so if/when the example is added it will not compile on that image.
+    {
+        "ctest": None,
+        "path": "HIP-Basic/cooperative_groups_prefix_sum",
+        "scope": ["build"],
+        "channels": ["stable"],
+        "reason": "hip_scan.h not present in the pinned 7.14 stable image (version skew)",
+    },
+]

--- a/.github/build_tools/skip_manifest.py
+++ b/.github/build_tools/skip_manifest.py
@@ -39,6 +39,10 @@ channels : list[str]  -- subset of {"stable", "nightly"}. "stable" = the pinned
     this to scope a skip to only one CI channel.
 targets  : list[str]  -- match against the --target value (e.g. "gfx1100").
 distros  : list[str]  -- match against the --distro value (e.g. "ubuntu-24.04").
+install_methods : list[str]  -- match against the --install-method value (e.g.
+    "whl-multi-arch", "tarball-multi-arch", "preinstalled"). Use this to scope a
+    skip to a specific packaging: whl and tarball are both the "nightly" channel
+    but ship different payloads, so this axis is orthogonal to ``channels``.
 
 How to add a skip
 -----------------
@@ -75,10 +79,14 @@ Then optionally narrow with channels / targets / distros (absent =
 applies everywhere). Always include a ``reason``.
 """
 
-# rocDecode leaf directories. All ten need the same test-only skip: they require
-# video test data under $ROCM_PATH/share/rocdecode that CI images don't carry.
-# ctest self-guards each on `if(EXISTS ...)`, so ctest key is None; only the
-# `make test` path needs the explicit skip.
+# rocDecode leaf directories. All ten need the video test data + utility sources
+# under $ROCM_PATH/share/rocdecode. The pinned stable image ships these via the
+# amdrocm-decode-test package, and the nightly tarball carries them too, so
+# rocDecode builds and its tests run in both. The nightly whl install does NOT
+# carry the data, so the make-test skip is scoped to that install method.
+# ctest self-guards each on `if(EXISTS ...)`, so the ctest key is None (ctest
+# auto-skips where the data is absent); only the `make test` path needs the
+# explicit, install-method-scoped skip.
 _ROCDECODE_DIRS = [
     "rocdec_decode",
     "video_decode",
@@ -108,27 +116,28 @@ SKIP_MANIFEST = [
         "scope": ["test"],
         "reason": "ROCm/rocm-systems#7263 static device symbol abort at runtime",
     },
-    # --- rocDecode: test-only, all channels, no ctest key -----------------
+    # --- rocDecode: test-only, nightly whl install only, no ctest key -----
+    # The stable image (amdrocm-decode-test) and the nightly tarball carry the
+    # video data, so their tests run; the nightly whl install doesn't, so skip
+    # make test only there.
     *[
         {
             "ctest": None,
             "path": f"Libraries/rocDecode/{d}",
             "scope": ["test"],
-            "reason": "requires video test data under $ROCM_PATH/share/rocdecode",
+            "channels": ["nightly"],
+            "install_methods": ["whl-multi-arch"],
+            "reason": "video test data absent from the TheRock nightly whl install (present on the stable image via amdrocm-decode-test and in the nightly tarball)",
         }
         for d in _ROCDECODE_DIRS
     ],
-    # --- Stable-only build skip (channel-scoping demonstrator) ------------
-    # NOTE: HIP-Basic/cooperative_groups_prefix_sum does not currently exist on
-    # amd-staging (only HIP-Basic/cooperative_groups). This entry is inert until
-    # that example lands; it documents the stable-only build-skip mechanism.
-    # hip_scan.h is absent from the pinned 7.14 stable image (version skew),
-    # so if/when the example is added it will not compile on that image.
+    # --- Stable-only build skip ------------
+    # hip_scan.h is absent from the pinned 7.14 stable image
     {
         "ctest": None,
         "path": "HIP-Basic/cooperative_groups_prefix_sum",
         "scope": ["build"],
         "channels": ["stable"],
-        "reason": "hip_scan.h not present in the pinned 7.14 stable image (version skew)",
+        "reason": "hip_scan.h not present in the pinned 7.14 stable image",
     },
 ]

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -101,15 +101,22 @@ jobs:
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
+      - name: Generate skip lists
+        run: |
+          python3 .github/build_tools/generate_skip_tests.py \
+            --channel nightly \
+            --target "${{ matrix.gpu_config.gpu_target }}" \
+            --distro "${{ inputs.distro }}"
+
       - name: Makefile build
         run: |
           ./Scripts/configure.sh --rocm-path="${ROCM_PATH}"
-          make -j HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}"
+          make -j HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_BUILD="$SKIP_FROM_BUILD"
 
       - name: CMake configure
         if: ${{ !cancelled() }}
         run: |
-          cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" 2> >(tee cmake_error.log >&2)
+          cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" 2> >(tee cmake_error.log >&2)
 
       - name: CMake configure error summary
         if: ${{ !cancelled() }}
@@ -177,8 +184,7 @@ jobs:
       - name: Run tests
         if: ${{ !cancelled() }}
         run: |
-          python3 .github/build_tools/generate_skip_tests.py --target ${{ matrix.gpu_config.gpu_target }} --distro ${{ inputs.distro }}
-
+          # skip_tests.txt was produced by the "Generate skip lists" step.
           SKIP_FILE="${GITHUB_WORKSPACE}/.github/build_tools/skip_tests.txt"
           if [ -s "${SKIP_FILE}" ]; then
             echo "## Skipped tests" >> $GITHUB_STEP_SUMMARY
@@ -244,7 +250,7 @@ jobs:
       - name: Makefile test
         if: ${{ !cancelled() }}
         run: |
-          make test HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" 2>&1 | tee makefile_test_output.log
+          make test HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_TEST="$SKIP_FROM_TEST" 2>&1 | tee makefile_test_output.log
 
       - name: Upload Makefile test logs
         if: ${{ !cancelled() }}

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -60,9 +60,6 @@ jobs:
         id: sanity-check
         continue-on-error: true
         run: |
-          ROCM_VERSION=$(rocm-sdk version)
-          echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
-          echo "## ROCm Version: ${ROCM_VERSION}" >> $GITHUB_STEP_SUMMARY
           rocm-sdk init
           rocm-sdk test
 
@@ -184,19 +181,9 @@ jobs:
       - name: Run tests
         if: ${{ !cancelled() }}
         run: |
-          # skip_tests.txt was produced by the "Generate skip lists" step.
+          # skip_tests.txt was produced by the "Generate skip lists" step,
+          # which also reports the full skip manifest to the step summary.
           SKIP_FILE="${GITHUB_WORKSPACE}/.github/build_tools/skip_tests.txt"
-          if [ -s "${SKIP_FILE}" ]; then
-            echo "## Skipped tests" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            cat "${SKIP_FILE}" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "No tests skipped." >> $GITHUB_STEP_SUMMARY
-          fi
-
           ctest --test-dir build --output-on-failure --exclude-from-file "${SKIP_FILE}" 2>&1 | tee ctest_output.log
 
       - name: Test summary

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -103,7 +103,8 @@ jobs:
           python3 .github/build_tools/generate_skip_tests.py \
             --channel nightly \
             --target "${{ matrix.gpu_config.gpu_target }}" \
-            --distro "${{ inputs.distro }}"
+            --distro "${{ inputs.distro }}" \
+            --install-method "${{ matrix.install_method }}"
 
       - name: Makefile build
         run: |

--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -31,12 +31,15 @@ jobs:
                 shell: bash
         steps:
           - uses: actions/checkout@v4
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             run: |
               cd Applications
-              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
+              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build -j
           - name: Make
             run: |
               cd Applications
-              make -j
+              make -j SKIP_FROM_BUILD="$SKIP_FROM_BUILD"

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -31,12 +31,15 @@ jobs:
                 shell: bash
         steps:
           - uses: actions/checkout@v4
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             run: |
               cd HIP-Basic
-              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
+              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build -j
           - name: Make
             run: |
               cd HIP-Basic
-              make -j
+              make -j SKIP_FROM_BUILD="$SKIP_FROM_BUILD"

--- a/.github/workflows/build_hip_documentation.yml
+++ b/.github/workflows/build_hip_documentation.yml
@@ -31,15 +31,18 @@ jobs:
                 shell: bash
         steps:
           - uses: actions/checkout@v4
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             # The CMAKE_POLICY_VERSION_MINIMUM environment variable can be removed once the CMake updates from ROCm 7.0 are available
             run: |
               cd HIP-Doc
               export CMAKE_POLICY_VERSION_MINIMUM="3.5"
-              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
+              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build -j
           - name: Make
             run: |
               cd HIP-Doc
               export HSA_XNACK=1
-              make -j
+              make -j SKIP_FROM_BUILD="$SKIP_FROM_BUILD"

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -58,15 +58,18 @@ jobs:
               fi
               echo "ENABLE_CK=${ENABLE_CK}" >> $GITHUB_ENV
               echo "ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK}"
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             run: |
               cd Libraries
-              cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} -DROCM_EXAMPLES_ENABLE_OPENMP=ON -S . -B build
+              cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} -DROCM_EXAMPLES_ENABLE_OPENMP=ON -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build --parallel $(nproc)
           - name: Make
             run: |
               cd Libraries
-              make -j $(nproc) ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} HIP_ARCHITECTURES="${GPU_TARGETS}"
+              make -j $(nproc) ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} HIP_ARCHITECTURES="${GPU_TARGETS}" SKIP_FROM_BUILD="$SKIP_FROM_BUILD"
 
           # Clean the workspace here since other jobs may not have the permissions to do so later
           # (needed for self-hosted runners)

--- a/.github/workflows/build_programming_guide.yml
+++ b/.github/workflows/build_programming_guide.yml
@@ -31,12 +31,15 @@ jobs:
                 shell: bash
         steps:
           - uses: actions/checkout@v4
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             run: |
               cd Programming-Guide
-              cmake -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
+              cmake -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build -j
           - name: Make
             run: |
               cd Programming-Guide
-              make -j
+              make -j SKIP_FROM_BUILD="$SKIP_FROM_BUILD"

--- a/.github/workflows/build_systems.yml
+++ b/.github/workflows/build_systems.yml
@@ -31,12 +31,15 @@ jobs:
                 shell: bash
         steps:
           - uses: actions/checkout@v4
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             run: |
               cd Systems
-              cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
+              cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build -j $(nproc)
           - name: Make
             run: |
               cd Systems
-              make -j $(nproc)
+              make -j $(nproc) SKIP_FROM_BUILD="$SKIP_FROM_BUILD"

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -30,12 +30,15 @@ jobs:
                 shell: bash
         steps:
           - uses: actions/checkout@v4
+          - name: Generate skip lists
+            run: |
+              python3 .github/build_tools/generate_skip_tests.py --channel stable --target "${GPU_TARGETS%%;*}"
           - name: CMake Configure and Build
             run: |
               cd Tools
-              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
+              cmake -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" -S . -B build
               cmake --build build -j
           - name: Make
             run: |
               cd Tools
-              make -j
+              make -j SKIP_FROM_BUILD="$SKIP_FROM_BUILD"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ CMakeUserPresets.json
 .cline_storage
 config.mk
 .claude/
+
+# Generated at CI time by .github/build_tools/generate_skip_tests.py
+.github/build_tools/skip_tests.txt
+.github/build_tools/skip_build.txt
+__pycache__/

--- a/Common/SkipExamples.cmake
+++ b/Common/SkipExamples.cmake
@@ -1,0 +1,64 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Build-skip hook for rocm-examples CI.
+#
+# Injected via `-DCMAKE_PROJECT_INCLUDE_BEFORE=<repo>/Common/SkipExamples.cmake`,
+# so CMake runs it at the start of every project() call. It overrides
+# add_subdirectory() to drop any example whose repo-root-relative path appears in
+# `.github/build_tools/skip_build.txt` (generated from skip_manifest.py). A
+# skipped leaf's project()/add_executable()/add_test() never run, so no dangling
+# target and no ctest entry are created.
+#
+# The override is installed exactly once (guarded by a cache variable). Because
+# CMake function overrides are inherited by subdirectories, installing it at the
+# first project() call intercepts every add_subdirectory() at any depth.
+
+if(NOT DEFINED ROCM_EXAMPLES_SKIP_BUILD_INITIALIZED)
+    set(ROCM_EXAMPLES_SKIP_BUILD_INITIALIZED TRUE CACHE INTERNAL "")
+
+    # This file lives in <repo>/Common, so the repo root is one directory up.
+    # It is stable regardless of which folder root cmake -S points at.
+    get_filename_component(_rocm_examples_root "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+    set(ROCM_EXAMPLES_ROOT "${_rocm_examples_root}" CACHE INTERNAL "")
+
+    set(_skip_file "${ROCM_EXAMPLES_ROOT}/.github/build_tools/skip_build.txt")
+    set(_skip_list "")
+    if(EXISTS "${_skip_file}")
+        file(STRINGS "${_skip_file}" _skip_list)
+    endif()
+    set(ROCM_EXAMPLES_SKIP_BUILD "${_skip_list}" CACHE INTERNAL "")
+
+    if(ROCM_EXAMPLES_SKIP_BUILD)
+        message(STATUS "SkipExamples: build-skip list = ${ROCM_EXAMPLES_SKIP_BUILD}")
+    endif()
+
+    function(add_subdirectory dir)
+        get_filename_component(_abs "${dir}" ABSOLUTE)
+        file(RELATIVE_PATH _rel "${ROCM_EXAMPLES_ROOT}" "${_abs}")
+        if("${_rel}" IN_LIST ROCM_EXAMPLES_SKIP_BUILD)
+            message(WARNING "SkipExamples: skipping ${_rel} (build-skip manifest)")
+            return()
+        endif()
+        _add_subdirectory("${dir}" ${ARGN})
+    endfunction()
+endif()

--- a/Libraries/hipFFT/Makefile
+++ b/Libraries/hipFFT/Makefile
@@ -28,15 +28,25 @@ EXAMPLES := \
   plan_z2z \
   setworkarea
 
-# ROCm/rocm-systems#7263: static device symbols in rocFFT callbacks abort at runtime
-SKIP_FROM_TEST := callback
+# Skips are driven by .github/build_tools/skip_manifest.py: CI runs
+# generate_skip_tests.py and passes SKIP_FROM_BUILD / SKIP_FROM_TEST as
+# repo-relative paths on the make command line (overriding these defaults).
+# skip_here matches only entries naming THIS directory's examples, so a shared
+# leaf name like `callback` (also under rocProfiler-SDK) is not skipped by
+# mistake. A bare local build/test skips nothing. The `callback` example is
+# test-skipped in CI (ROCm/rocm-systems#7263: static device symbols in FFT
+# callbacks abort at runtime). The `test` target honors SKIP_FROM_BUILD too: an
+# example that isn't built can't be tested, so build skips imply test skips.
+SKIP_FROM_BUILD ?=
+SKIP_FROM_TEST ?=
+skip_here = $(foreach e,$(EXAMPLES),$(if $(filter %/$(notdir $(CURDIR))/$(e),$(1)),$(e)))
 
 ifneq ($(GPU_RUNTIME), CUDA)
   EXAMPLES += \
     callback
 endif
 
-all: $(EXAMPLES)
+all: $(filter-out $(call skip_here,$(SKIP_FROM_BUILD)),$(EXAMPLES))
 
 clean: TARGET=clean
 clean: all
@@ -45,6 +55,6 @@ $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
 test: TARGET=test
-test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+test: $(filter-out $(call skip_here,$(SKIP_FROM_TEST) $(SKIP_FROM_BUILD)),$(EXAMPLES))
 
 .PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocDecode/Makefile
+++ b/Libraries/rocDecode/Makefile
@@ -32,15 +32,20 @@ EXAMPLES := \
 	video_decode_rgb \
 	video_to_sequence
 
-# All rocDecode tests are skipped by default: they require test data
-# (videos under $(ROCM_PATH)/share/rocdecode/) that ctest guards behind
-# `if(EXISTS …)` checks. Encoding the same conditional logic in Make is
-# possible but noisy; for now skip the whole subtree so `make test` from
-# root stays clean. To run rocDecode tests manually, cd into the leaf
-# Makefile and run `make test`.
-SKIP_FROM_TEST := $(EXAMPLES)
+# All rocDecode examples need video test data (under $(ROCM_PATH)/share/rocdecode)
+# that CI images don't carry, so every example is test-skipped. The skip is now
+# driven by .github/build_tools/skip_manifest.py: CI runs generate_skip_tests.py
+# and passes SKIP_FROM_TEST (all ten example paths) on the make command line,
+# overriding this default. skip_here matches only entries naming THIS directory's
+# examples. A bare local `make test` runs them; to skip manually, pass
+# SKIP_FROM_TEST or cd into a leaf and control it there. The `test` target honors
+# SKIP_FROM_BUILD too: an example that isn't built can't be tested, so build
+# skips imply test skips.
+SKIP_FROM_BUILD ?=
+SKIP_FROM_TEST ?=
+skip_here = $(foreach e,$(EXAMPLES),$(if $(filter %/$(notdir $(CURDIR))/$(e),$(1)),$(e)))
 
-all: $(EXAMPLES)
+all: $(filter-out $(call skip_here,$(SKIP_FROM_BUILD)),$(EXAMPLES))
 
 clean: TARGET=clean
 clean: all
@@ -49,6 +54,6 @@ $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
 test: TARGET=test
-test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+test: $(filter-out $(call skip_here,$(SKIP_FROM_TEST) $(SKIP_FROM_BUILD)),$(EXAMPLES))
 
 .PHONY: all clean test $(EXAMPLES)

--- a/Libraries/rocFFT/Makefile
+++ b/Libraries/rocFFT/Makefile
@@ -30,10 +30,20 @@ EXAMPLES := \
   multi_gpu \
   real_complex
 
-# ROCm/rocm-systems#7263: static device symbols in rocFFT callbacks abort at runtime
-SKIP_FROM_TEST := callback
+# Skips are driven by .github/build_tools/skip_manifest.py: CI runs
+# generate_skip_tests.py and passes SKIP_FROM_BUILD / SKIP_FROM_TEST as
+# repo-relative paths on the make command line (overriding these defaults).
+# skip_here matches only entries naming THIS directory's examples, so a shared
+# leaf name like `callback` (also under rocProfiler-SDK) is not skipped by
+# mistake. A bare local build/test skips nothing. The `callback` example is
+# test-skipped in CI (ROCm/rocm-systems#7263: static device symbols in rocFFT
+# callbacks abort at runtime). The `test` target honors SKIP_FROM_BUILD too: an
+# example that isn't built can't be tested, so build skips imply test skips.
+SKIP_FROM_BUILD ?=
+SKIP_FROM_TEST ?=
+skip_here = $(foreach e,$(EXAMPLES),$(if $(filter %/$(notdir $(CURDIR))/$(e),$(1)),$(e)))
 
-all: $(EXAMPLES)
+all: $(filter-out $(call skip_here,$(SKIP_FROM_BUILD)),$(EXAMPLES))
 
 clean: TARGET=clean
 clean: all
@@ -42,6 +52,6 @@ $(EXAMPLES):
 	$(MAKE) -C $@ $(TARGET)
 
 test: TARGET=test
-test: $(filter-out $(SKIP_FROM_TEST),$(EXAMPLES))
+test: $(filter-out $(call skip_here,$(SKIP_FROM_TEST) $(SKIP_FROM_BUILD)),$(EXAMPLES))
 
 .PHONY: all clean test $(EXAMPLES)


### PR DESCRIPTION
## Motivation

Enable's build skipping in CI.

Introduce a single source of truth (`.github/build_tools/skip_manifest.py`) feeding all four skip consumers: ctest (skip_tests.txt), CMake build (Common/SkipExamples.cmake via CMAKE_PROJECT_INCLUDE_BEFORE), make build (SKIP_FROM_BUILD), and make test (SKIP_FROM_TEST). Migrates the previously scattered static Makefile skips (hipFFT/rocFFT callback, all rocDecode examples) into the manifest.

## Technical Details

Skips carry repo-relative paths so a shared leaf name like `callback` (present under hipFFT, rocFFT, and rocProfiler-SDK/counter_collection) only skips the intended example. A --channel {stable,nightly} flag plus per-entry `channels` filter scopes a skip to the pinned rocm:7.14 native workflows or the TheRock multi-arch nightly workflow independently.

Skip the new `cooperative_groups_prefix_sum` for 7.14 stable CI.

## Test Plan

CI run

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
