### PR TITLE
Add nightly GPU build+test on pinned stable ROCm 7.14 image

### DIFF
--- a/.github/build_tools/configure_ci.py
+++ b/.github/build_tools/configure_ci.py
@@ -14,6 +14,10 @@ GPU_CONFIG_MAP = {
 # Install methods for all distros (ROCm installed at CI runtime from TheRock nightlies).
 INSTALL_METHODS = ["whl-multi-arch", "tarball-multi-arch"]
 
+# "preinstalled" is a valid input but is NOT part of the default "all" expansion:
+# it only applies to images that already ship ROCm (e.g. the pinned stable image).
+PREINSTALLED = "preinstalled"
+
 # Distros to build against – keyed by short name.
 # "install_methods": omit to use the global INSTALL_METHODS list.
 # Add new entries here to enable more distros (also add to workflow_dispatch options).
@@ -23,6 +27,12 @@ DISTRO_MAP = {
     "almalinux-8":  {"image": "ghcr.io/rocm/rocm-examples-almalinux-8-multiarch:latest",  "label": "AlmaLinux 8"},
     "ubuntu-24.04": {"image": "ghcr.io/rocm/rocm-examples-ubuntu-24.04-multiarch:latest", "label": "Ubuntu 24.04"},
     "ubuntu-26.04": {"image": "ghcr.io/rocm/rocm-examples-ubuntu-26.04-multiarch:latest", "label": "Ubuntu 26.04"},
+    # Pinned stable image: ROCm baked in at /opt/rocm (no runtime install).
+    "stable_release": {
+        "image": "ghcr.io/rocm/rocm-examples-ubuntu-24.04-rocm:7.14",
+        "label": "Ubuntu 24.04 (ROCm 7.14)",
+        "install_methods": [PREINSTALLED],
+    },
 }
 
 def _is_all(value):
@@ -46,8 +56,9 @@ def main():
     if _is_all(install_input):
         install_methods = INSTALL_METHODS
     else:
-        if install_input not in INSTALL_METHODS:
-            raise ValueError(f"Invalid install method: {install_input}. Allowed: {INSTALL_METHODS}")
+        allowed_methods = INSTALL_METHODS + [PREINSTALLED]
+        if install_input not in allowed_methods:
+            raise ValueError(f"Invalid install method: {install_input}. Allowed: {allowed_methods}")
         install_methods = [install_input]
 
     # Determine distros

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -101,6 +101,22 @@ jobs:
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
+      - name: Setup environment variables (preinstalled)
+        if: ${{ matrix.install_method == 'preinstalled' }}
+        id: preinstalled
+        run: |
+          ROCM_VERSION=$(cat /opt/rocm/core/.info/version)
+          echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
+          echo "## ROCm Version: ${ROCM_VERSION} (preinstalled)" >> $GITHUB_STEP_SUMMARY
+
+          ROCM_PATH=/opt/rocm
+          echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
+          echo "HIP_PATH=${ROCM_PATH}" >> $GITHUB_ENV
+          echo "HIP_PLATFORM=amd" >> $GITHUB_ENV
+          echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
+          echo "ENABLE_CK=ON" >> $GITHUB_ENV
+          echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
+
       - name: Makefile build
         run: |
           ./Scripts/configure.sh --rocm-path="${ROCM_PATH}"
@@ -109,7 +125,7 @@ jobs:
       - name: CMake configure
         if: ${{ !cancelled() }}
         run: |
-          cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" 2> >(tee cmake_error.log >&2)
+          cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -DROCM_EXAMPLES_ENABLE_CK="${ENABLE_CK}" 2> >(tee cmake_error.log >&2)
 
       - name: CMake configure error summary
         if: ${{ !cancelled() }}
@@ -164,14 +180,14 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: rocm-examples-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version }}-${{ matrix.install_method }}
+          name: rocm-examples-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: build/
 
       - name: Upload Makefile build artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: makefile-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version }}-${{ matrix.install_method }}
+          name: makefile-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: /tmp/makefile_build/
 
       - name: Run tests
@@ -238,7 +254,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ctest-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version }}-${{ matrix.install_method }}
+          name: ctest-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: build/Testing/Temporary/
 
       - name: Makefile test
@@ -250,7 +266,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: makefile-test-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version }}-${{ matrix.install_method }}
+          name: makefile-test-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: makefile_test_output.log
 
       - name: Clean the workspace

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -111,7 +111,7 @@ jobs:
           echo "HIP_PATH=${ROCM_PATH}" >> $GITHUB_ENV
           echo "HIP_PLATFORM=amd" >> $GITHUB_ENV
           echo "ENABLE_OPENMP=ON" >> $GITHUB_ENV
-          echo "ENABLE_CK=ON" >> $GITHUB_ENV
+          echo "ENABLE_CK=OFF" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
       - name: Generate skip lists

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -39,6 +39,7 @@ on:
         - ubuntu-26.04
         - sles-15.7
         - almalinux-8
+        - stable_release
 permissions:
   contents: read
   packages: read

--- a/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
+++ b/Dockerfiles/ubuntu-24.04-rocm.Dockerfile
@@ -85,7 +85,12 @@ RUN echo "/opt/rocm/lib" >> /etc/ld.so.conf.d/rocm.conf \
 ENV ROCM_PATH="/opt/rocm"
 
 # Python packages required by ROCm tooling
-RUN python3 -m pip install --no-cache-dir --break-system-packages pyyaml
+ENV VENV=/opt/rocm-venv
+RUN python3 -m venv ${VENV}
+ENV PATH="${VENV}/bin:${PATH}"
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir pyyaml cmake
 
 WORKDIR /workspace
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Motivation

Add nightly stable version testing.

## Technical Details

Adds a "preinstalled" install method and a stable_release distro (the self-contained ghcr rocm:7.14 image with ROCm baked in at /opt/rocm) so the nightly matrix exercises the pinned stable ROCm on GPU hardware, not just the TheRock nightlies. CK and OpenMP are enabled for this job.

Disables CK due to version skew.

Add venv and install cmake from pip on the stable docker image.

## Test Plan

CI

## Test Result

Nightly runs pass

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
