### PR TITLE
fix: skip RPP examples when OpenCV is absent, add OpenCV to AlmaLinux & SLES

### DIFF
--- a/Dockerfiles/almalinux-8-multiarch.Dockerfile
+++ b/Dockerfiles/almalinux-8-multiarch.Dockerfile
@@ -57,7 +57,8 @@ RUN dnf install -y dnf-plugins-core && \
         libXinerama-devel \
         libXrandr-devel \
         libatomic \
-        libquadmath && \
+        libquadmath \
+        opencv-devel && \
     dnf clean all
 
 # GCC 8's libstdc++fs has an ABI-incompatible std::filesystem::path layout vs

--- a/Dockerfiles/sles-15.7-multiarch.Dockerfile
+++ b/Dockerfiles/sles-15.7-multiarch.Dockerfile
@@ -57,8 +57,10 @@ RUN zypper -qni update -y && \
 # evaluation until instantiation (P2593R1).
 # gcc13-c++ is not in the SLES base image and SUSEConnect requires registration,
 # so we pull it from the openSUSE Leap 15.6 OSS repo (binary-compatible with SLE 15).
+# opencv-devel, needed by the RPP examples, is absent from SLE_BCI for the same
+# reason and comes from the same repo.
 RUN zypper -qni addrepo -G https://download.opensuse.org/distribution/leap/15.6/repo/oss/ leap-oss && \
-    zypper -qni install -y gcc13-c++ libstdc++6-devel-gcc13 && \
+    zypper -qni install -y gcc13-c++ libstdc++6-devel-gcc13 opencv-devel && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 130 && \
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 130 && \

--- a/Libraries/RPP/CMakeLists.txt
+++ b/Libraries/RPP/CMakeLists.txt
@@ -82,6 +82,17 @@ if(NOT rpp_FOUND)
     endif()
 endif()
 
+# The examples read and write images with OpenCV. It is not part of ROCm and is not
+# packaged on every distribution we build on, so skip the examples when it is absent
+# instead of failing the whole configure step. The GNU Make build applies the same
+# rule via REQUIRED_DEPS := OPENCV.
+find_package(OpenCV QUIET)
+
+if(NOT OpenCV_FOUND)
+    message(WARNING "OpenCV could not be found, not building RPP examples")
+    return()
+endif()
+
 add_subdirectory(box_filter)
 add_subdirectory(brightness)
 add_subdirectory(contrast)


### PR DESCRIPTION
## Problem

The six RPP examples call `find_package(OpenCV REQUIRED)`. The AlmaLinux 8 and
SLES 15.7 images did not install OpenCV, so the first `add_subdirectory()` aborted
the entire configure step:

CMake Error at Libraries/RPP/box_filter/CMakeLists.txt:45 (find_package):
  By not providing "FindOpenCV.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OpenCV", but
  CMake did not find one.
-- Configuring incomplete, errors occurred!

Because no build tree was produced, the "Run tests" step then reported:

No tests found!!!

So **all 8 AlmaLinux and SLES nightly jobs have been contributing zero test
signal** — not just for RPP, but for the entire suite (~395 tests each). This has
been happening every night for at least the last 11 nightlies; still reproducing
in run
[32091528200](https://github.com/ROCm/rocm-examples/actions/runs/32091528200)
(2026-08-18), job 95574619894.

The Ubuntu images were unaffected because they already install `libopencv-dev`.
The omission on the other two distros looks unintentional rather than deliberate.

## Changes

**Install OpenCV in both images**, so the RPP examples are actually built and
tested on all four distros instead of skipped:

| Distro | Package | Version | Repository |
|---|---|---|---|
| AlmaLinux 8 | `opencv-devel` | 3.4.6 | `powertools` — already enabled |
| SLES 15.7 | `opencv-devel` | 4.9.0 | `leap-oss` — already added for `gcc13-c++`
|

Both repositories were already configured in the images, so no new package source
is introduced.

**Guard OpenCV once in `Libraries/RPP/CMakeLists.txt`** and skip the examples when
it is missing. This is defense-in-depth: a missing image dependency should
degrade to skipping six examples, not take down the configure step and the whole
test suite with it. It mirrors how that same file already handles a missing RPP,
and how the GNU Make build handles OpenCV via `REQUIRED_DEPS := OPENCV`. The leaf
`CMakeLists.txt` files keep `REQUIRED` so a standalone configure still reports the
missing dependency directly.

## Verification

Package availability, compilation and CMake discovery were checked in containers
matching each Dockerfile:

- **AlmaLinux 8** — `opencv-devel` 3.4.6 installs from `powertools`;
`find_package(OpenCV REQUIRED)` succeeds.
- **SLES 15.7** — `opencv-devel` 4.9.0 installs from `leap-oss`; `find_package`
reports `Found OpenCV: /usr (found version "4.9.0")`.
- A probe using the exact OpenCV API surface the examples rely on (`cv::Mat`,
`cv::imread`, `cv::imwrite`, `cv::cvtColor`, `cv::COLOR_BGR2RGB` /
`COLOR_RGB2BGR`, `CV_8UC1/2/3`) compiles and links on both. These are all
available in OpenCV 3 and 4, so the 3.4.6 on AlmaLinux is sufficient.
- Guard behaviour confirmed both ways: with OpenCV absent, configure emits the
warning and completes with exit 0; with OpenCV present, it proceeds to
`add_subdirectory`.

The images themselves were not rebuilt end-to-end locally, as that requires the
ROCm nightly tarball — CI covers that.

## Note

The Ubuntu jobs currently fail for a separate, unrelated reason: RPP 3.1.2 removed
the `rppt_*_gpu` entry points (`use of undeclared identifier
'rppt_brightness_gpu'`). That migration is not part of this PR. Once these two
distros get past configure they will hit the same compile error, so both fixes are
needed to green the nightly.

Two things you may want to adjust before posting:
- The RPP _gpu note assumes that migration isn't landing first — drop it if it is.
- If the repo's PR bot enforces a unit-test check (as rocm-libraries does), this
may get flagged; the "test" here is really CI itself going from 0 tests to ~395 on
those 8 jobs, which is worth saying in a reply if the bot complains.
