### PR TITLE
Backport: CDNA fallback for optical_flow kernels (ROCM-25855)

### DIFF
--- a/Applications/optical_flow/common.h
+++ b/Applications/optical_flow/common.h
@@ -48,3 +48,52 @@ template <typename T> inline void Swap(T &a, T &b)
     a   = b;
     b   = t;
 }
+
+// Software bilinear sampler used on architectures that lack hardware texture
+// units (e.g. CDNA / MI300X). Replicates the behaviour of tex2D<float> with
+// normalizedCoords=true, hipFilterModeLinear, hipAddressModeMirror on both
+// axes. Guarded by __HIPCC__ so plain C++ translation units do not see the
+// __device__ keyword. Always compiled for all GPU targets so that *KernelSW
+// variants are available regardless of device architecture.
+#ifdef __HIPCC__
+
+__device__ inline float tex2D_mirror_coord(float u, int N)
+{
+    // Fold into [0, 2) then reflect the upper half back to [0, 1].
+    u = fabsf(u);
+    u = u - floorf(u * 0.5f) * 2.0f; // u in [0, 2)
+    if (u > 1.0f)
+        u = 2.0f - u; // u in [0, 1]
+    // Convert to continuous texel space; clamp for floating-point edge cases.
+    float p = u * (float)N - 0.5f;
+    if (p < 0.0f)
+        p = 0.0f;
+    if (p > (float)(N - 1))
+        p = (float)(N - 1);
+    return p;
+}
+
+__device__ inline float tex2D_bilinear(
+    const float* data, int width, int height, int stride, float u, float v)
+{
+    float px = tex2D_mirror_coord(u, width);
+    float py = tex2D_mirror_coord(v, height);
+
+    int x0 = (int)floorf(px);
+    int y0 = (int)floorf(py);
+    int x1 = x0 + 1 < width  ? x0 + 1 : width  - 1;
+    int y1 = y0 + 1 < height ? y0 + 1 : height - 1;
+
+    float ax = px - (float)x0;
+    float ay = py - (float)y0;
+
+    float v00 = data[y0 * stride + x0];
+    float v10 = data[y0 * stride + x1];
+    float v01 = data[y1 * stride + x0];
+    float v11 = data[y1 * stride + x1];
+
+    return (1.0f - ay) * ((1.0f - ax) * v00 + ax * v10)
+           + ay * ((1.0f - ax) * v01 + ax * v11);
+}
+
+#endif // __HIPCC__

--- a/Applications/optical_flow/derivativesKernel.hip
+++ b/Applications/optical_flow/derivativesKernel.hip
@@ -25,22 +25,106 @@
 #include "common.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-/// \brief compute image derivatives
+/// \brief compute image derivatives (software sampler path)
 ///
-/// HIP kernel, relies heavily on texture unit
-/// \param[in]  width   image width
-/// \param[in]  height  image height
-/// \param[in]  stride  image stride
-/// \param[out] Ix      x derivative
-/// \param[out] Iy      y derivative
-/// \param[out] Iz      temporal derivative
+/// Used on devices that lack hardware texture units (e.g. CDNA / MI300X).
+/// \param[in]  width      image width
+/// \param[in]  height     image height
+/// \param[in]  stride     image stride in elements
+/// \param[out] Ix         x derivative
+/// \param[out] Iy         y derivative
+/// \param[out] Iz         temporal derivative
+/// \param[in]  texSource  source image device pointer (SW path)
+/// \param[in]  srcWidth   source image width (SW path)
+/// \param[in]  srcHeight  source image height (SW path)
+/// \param[in]  srcStride  source image stride in elements (SW path)
+/// \param[in]  texTarget  target image device pointer (SW path)
 ///////////////////////////////////////////////////////////////////////////////
