### PR TITLE
ci: pass stable channel for preinstalled 7.14 image in nightly workflow

### DIFF
--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -116,8 +116,15 @@ jobs:
 
       - name: Generate skip lists
         run: |
+          # The preinstalled distro is the pinned rocm:7.14 image, i.e. the "stable"
+          # channel; every other install method pulls a TheRock "nightly" build.
+          if [ "${{ matrix.install_method }}" = "preinstalled" ]; then
+            CHANNEL=stable
+          else
+            CHANNEL=nightly
+          fi
           python3 .github/build_tools/generate_skip_tests.py \
-            --channel nightly \
+            --channel "$CHANNEL" \
             --target "${{ matrix.gpu_config.gpu_target }}" \
             --distro "${{ inputs.distro }}" \
             --install-method "${{ matrix.install_method }}"


### PR DESCRIPTION



## Motivation
The reusable workflow hardcoded --channel nightly for every job, so the stable-scoped skips (e.g. cooperative_groups_prefix_sum, absent hip_scan.h on the pinned 7.14 image) were filtered out for the preinstalled distro and the build failed. 

## Technical Details

Derive the channel from the install method: preinstalled is the pinned rocm:7.14 image (stable channel), everything else is nightly.
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [ ] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [ ] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
