### PR TITLE
ci: install the -tests tarball for rocDecode tests

### DIFF
--- a/.github/build_tools/skip_manifest.py
+++ b/.github/build_tools/skip_manifest.py
@@ -81,7 +81,7 @@ applies everywhere). Always include a ``reason``.
 
 # rocDecode leaf directories. All ten need the video test data + utility sources
 # under $ROCM_PATH/share/rocdecode. The pinned stable image ships these via the
-# amdrocm-decode-test package, and the nightly tarball carries them too, so
+# amdrocm-decode-test package, and the nightly "-tests" tarball carries them too, so
 # rocDecode builds and its tests run in both. The nightly whl install does NOT
 # carry the data, so the make-test skip is scoped to that install method.
 # ctest self-guards each on `if(EXISTS ...)`, so the ctest key is None (ctest
@@ -127,7 +127,7 @@ SKIP_MANIFEST = [
             "scope": ["test"],
             "channels": ["nightly"],
             "install_methods": ["whl-multi-arch"],
-            "reason": "video test data absent from the TheRock nightly whl install (present on the stable image via amdrocm-decode-test and in the nightly tarball)",
+            "reason": "video test data absent from the TheRock nightly whl install (present on the stable image via amdrocm-decode-test and in the nightly tests tarball)",
         }
         for d in _ROCDECODE_DIRS
     ],

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -73,7 +73,7 @@ jobs:
         id: install-tarball-multi-arch
         run: |
           TARBALL_LISTING=$(curl -s -H "Cache-Control: no-cache" -H "Pragma: no-cache" https://rocm.nightlies.amd.com/tarball-multi-arch/ \
-            | grep -oE "therock-dist-linux-${{ matrix.gpu_config.therock_family }}-[0-9]+\.[0-9]+\.\w+\.tar\.gz")
+            | grep -oE "therock-dist-linux-${{ matrix.gpu_config.therock_family }}-tests-[0-9]+\.[0-9]+\.\w+\.tar\.gz")
           LATEST_TARBALL=$(echo "${TARBALL_LISTING}" | sort -V | tail -1)
           mkdir /therock-tarball && cd /therock-tarball
           wget "https://rocm.nightlies.amd.com/tarball-multi-arch/${LATEST_TARBALL}"


### PR DESCRIPTION



## Motivation

The old therock-dist-linux-<family> tarballs used to ship test files which were needed by the rocDecode tests (share/rocdecode/frames), now the test files are included in the -tests tarballs.



## Technical Details

Change tarbel URL regex to point to the -test variant. Update skip test coments.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