-__global__ void ComputeDerivativesKernel(int                 width,
-                                         int                 height,
-                                         int                 stride,
-                                         float              *Ix,
-                                         float              *Iy,
-                                         float              *Iz,
+__global__ void ComputeDerivativesKernelSW(int          width,
+                                            int          height,
+                                            int          stride,
+                                            float       *Ix,
+                                            float       *Iy,
+                                            float       *Iz,
+                                            const float *texSource,
+                                            int          srcWidth,
+                                            int          srcHeight,
+                                            int          srcStride,
+                                            const float *texTarget)
+{
+    const int ix = threadIdx.x + blockIdx.x * blockDim.x;
+    const int iy = threadIdx.y + blockIdx.y * blockDim.y;
+
+    const int pos = ix + iy * stride;
+
+    if (ix >= width || iy >= height)
+        return;
+
+    float dx = 1.0f / (float)width;
+    float dy = 1.0f / (float)height;
+
+    float x = ((float)ix + 0.5f) * dx;
+    float y = ((float)iy + 0.5f) * dy;
+
+#define SAMPLE(tex, u, v) tex2D_bilinear(tex, srcWidth, srcHeight, srcStride, u, v)
+
+    float t0, t1;
+    // x derivative
+    t0 = SAMPLE(texSource, x - 2.0f * dx, y);
+    t0 -= SAMPLE(texSource, x - 1.0f * dx, y) * 8.0f;
+    t0 += SAMPLE(texSource, x + 1.0f * dx, y) * 8.0f;
+    t0 -= SAMPLE(texSource, x + 2.0f * dx, y);
+    t0 /= 12.0f;
+
+    t1 = SAMPLE(texTarget, x - 2.0f * dx, y);
+    t1 -= SAMPLE(texTarget, x - 1.0f * dx, y) * 8.0f;
+    t1 += SAMPLE(texTarget, x + 1.0f * dx, y) * 8.0f;
+    t1 -= SAMPLE(texTarget, x + 2.0f * dx, y);
+    t1 /= 12.0f;
+
+    Ix[pos] = (t0 + t1) * 0.5f;
+
+    // t derivative
+    Iz[pos] = SAMPLE(texTarget, x, y) - SAMPLE(texSource, x, y);
+
+    // y derivative
+    t0 = SAMPLE(texSource, x, y - 2.0f * dy);
+    t0 -= SAMPLE(texSource, x, y - 1.0f * dy) * 8.0f;
+    t0 += SAMPLE(texSource, x, y + 1.0f * dy) * 8.0f;
+    t0 -= SAMPLE(texSource, x, y + 2.0f * dy);
+    t0 /= 12.0f;
+
+    t1 = SAMPLE(texTarget, x, y - 2.0f * dy);
+    t1 -= SAMPLE(texTarget, x, y - 1.0f * dy) * 8.0f;
+    t1 += SAMPLE(texTarget, x, y + 1.0f * dy) * 8.0f;
+    t1 -= SAMPLE(texTarget, x, y + 2.0f * dy);
+    t1 /= 12.0f;
+
+    Iy[pos] = (t0 + t1) * 0.5f;
+
+#undef SAMPLE
+}
+
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+///////////////////////////////////////////////////////////////////////////////
+/// \brief compute image derivatives (hardware texture path)
+///
+/// Used on devices with hardware texture units (e.g. RDNA).
+/// \param[in]  width     image width
+/// \param[in]  height    image height
+/// \param[in]  stride    image stride in elements
+/// \param[out] Ix        x derivative
+/// \param[out] Iy        y derivative
+/// \param[out] Iz        temporal derivative
+/// \param[in]  texSource source image texture object
+/// \param[in]  texTarget target image texture object
+///////////////////////////////////////////////////////////////////////////////
+__global__ void ComputeDerivativesKernel(int                width,
+                                         int                height,
+                                         int                stride,
+                                         float             *Ix,
+                                         float             *Iy,
+                                         float             *Iz,
                                          hipTextureObject_t texSource,
                                          hipTextureObject_t texTarget)
 {
@@ -58,71 +142,93 @@ __global__ void ComputeDerivativesKernel(int                 width,
     float x = ((float)ix + 0.5f) * dx;
     float y = ((float)iy + 0.5f) * dy;
 
+#define SAMPLE(tex, u, v) tex2D<float>(tex, u, v)
+
     float t0, t1;
     // x derivative
-    t0 = tex2D<float>(texSource, x - 2.0f * dx, y);
-    t0 -= tex2D<float>(texSource, x - 1.0f * dx, y) * 8.0f;
-    t0 += tex2D<float>(texSource, x + 1.0f * dx, y) * 8.0f;
-    t0 -= tex2D<float>(texSource, x + 2.0f * dx, y);
+    t0 = SAMPLE(texSource, x - 2.0f * dx, y);
+    t0 -= SAMPLE(texSource, x - 1.0f * dx, y) * 8.0f;
+    t0 += SAMPLE(texSource, x + 1.0f * dx, y) * 8.0f;
+    t0 -= SAMPLE(texSource, x + 2.0f * dx, y);
     t0 /= 12.0f;
 
-    t1 = tex2D<float>(texTarget, x - 2.0f * dx, y);
-    t1 -= tex2D<float>(texTarget, x - 1.0f * dx, y) * 8.0f;
-    t1 += tex2D<float>(texTarget, x + 1.0f * dx, y) * 8.0f;
-    t1 -= tex2D<float>(texTarget, x + 2.0f * dx, y);
+    t1 = SAMPLE(texTarget, x - 2.0f * dx, y);
+    t1 -= SAMPLE(texTarget, x - 1.0f * dx, y) * 8.0f;
+    t1 += SAMPLE(texTarget, x + 1.0f * dx, y) * 8.0f;
+    t1 -= SAMPLE(texTarget, x + 2.0f * dx, y);
     t1 /= 12.0f;
 
     Ix[pos] = (t0 + t1) * 0.5f;
 
     // t derivative
-    Iz[pos] = tex2D<float>(texTarget, x, y) - tex2D<float>(texSource, x, y);
+    Iz[pos] = SAMPLE(texTarget, x, y) - SAMPLE(texSource, x, y);
 
     // y derivative
-    t0 = tex2D<float>(texSource, x, y - 2.0f * dy);
-    t0 -= tex2D<float>(texSource, x, y - 1.0f * dy) * 8.0f;
-    t0 += tex2D<float>(texSource, x, y + 1.0f * dy) * 8.0f;
-    t0 -= tex2D<float>(texSource, x, y + 2.0f * dy);
+    t0 = SAMPLE(texSource, x, y - 2.0f * dy);
+    t0 -= SAMPLE(texSource, x, y - 1.0f * dy) * 8.0f;
+    t0 += SAMPLE(texSource, x, y + 1.0f * dy) * 8.0f;
+    t0 -= SAMPLE(texSource, x, y + 2.0f * dy);
     t0 /= 12.0f;
 
-    t1 = tex2D<float>(texTarget, x, y - 2.0f * dy);
-    t1 -= tex2D<float>(texTarget, x, y - 1.0f * dy) * 8.0f;
-    t1 += tex2D<float>(texTarget, x, y + 1.0f * dy) * 8.0f;
-    t1 -= tex2D<float>(texTarget, x, y + 2.0f * dy);
+    t1 = SAMPLE(texTarget, x, y - 2.0f * dy);
+    t1 -= SAMPLE(texTarget, x, y - 1.0f * dy) * 8.0f;
+    t1 += SAMPLE(texTarget, x, y + 1.0f * dy) * 8.0f;
+    t1 -= SAMPLE(texTarget, x, y + 2.0f * dy);
     t1 /= 12.0f;
 
     Iy[pos] = (t0 + t1) * 0.5f;
+
+#undef SAMPLE
 }
+#endif // !__HIP_NO_IMAGE_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \brief compute image derivatives
 ///
-/// \param[in]  I0  source image
-/// \param[in]  I1  tracked image
-/// \param[in]  w   image width
-/// \param[in]  h   image height
-/// \param[in]  s   image stride
-/// \param[out] Ix  x derivative
-/// \param[out] Iy  y derivative
-/// \param[out] Iz  temporal derivative
+/// \param[in]  I0           source image
+/// \param[in]  I1           tracked image
+/// \param[in]  w            image width
+/// \param[in]  h            image height
+/// \param[in]  s            image stride
+/// \param[out] Ix           x derivative
+/// \param[out] Iy           y derivative
+/// \param[out] Iz           temporal derivative
+/// \param[in]  imageSupport non-zero if the current device has image support
 ///////////////////////////////////////////////////////////////////////////////
-static void ComputeDerivatives(const float *I0, const float *I1, int w, int h, int s, float *Ix, float *Iy, float *Iz)
+static void ComputeDerivatives(const float *I0,
+                               const float *I1,
+                               int          w,
+                               int          h,
+                               int          s,
+                               float       *Ix,
+                               float       *Iy,
+                               float       *Iz,
+                               int          imageSupport)
 {
     dim3 threads(32, 6);
     dim3 blocks(iDivUp(w, threads.x), iDivUp(h, threads.y));
 
-    hipTextureDesc texDescr = {};
-    texDescr.normalizedCoords = true;
-    texDescr.filterMode       = hipFilterModeLinear;
-    texDescr.addressMode[0]   = hipAddressModeMirror;
-    texDescr.addressMode[1]   = hipAddressModeMirror;
-    texDescr.readMode         = hipReadModeElementType;
+    if (!imageSupport)
+    {
+        ComputeDerivativesKernelSW<<<blocks, threads>>>(w, h, s, Ix, Iy, Iz, I0, w, h, s, I1);
+        HIP_CHECK(hipGetLastError());
+        return;
+    }
 
-    hipResourceDesc texRes = {};
-    texRes.resType                  = hipResourceTypePitch2D;
-    texRes.res.pitch2D.desc         = hipCreateChannelDesc<float>();
-    texRes.res.pitch2D.width        = w;
-    texRes.res.pitch2D.height       = h;
-    texRes.res.pitch2D.pitchInBytes = s * sizeof(float);
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+    hipTextureDesc texDescr        = {};
+    texDescr.normalizedCoords      = true;
+    texDescr.filterMode            = hipFilterModeLinear;
+    texDescr.addressMode[0]        = hipAddressModeMirror;
+    texDescr.addressMode[1]        = hipAddressModeMirror;
+    texDescr.readMode              = hipReadModeElementType;
+
+    hipResourceDesc texRes               = {};
+    texRes.resType                       = hipResourceTypePitch2D;
+    texRes.res.pitch2D.desc              = hipCreateChannelDesc<float>();
+    texRes.res.pitch2D.width             = w;
+    texRes.res.pitch2D.height            = h;
+    texRes.res.pitch2D.pitchInBytes      = s * sizeof(float);
 
     hipTextureObject_t texSource, texTarget;
     texRes.res.pitch2D.devPtr = (void *)I0;
@@ -131,7 +237,9 @@ static void ComputeDerivatives(const float *I0, const float *I1, int w, int h, i
     HIP_CHECK(hipCreateTextureObject(&texTarget, &texRes, &texDescr, NULL));
 
     ComputeDerivativesKernel<<<blocks, threads>>>(w, h, s, Ix, Iy, Iz, texSource, texTarget);
+    HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(hipDestroyTextureObject(texSource));
     HIP_CHECK(hipDestroyTextureObject(texTarget));
+#endif
 }

--- a/Applications/optical_flow/downscaleKernel.hip
+++ b/Applications/optical_flow/downscaleKernel.hip
@@ -25,22 +25,32 @@
 #include "common.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-/// \brief downscale image
+/// \brief downscale image (software sampler path)
 ///
-/// HIP kernel, relies heavily on texture unit
-/// \param[in]  width   image width
-/// \param[in]  height  image height
-/// \param[in]  stride  image stride
-/// \param[out] out     result
+/// Used on devices that lack hardware texture units (e.g. CDNA / MI300X).
+/// \param[in]  width      image width
+/// \param[in]  height     image height
+/// \param[in]  stride     image stride in elements
+/// \param[out] out        result
+/// \param[in]  texFine    source image device pointer (SW path)
+/// \param[in]  srcWidth   source image width (SW path)
+/// \param[in]  srcHeight  source image height (SW path)
+/// \param[in]  srcStride  source image stride in elements (SW path)
 ///////////////////////////////////////////////////////////////////////////////
-__global__ void DownscaleKernel(int width, int height, int stride, float *out, hipTextureObject_t texFine)
+__global__ void DownscaleKernelSW(int          width,
+                                   int          height,
+                                   int          stride,
+                                   float       *out,
+                                   const float *texFine,
+                                   int          srcWidth,
+                                   int          srcHeight,
+                                   int          srcStride)
 {
     const int ix = threadIdx.x + blockIdx.x * blockDim.x;
     const int iy = threadIdx.y + blockIdx.y * blockDim.y;
 
-    if (ix >= width || iy >= height) {
+    if (ix >= width || iy >= height)
         return;
-    }
 
     float dx = 1.0f / (float)width;
     float dy = 1.0f / (float)height;
@@ -48,45 +58,110 @@ __global__ void DownscaleKernel(int width, int height, int stride, float *out, h
     float x = ((float)ix + 0.5f) * dx;
     float y = ((float)iy + 0.5f) * dy;
 
+#define SAMPLE(u, v) tex2D_bilinear(texFine, srcWidth, srcHeight, srcStride, u, v)
+
     out[ix + iy * stride] = 0.25f
-                          * (tex2D<float>(texFine, x - dx * 0.25f, y) + tex2D<float>(texFine, x + dx * 0.25f, y)
-                             + tex2D<float>(texFine, x, y - dy * 0.25f) + tex2D<float>(texFine, x, y + dy * 0.25f));
+                            * (SAMPLE(x - dx * 0.25f, y) + SAMPLE(x + dx * 0.25f, y)
+                               + SAMPLE(x, y - dy * 0.25f) + SAMPLE(x, y + dy * 0.25f));
+
+#undef SAMPLE
 }
+
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+///////////////////////////////////////////////////////////////////////////////
+/// \brief downscale image (hardware texture path)
+///
+/// Used on devices with hardware texture units (e.g. RDNA).
+/// \param[in]  width   image width
+/// \param[in]  height  image height
+/// \param[in]  stride  image stride in elements
+/// \param[out] out     result
+/// \param[in]  texFine source image texture object
+///////////////////////////////////////////////////////////////////////////////
+__global__ void DownscaleKernel(int                width,
+                                int                height,
+                                int                stride,
+                                float             *out,
+                                hipTextureObject_t texFine)
+{
+    const int ix = threadIdx.x + blockIdx.x * blockDim.x;
+    const int iy = threadIdx.y + blockIdx.y * blockDim.y;
+
+    if (ix >= width || iy >= height)
+        return;
+
+    float dx = 1.0f / (float)width;
+    float dy = 1.0f / (float)height;
+
+    float x = ((float)ix + 0.5f) * dx;
+    float y = ((float)iy + 0.5f) * dy;
+
+#define SAMPLE(u, v) tex2D<float>(texFine, u, v)
+
+    out[ix + iy * stride] = 0.25f
+                            * (SAMPLE(x - dx * 0.25f, y) + SAMPLE(x + dx * 0.25f, y)
+                               + SAMPLE(x, y - dy * 0.25f) + SAMPLE(x, y + dy * 0.25f));
+
+#undef SAMPLE
+}
+#endif // !__HIP_NO_IMAGE_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \brief downscale image
 ///
-/// \param[in]  src     image to downscale
-/// \param[in]  width   image width
-/// \param[in]  height  image height
-/// \param[in]  stride  image stride
-/// \param[out] out     result
+/// \param[in]  src          image to downscale
+/// \param[in]  width        image width
+/// \param[in]  height       image height
+/// \param[in]  stride       image stride
+/// \param[in]  newWidth     downscaled width
+/// \param[in]  newHeight    downscaled height
+/// \param[in]  newStride    downscaled stride
+/// \param[out] out          result
+/// \param[in]  imageSupport non-zero if the current device has image support
 ///////////////////////////////////////////////////////////////////////////////
-static void
-Downscale(const float *src, int width, int height, int stride, int newWidth, int newHeight, int newStride, float *out)
+static void Downscale(const float *src,
+                      int          width,
+                      int          height,
+                      int          stride,
+                      int          newWidth,
+                      int          newHeight,
+                      int          newStride,
+                      float       *out,
+                      int          imageSupport)
 {
     dim3 threads(32, 8);
     dim3 blocks(iDivUp(newWidth, threads.x), iDivUp(newHeight, threads.y));
 
-    hipResourceDesc texRes = {};
-    texRes.resType                  = hipResourceTypePitch2D;
-    texRes.res.pitch2D.devPtr       = (void *)src;
-    texRes.res.pitch2D.desc         = hipCreateChannelDesc<float>();
-    texRes.res.pitch2D.width        = width;
-    texRes.res.pitch2D.height       = height;
-    texRes.res.pitch2D.pitchInBytes = stride * sizeof(float);
+    if (!imageSupport)
+    {
+        DownscaleKernelSW<<<blocks, threads>>>(newWidth, newHeight, newStride, out,
+                                               src, width, height, stride);
+        HIP_CHECK(hipGetLastError());
+        return;
+    }
 
-    hipTextureDesc texDescr = {};
-    texDescr.normalizedCoords = true;
-    texDescr.filterMode       = hipFilterModeLinear;
-    texDescr.addressMode[0]   = hipAddressModeMirror;
-    texDescr.addressMode[1]   = hipAddressModeMirror;
-    texDescr.readMode         = hipReadModeElementType;
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+    hipResourceDesc texRes               = {};
+    texRes.resType                       = hipResourceTypePitch2D;
+    texRes.res.pitch2D.devPtr            = (void *)src;
+    texRes.res.pitch2D.desc              = hipCreateChannelDesc<float>();
+    texRes.res.pitch2D.width             = width;
+    texRes.res.pitch2D.height            = height;
+    texRes.res.pitch2D.pitchInBytes      = stride * sizeof(float);
+
+    hipTextureDesc texDescr         = {};
+    texDescr.normalizedCoords       = true;
+    texDescr.filterMode             = hipFilterModeLinear;
+    texDescr.addressMode[0]         = hipAddressModeMirror;
+    texDescr.addressMode[1]         = hipAddressModeMirror;
+    texDescr.readMode               = hipReadModeElementType;
 
     hipTextureObject_t texFine;
     HIP_CHECK(hipCreateTextureObject(&texFine, &texRes, &texDescr, NULL));
 
     DownscaleKernel<<<blocks, threads>>>(newWidth, newHeight, newStride, out, texFine);
+    HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(hipDestroyTextureObject(texFine));
+#endif
 }

--- a/Applications/optical_flow/flowHIP.hip
+++ b/Applications/optical_flow/flowHIP.hip
@@ -63,6 +63,18 @@ void ComputeFlowHIP(const float *I0,
 {
     printf("Computing optical flow on GPU...\n");
 
+    // Query once: hipDeviceAttributeImageSupport is a static hardware property.
+    // On NVIDIA (CUDA backend) all GPUs support hardware textures; skip the
+    // driver-API query (cuDeviceGetAttribute) which requires libcuda at link time.
+#if defined(__HIP_PLATFORM_NVCC__) || defined(__HIP_PLATFORM_NVIDIA__)
+    int imageSupport = 1;
+#else
+    int imageSupport = 0;
+    int deviceId     = 0;
+    HIP_CHECK(hipGetDevice(&deviceId));
+    HIP_CHECK(hipDeviceGetAttribute(&imageSupport, hipDeviceAttributeImageSupport, deviceId));
+#endif
+
     // pI0 and pI1 will hold device pointers
     float **pI0 = new float *[nLevels];
     float **pI1 = new float *[nLevels];
@@ -133,7 +145,8 @@ void ComputeFlowHIP(const float *I0,
                   nw,
                   nh,
                   ns,
-                  pI0[currentLevel - 1]);
+                  pI0[currentLevel - 1],
+                  imageSupport);
 
         Downscale(pI1[currentLevel],
                   pW[currentLevel],
@@ -142,7 +155,8 @@ void ComputeFlowHIP(const float *I0,
                   nw,
                   nh,
                   ns,
-                  pI1[currentLevel - 1]);
+                  pI1[currentLevel - 1],
+                  imageSupport);
 
         pW[currentLevel - 1] = nw;
         pH[currentLevel - 1] = nh;
@@ -163,10 +177,10 @@ void ComputeFlowHIP(const float *I0,
 
             // on current level we compute optical flow
             // between frame 0 and warped frame 1
-            WarpImage(pI1[currentLevel], pW[currentLevel], pH[currentLevel], pS[currentLevel], d_u, d_v, d_tmp);
+            WarpImage(pI1[currentLevel], pW[currentLevel], pH[currentLevel], pS[currentLevel], d_u, d_v, d_tmp, imageSupport);
 
             ComputeDerivatives(
-                pI0[currentLevel], d_tmp, pW[currentLevel], pH[currentLevel], pS[currentLevel], d_Ix, d_Iy, d_Iz);
+                pI0[currentLevel], d_tmp, pW[currentLevel], pH[currentLevel], pS[currentLevel], d_Ix, d_Iy, d_Iz, imageSupport);
 
             for (int iter = 0; iter < nSolverIters; ++iter) {
                 SolveForUpdate(d_du0,
@@ -202,7 +216,8 @@ void ComputeFlowHIP(const float *I0,
                     pH[currentLevel + 1],
                     pS[currentLevel + 1],
                     scaleX,
-                    d_nu);
+                    d_nu,
+                    imageSupport);
 
             float scaleY = (float)pH[currentLevel + 1] / (float)pH[currentLevel];
 
@@ -214,7 +229,8 @@ void ComputeFlowHIP(const float *I0,
                     pH[currentLevel + 1],
                     pS[currentLevel + 1],
                     scaleY,
-                    d_nv);
+                    d_nv,
+                    imageSupport);
 
             Swap(d_u, d_nu);
             Swap(d_v, d_nv);

--- a/Applications/optical_flow/upscaleKernel.hip
+++ b/Applications/optical_flow/upscaleKernel.hip
@@ -25,14 +25,28 @@
 #include "common.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-/// \brief upscale one component of a displacement field, HIP kernel
-/// \param[in]  width   field width
-/// \param[in]  height  field height
-/// \param[in]  stride  field stride
-/// \param[in]  scale   scale factor (multiplier)
-/// \param[out] out     result
+/// \brief upscale one component of a displacement field (software sampler path)
+///
+/// Used on devices that lack hardware texture units (e.g. CDNA / MI300X).
+/// \param[in]  width      field width
+/// \param[in]  height     field height
+/// \param[in]  stride     field stride in elements
+/// \param[in]  scale      scale factor (multiplier)
+/// \param[out] out        result
+/// \param[in]  texCoarse  coarse field device pointer (SW path)
+/// \param[in]  srcWidth   coarse field width (SW path)
+/// \param[in]  srcHeight  coarse field height (SW path)
+/// \param[in]  srcStride  coarse field stride in elements (SW path)
 ///////////////////////////////////////////////////////////////////////////////
-__global__ void UpscaleKernel(int width, int height, int stride, float scale, float *out, hipTextureObject_t texCoarse)
+__global__ void UpscaleKernelSW(int          width,
+                                 int          height,
+                                 int          stride,
+                                 float        scale,
+                                 float       *out,
+                                 const float *texCoarse,
+                                 int          srcWidth,
+                                 int          srcHeight,
+                                 int          srcStride)
 {
     const int ix = threadIdx.x + blockIdx.x * blockDim.x;
     const int iy = threadIdx.y + blockIdx.y * blockDim.y;
@@ -43,22 +57,56 @@ __global__ void UpscaleKernel(int width, int height, int stride, float scale, fl
     float x = ((float)ix + 0.5f) / (float)width;
     float y = ((float)iy + 0.5f) / (float)height;
 
-    // exploit hardware interpolation
-    // and scale interpolated vector to match next pyramid level resolution
+    // bilinear interpolation scales the vector to match the next pyramid level
+    out[ix + iy * stride] = tex2D_bilinear(texCoarse, srcWidth, srcHeight, srcStride, x, y) * scale;
+}
+
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+///////////////////////////////////////////////////////////////////////////////
+/// \brief upscale one component of a displacement field (hardware texture path)
+///
+/// Used on devices with hardware texture units (e.g. RDNA).
+/// \param[in]  width     field width
+/// \param[in]  height    field height
+/// \param[in]  stride    field stride in elements
+/// \param[in]  scale     scale factor (multiplier)
+/// \param[out] out       result
+/// \param[in]  texCoarse coarse field texture object
+///////////////////////////////////////////////////////////////////////////////
+__global__ void UpscaleKernel(int                width,
+                              int                height,
+                              int                stride,
+                              float              scale,
+                              float             *out,
+                              hipTextureObject_t texCoarse)
+{
+    const int ix = threadIdx.x + blockIdx.x * blockDim.x;
+    const int iy = threadIdx.y + blockIdx.y * blockDim.y;
+
+    if (ix >= width || iy >= height)
+        return;
+
+    float x = ((float)ix + 0.5f) / (float)width;
+    float y = ((float)iy + 0.5f) / (float)height;
+
+    // bilinear interpolation scales the vector to match the next pyramid level
     out[ix + iy * stride] = tex2D<float>(texCoarse, x, y) * scale;
 }
+#endif // !__HIP_NO_IMAGE_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \brief upscale one component of a displacement field, kernel wrapper
-/// \param[in]  src         field component to upscale
-/// \param[in]  width       field current width
-/// \param[in]  height      field current height
-/// \param[in]  stride      field current stride
-/// \param[in]  newWidth    field new width
-/// \param[in]  newHeight   field new height
-/// \param[in]  newStride   field new stride
-/// \param[in]  scale       value scale factor (multiplier)
-/// \param[out] out         upscaled field component
+///
+/// \param[in]  src          field component to upscale
+/// \param[in]  width        field current width
+/// \param[in]  height       field current height
+/// \param[in]  stride       field current stride
+/// \param[in]  newWidth     field new width
+/// \param[in]  newHeight    field new height
+/// \param[in]  newStride    field new stride
+/// \param[in]  scale        value scale factor (multiplier)
+/// \param[out] out          upscaled field component
+/// \param[in]  imageSupport non-zero if the current device has image support
 ///////////////////////////////////////////////////////////////////////////////
 static void Upscale(const float *src,
                     int          width,
@@ -68,30 +116,42 @@ static void Upscale(const float *src,
                     int          newHeight,
                     int          newStride,
                     float        scale,
-                    float       *out)
+                    float       *out,
+                    int          imageSupport)
 {
     dim3 threads(32, 8);
     dim3 blocks(iDivUp(newWidth, threads.x), iDivUp(newHeight, threads.y));
 
-    hipResourceDesc texRes = {};
-    texRes.resType                  = hipResourceTypePitch2D;
-    texRes.res.pitch2D.devPtr       = (void *)src;
-    texRes.res.pitch2D.desc         = hipCreateChannelDesc<float>();
-    texRes.res.pitch2D.width        = width;
-    texRes.res.pitch2D.height       = height;
-    texRes.res.pitch2D.pitchInBytes = stride * sizeof(float);
+    if (!imageSupport)
+    {
+        UpscaleKernelSW<<<blocks, threads>>>(newWidth, newHeight, newStride, scale, out,
+                                             src, width, height, stride);
+        HIP_CHECK(hipGetLastError());
+        return;
+    }
 
-    hipTextureDesc texDescr = {};
-    texDescr.normalizedCoords = true;
-    texDescr.filterMode       = hipFilterModeLinear;
-    texDescr.addressMode[0]   = hipAddressModeMirror;
-    texDescr.addressMode[1]   = hipAddressModeMirror;
-    texDescr.readMode         = hipReadModeElementType;
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+    hipResourceDesc texRes               = {};
+    texRes.resType                       = hipResourceTypePitch2D;
+    texRes.res.pitch2D.devPtr            = (void *)src;
+    texRes.res.pitch2D.desc              = hipCreateChannelDesc<float>();
+    texRes.res.pitch2D.width             = width;
+    texRes.res.pitch2D.height            = height;
+    texRes.res.pitch2D.pitchInBytes      = stride * sizeof(float);
+
+    hipTextureDesc texDescr         = {};
+    texDescr.normalizedCoords       = true;
+    texDescr.filterMode             = hipFilterModeLinear;
+    texDescr.addressMode[0]         = hipAddressModeMirror;
+    texDescr.addressMode[1]         = hipAddressModeMirror;
+    texDescr.readMode               = hipReadModeElementType;
 
     hipTextureObject_t texCoarse;
     HIP_CHECK(hipCreateTextureObject(&texCoarse, &texRes, &texDescr, NULL));
 
     UpscaleKernel<<<blocks, threads>>>(newWidth, newHeight, newStride, scale, out, texCoarse);
+    HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(hipDestroyTextureObject(texCoarse));
+#endif
 }

--- a/Applications/optical_flow/warpingKernel.hip
+++ b/Applications/optical_flow/warpingKernel.hip
@@ -25,20 +25,59 @@
 #include "common.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-/// \brief warp image with a given displacement field, HIP kernel.
-/// \param[in]  width   image width
-/// \param[in]  height  image height
-/// \param[in]  stride  image stride
-/// \param[in]  u       horizontal displacement
-/// \param[in]  v       vertical displacement
-/// \param[out] out     result
+/// \brief warp image with a given displacement field (software sampler path)
+///
+/// Used on devices that lack hardware texture units (e.g. CDNA / MI300X).
+/// \param[in]  width      image width
+/// \param[in]  height     image height
+/// \param[in]  stride     image stride in elements
+/// \param[in]  u          horizontal displacement
+/// \param[in]  v          vertical displacement
+/// \param[out] out        result
+/// \param[in]  texToWarp  source image device pointer (SW path)
 ///////////////////////////////////////////////////////////////////////////////
-__global__ void WarpingKernel(int                 width,
-                              int                 height,
-                              int                 stride,
-                              const float        *u,
-                              const float        *v,
-                              float              *out,
+__global__ void WarpingKernelSW(int          width,
+                                 int          height,
+                                 int          stride,
+                                 const float *u,
+                                 const float *v,
+                                 float       *out,
+                                 const float *texToWarp)
+{
+    const int ix = threadIdx.x + blockIdx.x * blockDim.x;
+    const int iy = threadIdx.y + blockIdx.y * blockDim.y;
+
+    const int pos = ix + iy * stride;
+
+    if (ix >= width || iy >= height)
+        return;
+
+    float x = ((float)ix + u[pos] + 0.5f) / (float)width;
+    float y = ((float)iy + v[pos] + 0.5f) / (float)height;
+
+    // Source and output images share the same dimensions and stride per WarpImage contract.
+    out[pos] = tex2D_bilinear(texToWarp, width, height, stride, x, y);
+}
+
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+///////////////////////////////////////////////////////////////////////////////
+/// \brief warp image with a given displacement field (hardware texture path)
+///
+/// Used on devices with hardware texture units (e.g. RDNA).
+/// \param[in]  width     image width
+/// \param[in]  height    image height
+/// \param[in]  stride    image stride in elements
+/// \param[in]  u         horizontal displacement
+/// \param[in]  v         vertical displacement
+/// \param[out] out       result
+/// \param[in]  texToWarp source image texture object
+///////////////////////////////////////////////////////////////////////////////
+__global__ void WarpingKernel(int                width,
+                              int                height,
+                              int                stride,
+                              const float       *u,
+                              const float       *v,
+                              float             *out,
                               hipTextureObject_t texToWarp)
 {
     const int ix = threadIdx.x + blockIdx.x * blockDim.x;
@@ -54,6 +93,7 @@ __global__ void WarpingKernel(int                 width,
 
     out[pos] = tex2D<float>(texToWarp, x, y);
 }
+#endif // !__HIP_NO_IMAGE_SUPPORT
 
 ///////////////////////////////////////////////////////////////////////////////
 /// \brief warp image with provided vector field, HIP kernel wrapper.
@@ -63,38 +103,56 @@ __global__ void WarpingKernel(int                 width,
 /// pixel.
 /// It is assumed that images and the vector field have the same stride and
 /// resolution.
-/// \param[in]  src source image
-/// \param[in]  w   width
-/// \param[in]  h   height
-/// \param[in]  s   stride
-/// \param[in]  u   horizontal displacement
-/// \param[in]  v   vertical displacement
-/// \param[out] out warped image
+/// \param[in]  src          source image
+/// \param[in]  w            width
+/// \param[in]  h            height
+/// \param[in]  s            stride
+/// \param[in]  u            horizontal displacement
+/// \param[in]  v            vertical displacement
+/// \param[out] out          warped image
+/// \param[in]  imageSupport non-zero if the current device has image support
 ///////////////////////////////////////////////////////////////////////////////
-static void WarpImage(const float *src, int w, int h, int s, const float *u, const float *v, float *out)
+static void WarpImage(const float *src,
+                      int          w,
+                      int          h,
+                      int          s,
+                      const float *u,
+                      const float *v,
+                      float       *out,
+                      int          imageSupport)
 {
     dim3 threads(32, 6);
     dim3 blocks(iDivUp(w, threads.x), iDivUp(h, threads.y));
 
-    hipResourceDesc texRes = {};
-    texRes.resType                  = hipResourceTypePitch2D;
-    texRes.res.pitch2D.devPtr       = (void *)src;
-    texRes.res.pitch2D.desc         = hipCreateChannelDesc<float>();
-    texRes.res.pitch2D.width        = w;
-    texRes.res.pitch2D.height       = h;
-    texRes.res.pitch2D.pitchInBytes = s * sizeof(float);
+    if (!imageSupport)
+    {
+        WarpingKernelSW<<<blocks, threads>>>(w, h, s, u, v, out, src);
+        HIP_CHECK(hipGetLastError());
+        return;
+    }
 
-    hipTextureDesc texDescr = {};
-    texDescr.normalizedCoords = true;
-    texDescr.filterMode       = hipFilterModeLinear;
-    texDescr.addressMode[0]   = hipAddressModeMirror;
-    texDescr.addressMode[1]   = hipAddressModeMirror;
-    texDescr.readMode         = hipReadModeElementType;
+#if !defined(__HIP_NO_IMAGE_SUPPORT)
+    hipResourceDesc texRes               = {};
+    texRes.resType                       = hipResourceTypePitch2D;
+    texRes.res.pitch2D.devPtr            = (void *)src;
+    texRes.res.pitch2D.desc              = hipCreateChannelDesc<float>();
+    texRes.res.pitch2D.width             = w;
+    texRes.res.pitch2D.height            = h;
+    texRes.res.pitch2D.pitchInBytes      = s * sizeof(float);
+
+    hipTextureDesc texDescr         = {};
+    texDescr.normalizedCoords       = true;
+    texDescr.filterMode             = hipFilterModeLinear;
+    texDescr.addressMode[0]         = hipAddressModeMirror;
+    texDescr.addressMode[1]         = hipAddressModeMirror;
+    texDescr.readMode               = hipReadModeElementType;
 
     hipTextureObject_t texToWarp;
     HIP_CHECK(hipCreateTextureObject(&texToWarp, &texRes, &texDescr, NULL));
 
     WarpingKernel<<<blocks, threads>>>(w, h, s, u, v, out, texToWarp);
+    HIP_CHECK(hipGetLastError());
 
     HIP_CHECK(hipDestroyTextureObject(texToWarp));
+#endif
 }


### PR DESCRIPTION
## Summary
- Backport #462 (`d17d63ed`) onto `release/therock-7.14` to fix compile failures in `Applications/optical_flow` when building for CDNA targets (gfx942/gfx950).
- Adds software bilinear sampler paths (`*KernelSW`) guarded by `#if !defined(__HIP_NO_IMAGE_SUPPORT)` for hardware texture kernels, with runtime dispatch via `hipDeviceAttributeImageSupport`.
- Aligns optical_flow with the existing texture-guard pattern used in `HIP-Basic/texture_management` and `HIP-Doc/Tutorials/graph_api`.

## Test plan
- [x] `cmake -DCMAKE_HIP_ARCHITECTURES="gfx942;gfx1100" -S Applications/optical_flow -B build && cmake --build build` succeeds locally
- [ ] CI `Build Applications` workflow passes on this PR
- [ ] Run `applications_optical_flow` on an RDNA GPU (hardware texture path)
- [ ] Run `applications_optical_flow` on a CDNA GPU (software sampler path)


Made with [Cursor](https://cursor.com)