### PR TITLE
test: re-enable hipFFT and rocFFT callback tests

### DIFF
--- a/.github/build_tools/skip_manifest.py
+++ b/.github/build_tools/skip_manifest.py
@@ -101,21 +101,6 @@ _ROCDECODE_DIRS = [
 ]
 
 SKIP_MANIFEST = [
-    # --- FFT callbacks: test-only, all channels ---------------------------
-    # ROCm/rocm-systems#7263: HIP CLR cannot resolve static device symbols via
-    # hipModuleGetGlobal; the default store callback aborts at runtime.
-    {
-        "ctest": "hipfft_callback",
-        "path": "Libraries/hipFFT/callback",
-        "scope": ["test"],
-        "reason": "ROCm/rocm-systems#7263 static device symbol abort at runtime",
-    },
-    {
-        "ctest": "rocfft_callback",
-        "path": "Libraries/rocFFT/callback",
-        "scope": ["test"],
-        "reason": "ROCm/rocm-systems#7263 static device symbol abort at runtime",
-    },
     # --- rocDecode: test-only, nightly whl install only, no ctest key -----
     # The stable image (amdrocm-decode-test) and the nightly tarball carry the
     # video data, so their tests run; the nightly whl install doesn't, so skip

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -8,6 +8,7 @@ on:
     branches: [ amd-staging, amd-mainline, release/** ]
     paths:
       - '.github/workflows/**'
+      - '.github/build_tools/**'
   workflow_dispatch:
     inputs:
       gpu_config:

--- a/.github/workflows/ci_therock.yml
+++ b/.github/workflows/ci_therock.yml
@@ -16,6 +16,7 @@ on:
       - 'CMakeLists.txt'
       - 'Makefile'
       - '.github/workflows/**'
+      - '.github/build_tools/**'
   pull_request:
     branches: [ amd-staging, amd-mainline, release/** ]
     paths:
@@ -31,6 +32,7 @@ on:
       - 'CMakeLists.txt'
       - 'Makefile'
       - '.github/workflows/**'
+      - '.github/build_tools/**'
   workflow_dispatch:
     inputs:
       gpu_config:


### PR DESCRIPTION
## Summary

Re-enables the `hipfft_callback` and `rocfft_callback` tests by removing their
entries from `.github/build_tools/skip_manifest.py`.

## Why they were skipped

rocFFT's default store callback was a **static** device function, so the compiler
appended a `.static.<hash>` suffix to its mangled name. HIP CLR could not resolve
that symbol through `hipModuleGetGlobal`, and both examples aborted at runtime:

```
:0:.../clr/hipamd/src/hip_global.cpp:209 : Cannot create GlobalVar Obj for symbol:
_ZL31store_cb_default_complex_double.static.4d22c59b5a98cebc
```

Tracked as
[ROCm/rocm-systems#7263](https://github.com/ROCm/rocm-systems/issues/7263).

## Why it is safe to re-enable

The issue was fixed by [ROCm/rocm-libraries@004a100615a](https://github.com/ROCm/r
ocm-libraries/commit/004a100615a) — *"rocFFT: give default FFT callbacks external
linkage to fix hipModuleGlobal (#8477)"*, merged **2026-07-10**; #7263 was closed
the same day.

The default callbacks are now declared with external linkage rather than static:

```cpp
// projects/rocfft/library/src/device/kernels/callback.h:108
inline __device__ auto store_cb_default_complex_double =
store_cb_default<rocfft_complex<double>>;
```

No `.static.<hash>` suffix, so `hipModuleGetGlobal` resolves the symbol. The
commit is an ancestor of `develop` and predates the current nightly package by
roughly five weeks, so the fix is present in what CI tests against.

## Changes

Removed both entries from `SKIP_MANIFEST` (15 lines, one file). The examples
themselves are unchanged.

## Verification

Generator output for `--channel nightly --target gfx1100 --distro ubuntu-24.04
--install-method tarball-multi-arch`:

| | `skip_tests.txt` | `SKIP_FROM_TEST` |
|---|---|---|
| before | `hipfft_callback`, `rocfft_callback` | `Libraries/hipFFT/callback
Libraries/rocFFT/callback` |
| after | *(empty)* | *(empty)* |

All other manifest entries (rocDecode and the rest) are unaffected.

**Empty-exclude-list edge case:** these were the only entries carrying a `ctest`
key, so `skip_tests.txt` is now empty while the workflow still passes
`--exclude-from-file` unconditionally. Both halves check out:

- `generate_skip_tests.py` opens the file outside the `if skip_tests:` guard, so
it is still created, just zero bytes.
- `ctest --exclude-from-file <empty file>` runs normally and exits 0 (verified on
ctest 3.28.3).

## Not verified on hardware

Every ROCm SDK available locally predates the fix (newest `7.15.0a20260702`; the
fix landed 2026-07-10), so the examples could not be run directly. CI on the next
nightly is the real check.

If either test still aborts with the `GlobalVar Obj` error, the right response is
to reopen
[ROCm/rocm-systems#7263](https://github.com/ROCm/rocm-systems/issues/7263) with
the new log rather than silently restoring the skip — the manifest entry would
otherwise hide a regression in a fix that is supposed to have shipped.
